### PR TITLE
Test that CSVs are not empty

### DIFF
--- a/tests/app/data.test.js
+++ b/tests/app/data.test.js
@@ -1,0 +1,13 @@
+import fs from "fs/promises";
+
+import { expect, test } from "@playwright/test";
+
+test("CSV files have enough entries", async () => {
+  const assert = async (fp) => {
+    const csv = await fs.readFile(fp, "utf8");
+    const numLines = csv.split("\n").length;
+    expect(numLines).toBeGreaterThan(1900);
+  };
+  await assert("map/tidied_map_data.csv");
+  await assert("map/trimmed_map_data.csv");
+});

--- a/tests/scripts/brokenLinks.test.js
+++ b/tests/scripts/brokenLinks.test.js
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { parseCitationLinks } from "../scripts/brokenLinks";
+import { parseCitationLinks } from "../../scripts/brokenLinks";
 
 test("parseCitationLinks correctly extracts some example pages", async () => {
   // If the links get updated, then update the below tests.

--- a/tests/scripts/updateCityDetail.test.js
+++ b/tests/scripts/updateCityDetail.test.js
@@ -3,7 +3,7 @@ import {
   needsUpdate,
   normalizeAttachments,
   parseDatetime,
-} from "../scripts/updateCityDetail";
+} from "../../scripts/updateCityDetail";
 
 test.describe("needsUpdate()", () => {
   test("returns false if everything is older than globalLastUpdated", () => {

--- a/tests/scripts/updateMapData.test.js
+++ b/tests/scripts/updateMapData.test.js
@@ -5,7 +5,7 @@ import {
   magnitudeToHighestOrAllUses,
   landUseToString,
   populationToBin,
-} from "../scripts/updateMapData";
+} from "../../scripts/updateMapData";
 
 test.describe("magnitudeToHighest", () => {
   const testCases = [


### PR DESCRIPTION
Closes https://github.com/ParkingReformNetwork/reform-map/issues/168. While we already fixed the issue, this adds the regression test.