### PR TITLE
See if different HTML order fixes #210

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,8 +98,9 @@
       </p>
     </div>
 
-    <div id="map"></div>
     <select multiple class="city-search"></select>
+    <div id="map"></div>
+
     <script type="module">
       import setUpSite from "./src/js/setUpSite";
 


### PR DESCRIPTION
Trying to fix https://github.com/ParkingReformNetwork/reform-map/issues/210. The page order is one of the only things I could find different to parking lot map, which doesn't have the bug. There, the map is the very last HTML element.