### PR TITLE
Simplify page setup

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,23 +5,21 @@
     <link rel="stylesheet" href="./src/css/style.scss" />
   </head>
   <body>
-    <div class="page">
-      <header>
-        <span class="header-title">Parking Reform Map</span>
-        <div class="header-icons">
-          <i class="fa-solid fa-circle-info fa-lg" title="About"></i>
-          <i class="fa-solid fa-share-alt fa-lg"></i>
-          <a href="https://parkingreform.org/mandates-map" target="_blank">
-            <i
-              class="fa-solid fa-up-right-from-square fa-lg"
-              title="View fullscreen"
-            ></i>
-          </a>
-        </div>
-      </header>
+    <header>
+      <span class="header-title">Parking Reform Map</span>
+      <div class="header-icons">
+        <i class="fa-solid fa-circle-info fa-lg" title="About"></i>
+        <i class="fa-solid fa-share-alt fa-lg"></i>
+        <a href="https://parkingreform.org/mandates-map" target="_blank">
+          <i
+            class="fa-solid fa-up-right-from-square fa-lg"
+            title="View fullscreen"
+          ></i>
+        </a>
+      </div>
+    </header>
 
-      <div id="map"></div>
-    </div>
+    <div id="map"></div>
     <script type="module">
       import setUpSite from "./src/js/setUpSite";
 

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -3,22 +3,26 @@
 @import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap");
 
 html,
-body,
-div.page,
-#map {
+body {
   padding: 0;
   margin: 0;
-  overflow: hidden;
-  height: 100%;
+  height: 100vh;
   width: 100%;
-}
-
-div.page {
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+}
+
+#map {
+  flex: 1;
+  width: 100%;
 }
 
 body,
 .leaflet-container {
   font-family: Poppins, Helvetica, Arial, sans-serif;
+}
+
+.leaflet-grab {
+  cursor: unset;
 }


### PR DESCRIPTION
Simpler implementation of https://github.com/ParkingReformNetwork/reform-map/pull/169. No need for a `div` named `page` -- we can set the `body` to be flex.