### PR TITLE
Connect search and filter functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,13 +109,13 @@
     </div>
 
     <select multiple class="filter--scope">
-      <option value="Regional">Regional</option>
-      <option value="Citywide">Citywide</option>
-      <option value="City Center/Business District">
+      <option value="Regional" selected>Regional</option>
+      <option value="Citywide" selected>Citywide</option>
+      <option value="City Center/Business District" selected>
         City Center/Business District
       </option>
-      <option value="Transit Oriented">Transit Oriented</option>
-      <option value="Main Street/Special">Main Street/Special</option>
+      <option value="Transit Oriented" selected>Transit Oriented</option>
+      <option value="Main Street/Special" selected>Main Street/Special</option>
     </select>
 
     <select multiple class="city-search"></select>

--- a/src/js/filter.ts
+++ b/src/js/filter.ts
@@ -1,19 +1,56 @@
 /* global document, window */
 
+import type Choices from "choices.js";
 import type { CircleMarker, FeatureGroup } from "leaflet";
 import type { CityId, CityEntry } from "./types";
 
 /**
+ * Return true if the city should be rendered on the map.
+ *
+ * Note that search takes priority. If certain cities are selected via
+ * search, they should be shown regardless of the filters.
+ */
+const shouldBeSelected = (
+  cityState: CityId,
+  entry: CityEntry,
+  searchElement: Choices
+): boolean => {
+  const searchChosen = new Set(searchElement.getValue(true) as string[]);
+  if (searchChosen.size > 0) {
+    return searchChosen.has(cityState);
+  }
+
+  // Else, search is not used and the filters should apply.
+  const getSelected = (cls: string): Set<string> =>
+    new Set(
+      Array.from(document.querySelectorAll(cls)).map(
+        (option: HTMLInputElement) => option.value
+      )
+    );
+
+  const scopeSelected = getSelected(".filter--scope :checked");
+  const isScope = entry["report_magnitude"]
+    .split(",")
+    .some((scope) => scopeSelected.has(scope));
+
+  return isScope;
+};
+
+/**
  * Helper function to iterate over every city and either remove it or add it,
- * depending on the result of filterFn for that city.
+ * based on the search and filter values.
+ *
+ * This should be used with an event listener for each filter and search, whenever
+ * their values change.
  */
 const changeSelectedMarkers = (
   markerGroup: FeatureGroup,
   citiesToMarkers: Record<CityId, CircleMarker>,
-  filterFn: (cityState: CityId) => boolean
+  data: Record<CityId, CityEntry>,
+  searchElement: Choices
 ) => {
   Object.entries(citiesToMarkers).forEach(([cityState, marker]) => {
-    if (filterFn(cityState)) {
+    if (shouldBeSelected(cityState, data[cityState], searchElement)) {
       marker.addTo(markerGroup);
     } else {
       // @ts-ignore the API allows passing a LayerGroup, but the type hint doesn't show this.
@@ -22,40 +59,17 @@ const changeSelectedMarkers = (
   });
 };
 
-// The double => is "partial application".
-const onScopeFilterChange =
-  (
-    markerGroup: FeatureGroup,
-    citiesToMarkers: Record<CityId, CircleMarker>,
-    data: Record<CityId, CityEntry>
-  ) =>
-  (): void => {
-    const selected = new Set(
-      Array.from(document.querySelectorAll(".filter--scope :checked")).map(
-        (option: HTMLInputElement) => option.value
-      )
-    );
-    changeSelectedMarkers(markerGroup, citiesToMarkers, (cityState) =>
-      data[cityState]["report_magnitude"]
-        .split(",")
-        .some((scope) => selected.has(scope))
-    );
-  };
-
 const setUpFilter = (
   markerGroup: FeatureGroup,
   citiesToMarkers: Record<CityId, CircleMarker>,
-  data: Record<CityId, CityEntry>
+  data: Record<CityId, CityEntry>,
+  searchElement: Choices
 ): void => {
-  const filter = document.querySelector(".filter--scope");
-  // Pre-select all options.
-  filter.querySelectorAll("option").forEach((option) => {
-    option.selected = true;
-  });
-  filter.addEventListener(
-    "change",
-    onScopeFilterChange(markerGroup, citiesToMarkers, data)
-  );
+  document
+    .querySelector(".filter--scope")
+    .addEventListener("change", () =>
+      changeSelectedMarkers(markerGroup, citiesToMarkers, data, searchElement)
+    );
 };
 
-export { changeSelectedMarkers, setUpFilter };
+export { changeSelectedMarkers, setUpFilter, shouldBeSelected };

--- a/src/js/filter.ts
+++ b/src/js/filter.ts
@@ -10,7 +10,7 @@ import type { CityId, CityEntry } from "./types";
  * Note that search takes priority. If certain cities are selected via
  * search, they should be shown regardless of the filters.
  */
-const shouldBeSelected = (
+const shouldBeRendered = (
   cityState: CityId,
   entry: CityEntry,
   searchElement: Choices
@@ -50,7 +50,7 @@ const changeSelectedMarkers = (
   searchElement: Choices
 ) => {
   Object.entries(citiesToMarkers).forEach(([cityState, marker]) => {
-    if (shouldBeSelected(cityState, data[cityState], searchElement)) {
+    if (shouldBeRendered(cityState, data[cityState], searchElement)) {
       marker.addTo(markerGroup);
     } else {
       // @ts-ignore the API allows passing a LayerGroup, but the type hint doesn't show this.
@@ -72,4 +72,4 @@ const setUpFilter = (
     );
 };
 
-export { changeSelectedMarkers, setUpFilter, shouldBeSelected };
+export { changeSelectedMarkers, setUpFilter, shouldBeRendered };

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -1,6 +1,21 @@
-import { changeSelectedMarkers } from "./filter";
 import type { CircleMarker, FeatureGroup } from "leaflet";
 import type { CityId, CityEntry } from "./types";
+
+// TODO: replace with changeSelectedMarkers from ./filter.ts.
+const changeSelectedMarkers = (
+  markerGroup: FeatureGroup,
+  citiesToMarkers: Record<CityId, CircleMarker>,
+  filterFn: (cityState: CityId) => boolean
+) => {
+  Object.entries(citiesToMarkers).forEach(([cityState, marker]) => {
+    if (filterFn(cityState)) {
+      marker.addTo(markerGroup);
+    } else {
+      // @ts-ignore the API allows passing a LayerGroup, but the type hint doesn't show this.
+      marker.removeFrom(markerGroup);
+    }
+  });
+};
 
 const thumbsize = 14;
 // change interval by updating both stringIntervals and numInterval (slider will automatically adjust)

--- a/src/js/search.ts
+++ b/src/js/search.ts
@@ -2,45 +2,35 @@ import type { FeatureGroup, CircleMarker } from "leaflet";
 import Choices from "choices.js";
 import "choices.js/public/assets/styles/choices.css";
 
-import type { CityId } from "./types";
+import type { CityId, CityEntry } from "./types";
 import { changeSelectedMarkers } from "./filter";
 
-// The double => is "partial application".
-const onChange =
-  (
-    markerGroup: FeatureGroup,
-    citiesToMarkers: Record<CityId, CircleMarker>,
-    choices: Choices
-  ) =>
-  (): void => {
-    const selectedSet = new Set(choices.getValue(true) as string[]);
-    changeSelectedMarkers(
-      markerGroup,
-      citiesToMarkers,
-      (cityState) => selectedSet.size === 0 || selectedSet.has(cityState)
-    );
-  };
-
-const setUpSearch = (
-  markerGroup: FeatureGroup,
-  citiesToMarkers: Record<CityId, CircleMarker>
-): void => {
-  const cities = Object.keys(citiesToMarkers).map((cityState) => ({
+const createSearchElement = (cityStates: Array<CityId>): Choices => {
+  const cities = cityStates.map((cityState) => ({
     value: cityState,
     label: cityState,
   }));
   const element = document.querySelector(".city-search");
-  const choices = new Choices(element, {
+  return new Choices(element, {
     choices: cities,
     placeholderValue: "City search",
     removeItemButton: true,
     allowHTML: false,
     itemSelectText: "Select",
   });
-  element.addEventListener(
-    "change",
-    onChange(markerGroup, citiesToMarkers, choices)
-  );
 };
 
-export default setUpSearch;
+const setUpSearch = (
+  markerGroup: FeatureGroup,
+  citiesToMarkers: Record<CityId, CircleMarker>,
+  data: Record<CityId, CityEntry>,
+  searchElement: Choices
+): void => {
+  document
+    .querySelector(".city-search")
+    .addEventListener("change", () =>
+      changeSelectedMarkers(markerGroup, citiesToMarkers, data, searchElement)
+    );
+};
+
+export { createSearchElement, setUpSearch };

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -4,7 +4,7 @@ import "leaflet/dist/leaflet.css";
 import type { CityId, CityEntry } from "./types";
 import setUpIcons from "./fontAwesome";
 import addLegend from "./legend";
-import setUpSearch from "./search";
+import { createSearchElement, setUpSearch } from "./search";
 import setUpAbout from "./about";
 import setUpDetails from "./cityDetails";
 import { setUpFilter } from "./filter";
@@ -95,10 +95,12 @@ const setUpSite = async (): Promise<void> => {
   addLegend(map, SCOPE_TO_COLOR);
 
   const data = await readData();
+  const searchElement = createSearchElement(Object.keys(data));
   const citiesToMarkers = createCityMarkers(data, markerGroup);
+
   setUpDetails(markerGroup, data);
-  setUpSearch(markerGroup, citiesToMarkers);
-  setUpFilter(markerGroup, citiesToMarkers, data);
+  setUpSearch(markerGroup, citiesToMarkers, data, searchElement);
+  setUpFilter(markerGroup, citiesToMarkers, data, searchElement);
 };
 
 export default setUpSite;


### PR DESCRIPTION
Before, each filter was being traeted as its own separate thing, without paying attention to the other filters and the search. They would each call `changeSelectedMarkers` with their own `filterFn`. So if you changed one filter, it would ignore the other filters and override their prior filtering.

Instead, when deciding whether to show a city, we need to consider _all_ the filters. The city must match every filter. 

## Search vs filter

I wasn't sure how we should handle search vs. the filter mechanism. If you have selected a city in the search, but it doesn't match the filters, what should we do?

ChatGPT helped convince me that search should take priority. If you actively choose a city, then the least confusing UX is to still show that city, regardless of filters. 

## Punts on population slider

I was having a tough time figuring out how to hook up the code to the filter. I want to refactor the code first. So this PR punts on that file.