### PR TITLE
Remove population slider usage of `data-x` attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,13 +123,18 @@
         <span> - </span>
         <span class="population-slider-label-max"></span>
       </div>
-      <div class="population-slider-controls" data-legendnum="12">
+      <div
+        class="population-slider-controls"
+        data-rangemin="0"
+        data-legendnum="12"
+      >
         <input
           class="population-slider-left"
           name="min"
           type="range"
           step="0.5"
           min="0"
+          data-value="0"
         />
         <input
           class="population-slider-right"

--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
           type="range"
           step="0.5"
           min="0"
-          data-value="0"
+          value="0"
         />
         <input
           class="population-slider-right"

--- a/index.html
+++ b/index.html
@@ -123,11 +123,7 @@
         <span> - </span>
         <span class="population-slider-label-max"></span>
       </div>
-      <div
-        class="population-slider-controls"
-        data-rangemin="0"
-        data-legendnum="12"
-      >
+      <div class="population-slider-controls">
         <input
           class="population-slider-left"
           name="min"

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -17,7 +17,11 @@ const changeSelectedMarkers = (
   });
 };
 
+// Corresponds to setting `min="0"` on the two `input` elements.
+const RANGE_MIN = 0;
+
 const THUMBSIZE = 14;
+
 // change interval by updating both stringIntervals and numInterval (slider will automatically adjust)
 const STRING_INTERVALS = [
   "100",
@@ -33,7 +37,6 @@ const STRING_INTERVALS = [
   "10M",
   "50M",
 ];
-
 const NUM_INTERVALS = [
   100, 500, 1000, 5000, 10000, 50000, 100000, 500000, 1000000, 5000000,
   10000000, 50000000,
@@ -51,9 +54,8 @@ const draw = (
     ".population-slider-right"
   ) as HTMLInputElement;
   const rangewidth = parseInt(sliderControls.getAttribute("data-rangewidth"));
-  const rangemin = parseInt(sliderControls.getAttribute("data-rangemin")); // total min
   const rangemax = parseInt(sliderControls.getAttribute("data-rangemax")); // total max
-  const intervalSize = rangewidth / (rangemax - rangemin + 1); // how far the slider moves for each interval (px)
+  const intervalSize = rangewidth / (rangemax - RANGE_MIN + 1); // how far the slider moves for each interval (px)
   const leftValue = parseInt(leftSlider.value);
   const rightValue = parseInt(rightSlider.value);
 
@@ -112,14 +114,11 @@ const init = (
   ) as HTMLInputElement;
   leftSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString()); // will auto-adjust sliders if more options are added to the stringInterval list
   rightSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString());
-  const rangemin = parseInt(leftSlider.getAttribute("min"));
   const rangemax = parseInt(rightSlider.getAttribute("max"));
   const legendnum = sliderControls.getAttribute("data-legendnum");
 
   // Setting data attributes
-  leftSlider.setAttribute("data-value", rangemin.toString());
   rightSlider.setAttribute("data-value", rangemax.toString());
