### PR TITLE
Rename population slider's class names

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,14 +125,14 @@
       </div>
       <div class="population-slider-controls" data-legendnum="12">
         <input
-          class="population-slider-min"
+          class="population-slider-left"
           name="min"
           type="range"
           step="0.5"
           min="0"
         />
         <input
-          class="population-slider-max"
+          class="population-slider-right"
           name="max"
           type="range"
           step="0.5"

--- a/index.html
+++ b/index.html
@@ -119,29 +119,27 @@
     </select>
     <div class="population-slider-container">
       <div class="population-slider-label">
-        <span class="lower value"></span>
+        <span class="population-slider-label-min"></span>
         <span> - </span>
-        <span class="upper value"></span>
+        <span class="population-slider-label-max"></span>
       </div>
-      <div class="population-slider" data-legendnum="12">
+      <div class="population-slider-controls" data-legendnum="12">
         <input
-          id="left-slider"
-          class="left-slider"
+          class="population-slider-min"
           name="min"
           type="range"
           step="0.5"
           min="0"
         />
         <input
-          id="right-slider"
-          class="right-slider"
+          class="population-slider-max"
           name="max"
           type="range"
           step="0.5"
           min="0"
         />
       </div>
-      <div class="slider-legend"></div>
+      <div class="population-slider-legend"></div>
     </div>
 
     <select multiple class="city-search"></select>

--- a/src/css/_population-slider.scss
+++ b/src/css/_population-slider.scss
@@ -13,7 +13,7 @@
   left: 1em;
 }
 
