### PR TITLE
Lower max zoom to 10

### DIFF
--- a/src/js/setUpSite.js
+++ b/src/js/setUpSite.js
@@ -11,7 +11,7 @@ const BASE_LAYER = new TileLayer(
       'Map tiles: <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a>',
     subdomains: "abcd",
     minZoom: 0,
-    maxZoom: 20,
+    maxZoom: 10,
     ext: "png",
   }
 );


### PR DESCRIPTION
There's no reason to zoom into cities themselves. This is what the max zoom looks like now:

<img width="947" alt="Captura de pantalla 2023-08-20 a la(s) 11 20 34 a m" src="https://github.com/ParkingReformNetwork/reform-map/assets/14852634/7a4fd9ec-60fb-419c-90bb-48d831b31001">
