### PR TITLE
Improve issue with search being too wide

### DIFF
--- a/src/css/_search.scss
+++ b/src/css/_search.scss
@@ -2,11 +2,15 @@ div.choices {
   position: absolute;
   top: 3.2em;
   left: 3em;
-  width: 250px;
+  max-width: 250px;
   z-index: 1100;
 
   @media only screen and (min-width: 48em) {
     top: 3.85em;
+  }
+
+  &.is-open {
+    width: 250px;
   }
 }
 


### PR DESCRIPTION
Fixes https://github.com/ParkingReformNetwork/reform-map/issues/215.

We have to keep `.choices` at 250px width when the dropdown is open because otherwise it won't be the right width:

<img width="150" alt="Captura de pantalla 2023-09-03 a la(s) 5 26 45 p m" src="https://github.com/ParkingReformNetwork/reform-map/assets/14852634/43a32ac9-2b4a-4652-bf3e-db8dccdca8f0">

This gets us the behavior we want, including that the search bar never gets bigger than 250px:

<img width="324" alt="Captura de pantalla 2023-09-03 a la(s) 5 27 34 p m" src="https://github.com/ParkingReformNetwork/reform-map/assets/14852634/f32eef98-abc5-499c-a103-b47ad390cc3c">

The main issue is that when the search bar is active, you can't click it by clicking immediately to the right of the search. This is only when the search bar is active. It's a weird UX, but maybe fine. If people complain, we can figure out a more reliable fix.