-.population-slider {
+.population-slider-controls {
   width: 360px;
   height: 2em;
   display: flex;
@@ -26,7 +26,7 @@
   display: inline-block;
 }
 
-.slider-legend {
+.population-slider-legend {
   display: flex;
   justify-content: space-between;
   width: 100%;
@@ -40,7 +40,7 @@
   }
 }
 
-.population-slider > input {
+.population-slider-controls > input {
   cursor: pointer;
   position: absolute;
   -webkit-appearance: none;
@@ -57,7 +57,7 @@
   );
 }
 
-.population-slider > input::-webkit-slider-thumb {
+.population-slider-controls > input::-webkit-slider-thumb {
   -webkit-appearance: none; // Override default look
   appearance: none;
   width: 14px;
@@ -68,6 +68,6 @@
   border-radius: 100%;
 }
 
-.population-slider > input::-webkit-slider-runnable-track {
+.population-slider-controls > input::-webkit-slider-runnable-track {
   cursor: pointer;
 }

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -17,9 +17,9 @@ const changeSelectedMarkers = (
   });
 };
 
-const thumbsize = 14;
+const THUMBSIZE = 14;
 // change interval by updating both stringIntervals and numInterval (slider will automatically adjust)
-const stringIntervals = [
+const STRING_INTERVALS = [
   "100",
   "500",
   "1k",
@@ -34,7 +34,7 @@ const stringIntervals = [
   "50M",
 ];
 
-const numInterval = [
+const NUM_INTERVALS = [
   100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000, 5000000,
   10000000, 50000000,
 ];
@@ -67,8 +67,8 @@ const draw = (slider: HTMLInputElement, low: string, high: string): void => {
   const rightWidth =
     (rangemax - parseFloat(rightSlider.getAttribute("min"))) * intervalSize;
   // Note: cannot set maxWidth to (rangewidth - minWidth) due to the overlaping interval
-  leftSlider.style.width = leftWidth + thumbsize + "px";
-  rightSlider.style.width = rightWidth + thumbsize + "px";
+  leftSlider.style.width = leftWidth + THUMBSIZE + "px";
+  rightSlider.style.width = rightWidth + THUMBSIZE + "px";
 
   // The left slider has a fixed anchor. However the right slider has to move everytime the range of the slider changes.
   const offset = 5;
@@ -76,10 +76,10 @@ const draw = (slider: HTMLInputElement, low: string, high: string): void => {
   rightSlider.style.left = extend
     ? parseInt(leftSlider.style.width) -
       intervalSize / 2 -
-      thumbsize +
+      THUMBSIZE +
       offset +
       "px"
-    : parseInt(leftSlider.style.width) - thumbsize + offset + "px";
+    : parseInt(leftSlider.style.width) - THUMBSIZE + offset + "px";
 
   // There is a separate attribute "data-value" to ensure the slider resets when page is refreshed.
   rightSlider.value = rightSlider.getAttribute("data-value");
@@ -97,8 +97,8 @@ const init = (
   // Setting variables.
   const leftSlider = slider.querySelector(".left-slider") as HTMLInputElement;
   const rightSlider = slider.querySelector(".right-slider") as HTMLInputElement;
-  leftSlider.setAttribute("max", (stringIntervals.length - 1).toString()); // will auto-adjust sliders if more options are added to the stringInterval list
-  rightSlider.setAttribute("max", (stringIntervals.length - 1).toString());
+  leftSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString()); // will auto-adjust sliders if more options are added to the stringInterval list
+  rightSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString());
   const rangemin = parseInt(leftSlider.getAttribute("min"));
   const rangemax = parseInt(rightSlider.getAttribute("max"));
   const legendnum = slider.getAttribute("data-legendnum");
@@ -108,7 +108,7 @@ const init = (
   rightSlider.setAttribute("data-value", rangemax.toString());
   slider.setAttribute("data-rangemin", rangemin.toString());
   slider.setAttribute("data-rangemax", rangemax.toString());
-  slider.setAttribute("data-thumbsize", thumbsize.toString());
+  slider.setAttribute("data-thumbsize", THUMBSIZE.toString());
   slider.setAttribute("data-rangewidth", slider.offsetWidth.toString());
 
   // Writing and inserting header label
@@ -122,7 +122,7 @@ const init = (
   const legendvalues = [];
   for (let i = 0; i < parseInt(legendnum); i++) {
     legendvalues[i] = document.createElement("span");
-    const val = stringIntervals[i];
+    const val = STRING_INTERVALS[i];
     legendvalues[i].appendChild(document.createTextNode(val));
     legend.appendChild(legendvalues[i]);
   }
@@ -156,8 +156,8 @@ const updateExponential = (
   leftSlider.value = leftValue;
   rightSlider.value = rightValue;
 
-  const min = numInterval[leftValue];
-  const max = numInterval[rightValue];
+  const min = NUM_INTERVALS[leftValue];
+  const max = NUM_INTERVALS[rightValue];
 
   // Checks if x is in between the integer value of low and high.
   const inBetween = (x: number, low: number, high: number): boolean => {
@@ -168,7 +168,7 @@ const updateExponential = (
     inBetween(parseInt(data[cityState]["population"]), min, max)
   );
 
-  draw(slider, stringIntervals[leftValue], stringIntervals[rightValue]);
+  draw(slider, STRING_INTERVALS[leftValue], STRING_INTERVALS[rightValue]);
 };
 
 // Finds a specified div and initializes the two sliders that creates the double headed slider.

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -40,9 +40,6 @@ const NUM_INTERVALS = [
 ];
 
 const draw = (slider: HTMLInputElement, low: string, high: string): void => {
-  // Setting vars from top to bottom.
-  const lower = document.querySelector(".population-slider-label-min");
-  const upper = document.querySelector(".population-slider-label-max");
   const leftSlider = slider.querySelector(
     ".population-slider-min"
   ) as HTMLInputElement;
@@ -88,8 +85,12 @@ const draw = (slider: HTMLInputElement, low: string, high: string): void => {
   // There is a separate attribute "data-value" to ensure the slider resets when page is refreshed.
   rightSlider.value = rightSlider.getAttribute("data-value");
   leftSlider.value = leftSlider.getAttribute("data-value");
-  lower.innerHTML = low;
-  upper.innerHTML = high;
+
+  const updateLabel = (cls: string, val: string): void => {
+    document.querySelector(cls).innerHTML = val;
+  };
+  updateLabel(".population-slider-label-min", low);
+  updateLabel(".population-slider-label-max", high);
 };
 
 const init = (
@@ -119,11 +120,12 @@ const init = (
   slider.setAttribute("data-thumbsize", THUMBSIZE.toString());
   slider.setAttribute("data-rangewidth", slider.offsetWidth.toString());
 
-  // Writing and inserting header label
-  const lower = document.querySelector(".population-slider-label-min");
-  const upper = document.querySelector(".population-slider-label-max");
-  lower.appendChild(document.createTextNode(rangemin.toString()));
-  upper.appendChild(document.createTextNode(rangemax.toString()));
+  const setUpLabel = (cls: string, val: number): void => {
+    const node = document.createTextNode(val.toString());
+    document.querySelector(cls).appendChild(node);
+  };
+  setUpLabel(".population-slider-label-min", rangemin);
+  setUpLabel(".population-slider-label-max", rangemax);
 
   // Writing and inserting interval legend
   const legend = document.querySelector(".population-slider-legend");

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -39,16 +39,20 @@ const NUM_INTERVALS = [
   10000000, 50000000,
 ];
 
-const draw = (slider: HTMLInputElement, low: string, high: string): void => {
-  const leftSlider = slider.querySelector(
+const draw = (
+  sliderControls: HTMLDivElement,
+  low: string,
+  high: string
+): void => {
+  const leftSlider = sliderControls.querySelector(
     ".population-slider-min"
   ) as HTMLInputElement;
-  const rightSlider = slider.querySelector(
+  const rightSlider = sliderControls.querySelector(
     ".population-slider-max"
   ) as HTMLInputElement;
-  const rangewidth = parseInt(slider.getAttribute("data-rangewidth"));
-  const rangemin = parseInt(slider.getAttribute("data-rangemin")); // total min
-  const rangemax = parseInt(slider.getAttribute("data-rangemax")); // total max
+  const rangewidth = parseInt(sliderControls.getAttribute("data-rangewidth"));
+  const rangemin = parseInt(sliderControls.getAttribute("data-rangemin")); // total min
+  const rangemax = parseInt(sliderControls.getAttribute("data-rangemax")); // total max
   const intervalSize = rangewidth / (rangemax - rangemin + 1); // how far the slider moves for each interval (px)
   const leftValue = parseInt(leftSlider.value);
   const rightValue = parseInt(rightSlider.value);
@@ -94,31 +98,34 @@ const draw = (slider: HTMLInputElement, low: string, high: string): void => {
 };
 
 const init = (
-  slider: HTMLInputElement,
+  sliderControls: HTMLDivElement,
   markerGroup: FeatureGroup,
   citiesToMarkers: Record<CityId, CircleMarker>,
   data: Record<CityId, CityEntry>
 ): void => {
   // Setting variables.
-  const leftSlider = slider.querySelector(
+  const leftSlider = sliderControls.querySelector(
     ".population-slider-min"
   ) as HTMLInputElement;
-  const rightSlider = slider.querySelector(
+  const rightSlider = sliderControls.querySelector(
     ".population-slider-max"
   ) as HTMLInputElement;
   leftSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString()); // will auto-adjust sliders if more options are added to the stringInterval list
   rightSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString());
   const rangemin = parseInt(leftSlider.getAttribute("min"));
   const rangemax = parseInt(rightSlider.getAttribute("max"));
-  const legendnum = slider.getAttribute("data-legendnum");
+  const legendnum = sliderControls.getAttribute("data-legendnum");
 
   // Setting data attributes
   leftSlider.setAttribute("data-value", rangemin.toString());
   rightSlider.setAttribute("data-value", rangemax.toString());
-  slider.setAttribute("data-rangemin", rangemin.toString());
-  slider.setAttribute("data-rangemax", rangemax.toString());
-  slider.setAttribute("data-thumbsize", THUMBSIZE.toString());
-  slider.setAttribute("data-rangewidth", slider.offsetWidth.toString());
+  sliderControls.setAttribute("data-rangemin", rangemin.toString());
+  sliderControls.setAttribute("data-rangemax", rangemax.toString());
+  sliderControls.setAttribute("data-thumbsize", THUMBSIZE.toString());
+  sliderControls.setAttribute(
+    "data-rangewidth",
+    sliderControls.offsetWidth.toString()
+  );
 
   const setUpLabel = (cls: string, val: number): void => {
     const node = document.createTextNode(val.toString());
@@ -137,7 +144,7 @@ const init = (
     legend.appendChild(legendvalues[i]);
   }
 
-  draw(slider, "100", "50M");
+  draw(sliderControls, "100", "50M");
 
   leftSlider.addEventListener("input", (): void => {
     updateExponential(leftSlider, markerGroup, citiesToMarkers, data);
@@ -187,10 +194,10 @@ const setUpSlider = (
   citiesToMarkers: Record<CityId, CircleMarker>,
   data: Record<CityId, CityEntry>
 ): void => {
-  const sliders = document.querySelectorAll(".population-slider-controls");
-  sliders.forEach((slider: HTMLInputElement) => {
-    init(slider, markerGroup, citiesToMarkers, data);
-  });
+  const sliderControls = document.querySelector(
+    ".population-slider-controls"
+  ) as HTMLDivElement;
+  init(sliderControls, markerGroup, citiesToMarkers, data);
 };
 
 export default setUpSlider;

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -127,13 +127,6 @@ const init = (
     sliderControls.offsetWidth.toString()
   );
 
-  const setUpLabel = (cls: string, val: number): void => {
-    const node = document.createTextNode(val.toString());
-    document.querySelector(cls).appendChild(node);
-  };
-  setUpLabel(".population-slider-label-min", rangemin);
-  setUpLabel(".population-slider-label-max", rangemax);
-
   // Writing and inserting interval legend
   const legend = document.querySelector(".population-slider-legend");
   const legendvalues = [];

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -41,10 +41,14 @@ const NUM_INTERVALS = [
 
 const draw = (slider: HTMLInputElement, low: string, high: string): void => {
   // Setting vars from top to bottom.
-  const lower = document.querySelector(".lower");
-  const upper = document.querySelector(".upper");
-  const leftSlider = slider.querySelector(".left-slider") as HTMLInputElement;
-  const rightSlider = slider.querySelector(".right-slider") as HTMLInputElement;
+  const lower = document.querySelector(".population-slider-label-min");
+  const upper = document.querySelector(".population-slider-label-max");
+  const leftSlider = slider.querySelector(
+    ".population-slider-min"
+  ) as HTMLInputElement;
+  const rightSlider = slider.querySelector(
+    ".population-slider-max"
+  ) as HTMLInputElement;
   const rangewidth = parseInt(slider.getAttribute("data-rangewidth"));
   const rangemin = parseInt(slider.getAttribute("data-rangemin")); // total min
   const rangemax = parseInt(slider.getAttribute("data-rangemax")); // total max
@@ -95,8 +99,12 @@ const init = (
   data: Record<CityId, CityEntry>
 ): void => {
   // Setting variables.
-  const leftSlider = slider.querySelector(".left-slider") as HTMLInputElement;
-  const rightSlider = slider.querySelector(".right-slider") as HTMLInputElement;
+  const leftSlider = slider.querySelector(
+    ".population-slider-min"
+  ) as HTMLInputElement;
+  const rightSlider = slider.querySelector(
+    ".population-slider-max"
+  ) as HTMLInputElement;
   leftSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString()); // will auto-adjust sliders if more options are added to the stringInterval list
   rightSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString());
   const rangemin = parseInt(leftSlider.getAttribute("min"));
@@ -112,13 +120,13 @@ const init = (
   slider.setAttribute("data-rangewidth", slider.offsetWidth.toString());
 
   // Writing and inserting header label
-  const lower = document.querySelector(".lower");
-  const upper = document.querySelector(".upper");
+  const lower = document.querySelector(".population-slider-label-min");
+  const upper = document.querySelector(".population-slider-label-max");
   lower.appendChild(document.createTextNode(rangemin.toString()));
   upper.appendChild(document.createTextNode(rangemax.toString()));
 
   // Writing and inserting interval legend
-  const legend = document.querySelector(".slider-legend");
+  const legend = document.querySelector(".population-slider-legend");
   const legendvalues = [];
   for (let i = 0; i < parseInt(legendnum); i++) {
     legendvalues[i] = document.createElement("span");
@@ -145,8 +153,12 @@ const updateExponential = (
 ): void => {
   // Set variables.
   const slider = el.parentElement as HTMLInputElement;
-  const leftSlider = slider.querySelector("#left-slider") as HTMLInputElement;
-  const rightSlider = slider.querySelector("#right-slider") as HTMLInputElement;
+  const leftSlider = slider.querySelector(
+    ".population-slider-min"
+  ) as HTMLInputElement;
+  const rightSlider = slider.querySelector(
+    ".population-slider-max"
+  ) as HTMLInputElement;
   const leftValue = Math.floor(parseFloat(leftSlider.value)).toString();
   const rightValue = Math.floor(parseFloat(rightSlider.value)).toString();
 
@@ -177,7 +189,7 @@ const setUpSlider = (
   citiesToMarkers: Record<CityId, CircleMarker>,
   data: Record<CityId, CityEntry>
 ): void => {
-  const sliders = document.querySelectorAll(".population-slider");
+  const sliders = document.querySelectorAll(".population-slider-controls");
   sliders.forEach((slider: HTMLInputElement) => {
     init(slider, markerGroup, citiesToMarkers, data);
   });

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -170,17 +170,13 @@ const updateExponential = (
   leftSlider.value = leftValue;
   rightSlider.value = rightValue;
 
-  const min = NUM_INTERVALS[leftValue];
-  const max = NUM_INTERVALS[rightValue];
-
-  // Checks if x is in between the integer value of low and high.
-  const inBetween = (x: number, low: number, high: number): boolean => {
-    return x >= low && x <= high;
-  };
-
-  changeSelectedMarkers(markerGroup, citiesToMarkers, (cityState) =>
-    inBetween(parseInt(data[cityState]["population"]), min, max)
-  );
+  changeSelectedMarkers(markerGroup, citiesToMarkers, (cityState) => {
+    const population = parseInt(data[cityState]["population"]);
+    return (
+      population >= NUM_INTERVALS[leftValue] &&
+      population <= NUM_INTERVALS[rightValue]
+    );
+  });
 
   draw(slider, STRING_INTERVALS[leftValue], STRING_INTERVALS[rightValue]);
 };

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -45,10 +45,10 @@ const draw = (
   high: string
 ): void => {
   const leftSlider = sliderControls.querySelector(
-    ".population-slider-min"
+    ".population-slider-left"
   ) as HTMLInputElement;
   const rightSlider = sliderControls.querySelector(
-    ".population-slider-max"
+    ".population-slider-right"
   ) as HTMLInputElement;
   const rangewidth = parseInt(sliderControls.getAttribute("data-rangewidth"));
   const rangemin = parseInt(sliderControls.getAttribute("data-rangemin")); // total min
@@ -105,10 +105,10 @@ const init = (
 ): void => {
   // Setting variables.
   const leftSlider = sliderControls.querySelector(
-    ".population-slider-min"
+    ".population-slider-left"
   ) as HTMLInputElement;
   const rightSlider = sliderControls.querySelector(
-    ".population-slider-max"
+    ".population-slider-right"
   ) as HTMLInputElement;
   leftSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString()); // will auto-adjust sliders if more options are added to the stringInterval list
   rightSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString());
@@ -156,10 +156,10 @@ const updateExponential = (
   // Set variables.
   const slider = el.parentElement as HTMLInputElement;
   const leftSlider = slider.querySelector(
-    ".population-slider-min"
+    ".population-slider-left"
   ) as HTMLInputElement;
   const rightSlider = slider.querySelector(
-    ".population-slider-max"
+    ".population-slider-right"
   ) as HTMLInputElement;
   const leftValue = Math.floor(parseFloat(leftSlider.value)).toString();
   const rightValue = Math.floor(parseFloat(rightSlider.value)).toString();

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -37,8 +37,8 @@ test("scope filter updates markers", async ({ page }) => {
 
 test("population filter updates markers", async ({ page }) => {
   await loadMap(page);
-  const left = await page.$(".left-slider");
-  const right = await page.$(".right-slider");
+  const left = await page.$(".population-slider-min");
+  const right = await page.$(".population-slider-max");
 
   // min updated on 9/10/23
   const populationDiff = [61, 115, 538, 247, 512, 131, 128, 29, 16, 3, 1];

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -37,8 +37,8 @@ test("scope filter updates markers", async ({ page }) => {
 
 test("population filter updates markers", async ({ page }) => {
   await loadMap(page);
-  const left = await page.$(".population-slider-min");
-  const right = await page.$(".population-slider-max");
+  const left = await page.$(".population-slider-left");
+  const right = await page.$(".population-slider-right");
 
   // min updated on 9/10/23
   const populationDiff = [61, 115, 538, 247, 512, 131, 128, 29, 16, 3, 1];


### PR DESCRIPTION
Some small improvements:

* Rename slider to sliderControls and fix type hint to be a single `HTMLDivElement`, not `HTMLInputElement`
* Inline predicate function to check if population in range
* Deduplicate code to set up label
* Remove unnecessary set up of labels in `init` function
* Better HTML class names
* Use UPPER_CASE for global constants

Follow up PRs will make more improvements. I wanted to keep the diff from getting too big.