### PR TITLE
Fix height on mobile

### DIFF
--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -9,7 +9,7 @@ html,
 body {
   padding: 0;
   margin: 0;
-  height: 100vh;
+  height: 100%;
   width: 100%;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
The address bar was hiding part of the site before. ChatGPT warns that the issue was probably using vh rather than % as the unit for the overall site height.