### PR TITLE
Rename map from "Mandates Map" to "Reform Map"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
-# Parking Reform Network Map
+# Parking Reform Map
 
-This code runs the Mandates Map app for the Parking Reform Network: https://parkingreform.org/mandates-map/.
+This code runs the Reform Map app for the Parking Reform Network: https://parkingreform.org/mandates-map/.
 
-The scripts are written in JavaScript and the app in R. We want to rewrite the app to JavaScript.
+The scripts are written in JavaScript. We are migrating the app from R to JavaScript.
 
 # Running the map app
 
 ## JavaScript Migration
 
-We are currently migrating from R to JavaScript. We are taking inspiration from the [Parking Lot Map](https://github.com/ParkingReformNetwork/parking-lot-map).
+The migration takes inspiration from the [Parking Lot Map](https://github.com/ParkingReformNetwork/parking-lot-map).
 
 1. Install [Node Package Manager (npm)](https://nodejs.dev/en/download/).
 
@@ -40,7 +40,7 @@ If the tests are taking a long time to start, run `rm -rf .parcel-cache` and try
 
 ### Autoformat code
 
-Using prettier to nicely format code.
+We use Prettier to nicely format code.
 
 ```bash
 ❯ npm run fmt

--- a/index.html
+++ b/index.html
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Parking Mandates Map</title>
+    <title>Parking Reform Map</title>
     <link rel="stylesheet" href="./src/css/style.scss" />
   </head>
   <body>
     <div class="page">
       <header>
-        <span class="header-title">Parking Mandates Map</span>
+        <span class="header-title">Parking Reform Map</span>
         <div class="header-icons">
           <i class="fa-solid fa-circle-info fa-lg" title="About"></i>
           <i class="fa-solid fa-share-alt fa-lg"></i>


### PR DESCRIPTION
We decided that this is a much more accurate description of what the map is about: where reforms have happened. Compared to https://github.com/ParkingReformNetwork/parking-requirement-database being about where mandates still exist.

Reform is also a more positive framing. We want to show how much progress is being made.

We don't rename the R map because we're sprinting to drop it in favor of JavaScript.