-  sliderControls.setAttribute("data-rangemin", rangemin.toString());
   sliderControls.setAttribute("data-rangemax", rangemax.toString());
   sliderControls.setAttribute("data-thumbsize", THUMBSIZE.toString());
   sliderControls.setAttribute(

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -44,10 +44,10 @@ const draw = (
   low: string,
   high: string
 ): void => {
-  const leftSlider = sliderControls.querySelector(
+  const leftSlider = document.querySelector(
     ".population-slider-left"
   ) as HTMLInputElement;
-  const rightSlider = sliderControls.querySelector(
+  const rightSlider = document.querySelector(
     ".population-slider-right"
   ) as HTMLInputElement;
   const rangewidth = parseInt(sliderControls.getAttribute("data-rangewidth"));
@@ -104,10 +104,10 @@ const init = (
   data: Record<CityId, CityEntry>
 ): void => {
   // Setting variables.
-  const leftSlider = sliderControls.querySelector(
+  const leftSlider = document.querySelector(
     ".population-slider-left"
   ) as HTMLInputElement;
-  const rightSlider = sliderControls.querySelector(
+  const rightSlider = document.querySelector(
     ".population-slider-right"
   ) as HTMLInputElement;
   leftSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString()); // will auto-adjust sliders if more options are added to the stringInterval list

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -17,9 +17,6 @@ const changeSelectedMarkers = (
   });
 };
 
-// Corresponds to setting `min="0"` on the two `input` elements.
-const RANGE_MIN = 0;
-
 const THUMBSIZE = 14;
 
 // change interval by updating both stringIntervals and numInterval (slider will automatically adjust)
@@ -42,6 +39,8 @@ const NUM_INTERVALS = [
   10000000, 50000000,
 ];
 
+const RANGE_MAX = STRING_INTERVALS.length - 1;
+
 const draw = (
   sliderControls: HTMLDivElement,
   low: string,
@@ -53,9 +52,7 @@ const draw = (
   const rightSlider = document.querySelector(
     ".population-slider-right"
   ) as HTMLInputElement;
-  const rangewidth = parseInt(sliderControls.getAttribute("data-rangewidth"));
-  const rangemax = parseInt(sliderControls.getAttribute("data-rangemax")); // total max
-  const intervalSize = rangewidth / (rangemax - RANGE_MIN + 1); // how far the slider moves for each interval (px)
+  const intervalSizePx = sliderControls.offsetWidth / STRING_INTERVALS.length;
   const leftValue = parseInt(leftSlider.value);
   const rightValue = parseInt(rightSlider.value);
 
@@ -70,9 +67,9 @@ const draw = (
 
   // Setting CSS.
   // To prevent the two sliders from crossing, this sets the max and min for the left and right sliders respectively.
-  const leftWidth = parseFloat(leftSlider.getAttribute("max")) * intervalSize;
+  const leftWidth = parseFloat(leftSlider.getAttribute("max")) * intervalSizePx;
   const rightWidth =
-    (rangemax - parseFloat(rightSlider.getAttribute("min"))) * intervalSize;
+    (RANGE_MAX - parseFloat(rightSlider.getAttribute("min"))) * intervalSizePx;
   // Note: cannot set maxWidth to (rangewidth - minWidth) due to the overlaping interval
   leftSlider.style.width = leftWidth + THUMBSIZE + "px";
   rightSlider.style.width = rightWidth + THUMBSIZE + "px";
@@ -82,15 +79,11 @@ const draw = (
   leftSlider.style.left = offset + "px";
   rightSlider.style.left = extend
     ? parseInt(leftSlider.style.width) -
-      intervalSize / 2 -
+      intervalSizePx / 2 -
       THUMBSIZE +
       offset +
       "px"
     : parseInt(leftSlider.style.width) - THUMBSIZE + offset + "px";
-
-  // There is a separate attribute "data-value" to ensure the slider resets when page is refreshed.
-  rightSlider.value = rightSlider.getAttribute("data-value");
-  leftSlider.value = leftSlider.getAttribute("data-value");
 
   const updateLabel = (cls: string, val: string): void => {
     document.querySelector(cls).innerHTML = val;
@@ -112,16 +105,9 @@ const init = (
     ".population-slider-right"
   ) as HTMLInputElement;
 
-  const rangeMax = (STRING_INTERVALS.length - 1).toString();
-  leftSlider.setAttribute("max", rangeMax);
-  rightSlider.setAttribute("max", rangeMax);
-  rightSlider.setAttribute("data-value", rangeMax);
-  sliderControls.setAttribute("data-rangemax", rangeMax);
-
-  sliderControls.setAttribute(
-    "data-rangewidth",
-    sliderControls.offsetWidth.toString()
-  );
+  leftSlider.setAttribute("max", RANGE_MAX.toString());
+  rightSlider.setAttribute("max", RANGE_MAX.toString());
+  rightSlider.value = RANGE_MAX.toString();
 
   const legend = document.querySelector(".population-slider-legend");
   STRING_INTERVALS.forEach((val) => {
@@ -157,9 +143,6 @@ const updateExponential = (
   const leftValue = Math.floor(parseFloat(leftSlider.value)).toString();
   const rightValue = Math.floor(parseFloat(rightSlider.value)).toString();
 
-  // Set attributes before drawing.
-  leftSlider.setAttribute("data-value", leftValue);
-  rightSlider.setAttribute("data-value", rightValue);
   leftSlider.value = leftValue;
   rightSlider.value = rightValue;
 

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -124,15 +124,12 @@ const init = (
     sliderControls.offsetWidth.toString()
   );
 
-  // Writing and inserting interval legend
   const legend = document.querySelector(".population-slider-legend");
-  const legendvalues = [];
-  for (let i = 0; i < STRING_INTERVALS.length; i++) {
-    legendvalues[i] = document.createElement("span");
-    const val = STRING_INTERVALS[i];
-    legendvalues[i].appendChild(document.createTextNode(val));
-    legend.appendChild(legendvalues[i]);
-  }
+  STRING_INTERVALS.forEach((val) => {
+    const span = document.createElement("span");
+    span.appendChild(document.createTextNode(val));
+    legend.appendChild(span);
+  });
 
   draw(sliderControls, "100", "50M");
 

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -105,20 +105,19 @@ const init = (
   citiesToMarkers: Record<CityId, CircleMarker>,
   data: Record<CityId, CityEntry>
 ): void => {
-  // Setting variables.
   const leftSlider = document.querySelector(
     ".population-slider-left"
   ) as HTMLInputElement;
   const rightSlider = document.querySelector(
     ".population-slider-right"
   ) as HTMLInputElement;
-  leftSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString()); // will auto-adjust sliders if more options are added to the stringInterval list
-  rightSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString());
-  const rangemax = parseInt(rightSlider.getAttribute("max"));
 
-  // Setting data attributes
-  rightSlider.setAttribute("data-value", rangemax.toString());
-  sliderControls.setAttribute("data-rangemax", rangemax.toString());
+  const rangeMax = (STRING_INTERVALS.length - 1).toString();
+  leftSlider.setAttribute("max", rangeMax);
+  rightSlider.setAttribute("max", rangeMax);
+  rightSlider.setAttribute("data-value", rangeMax);
+  sliderControls.setAttribute("data-rangemax", rangeMax);
+
   sliderControls.setAttribute(
     "data-rangewidth",
     sliderControls.offsetWidth.toString()

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -115,12 +115,10 @@ const init = (
   leftSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString()); // will auto-adjust sliders if more options are added to the stringInterval list
   rightSlider.setAttribute("max", (STRING_INTERVALS.length - 1).toString());
   const rangemax = parseInt(rightSlider.getAttribute("max"));
-  const legendnum = sliderControls.getAttribute("data-legendnum");
 
   // Setting data attributes
   rightSlider.setAttribute("data-value", rangemax.toString());
   sliderControls.setAttribute("data-rangemax", rangemax.toString());
-  sliderControls.setAttribute("data-thumbsize", THUMBSIZE.toString());
   sliderControls.setAttribute(
     "data-rangewidth",
     sliderControls.offsetWidth.toString()
@@ -129,7 +127,7 @@ const init = (
   // Writing and inserting interval legend
   const legend = document.querySelector(".population-slider-legend");
   const legendvalues = [];
-  for (let i = 0; i < parseInt(legendnum); i++) {
+  for (let i = 0; i < STRING_INTERVALS.length; i++) {
     legendvalues[i] = document.createElement("span");
     const val = STRING_INTERVALS[i];
     legendvalues[i].appendChild(document.createTextNode(val));


### PR DESCRIPTION
You can set "attributes" on HTML elements like `data-myvalue`. They don't actually impact the browser! They are solely so we can store values on HTML elements and grab them later via JavaScript. 

Turns out, we don't actually need to use them! We can store the values via normal JavaScript constants. For `data-value`, we already were setting `leftSlider.value` and there was no need to also set `data-myvalue`; I don't know what the comment was talking about saying it's about browser refreshes.

Also simplifies creation of the legend and uses `document.querySelector` rather than `selectorControls.querySelector`.