### PR TITLE
Prevent slider from overlapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,6 @@
           type="range"
           step="0.5"
           min="0"
-          value="0"
         />
         <input
           class="population-slider-right"

--- a/src/css/_population-slider.scss
+++ b/src/css/_population-slider.scss
@@ -14,7 +14,7 @@
 }
 
 .population-slider-controls {
-  width: 360px;
+  width: 20em;
   height: 2em;
   display: flex;
   justify-content: space-between;

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -20,6 +20,8 @@ const draw = (
 
   sliders.left.setAttribute("max", newLeftMax.toString());
   sliders.right.setAttribute("min", newRightMin.toString());
+  sliders.left.setAttribute("value", leftIndex.toString());
+  sliders.right.setAttribute("value", rightIndex.toString());
 
   const intervalSizePx =
     sliders.controls.offsetWidth / POPULATION_INTERVALS.length;
@@ -52,7 +54,6 @@ const createPopulationSlider = (): PopulationSliders => {
 
   sliders.left.setAttribute("max", RANGE_MAX.toString());
   sliders.right.setAttribute("max", RANGE_MAX.toString());
-  sliders.right.value = RANGE_MAX.toString();
   draw(sliders, 0, RANGE_MAX);
 
   const legend = document.querySelector(".population-slider-legend");

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -13,10 +13,9 @@ const draw = (
   rightIndex: number
 ): void => {
   // We dynamically change the sliders so that they cannot extend past each other.
-  const cross = rightIndex - 0.5 >= leftIndex ? rightIndex - 0.5 : rightIndex; // a single interval that min and max sliders overlap
-  const extend = leftIndex + 1 == rightIndex; // if sliders are close and within 1 step can overlap
-  const newLeftMax = extend ? cross + 0.5 : cross;
-  const newRightMin = cross;
+  const inBetween = (rightIndex - leftIndex) / 2;
+  const newLeftMax = leftIndex + inBetween;
+  const newRightMin = rightIndex - inBetween;
 
   sliders.left.setAttribute("max", newLeftMax.toString());
   sliders.right.setAttribute("min", newRightMin.toString());
@@ -24,7 +23,8 @@ const draw = (
   sliders.right.setAttribute("value", rightIndex.toString());
 
   const intervalSizePx =
-    sliders.controls.offsetWidth / POPULATION_INTERVALS.length;
+    (sliders.controls.offsetWidth + THUMBSIZE / 2) /
+    POPULATION_INTERVALS.length;
   const leftWidth = newLeftMax * intervalSizePx;
   const rightWidth = (RANGE_MAX - newRightMin) * intervalSizePx;
   sliders.left.style.width = `${leftWidth + THUMBSIZE}px`;
@@ -32,11 +32,7 @@ const draw = (
 
   // The left slider has a fixed anchor. However, the right slider has to move
   // everytime the range of the slider changes.
-  const offset = 5;
-  sliders.left.style.left = `${offset}px`;
-  sliders.right.style.left = extend
-    ? `${leftWidth - intervalSizePx / 2 + offset}px`
-    : `${leftWidth + offset}px`;
+  sliders.right.style.left = `${leftWidth}px`;
 
   const updateLabel = (cls: string, index: number): void => {
     document.querySelector(cls).innerHTML = POPULATION_INTERVALS[index][0];

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -59,8 +59,9 @@ export class PopulationSliders {
 
   /** Return the [leftIndex, rightIndex] of the sliders. */
   getCurrentIndexes(): [number, number] {
-    const get = (slider: HTMLInputElement): number =>
-      Math.floor(parseFloat(slider.value));
-    return [get(this.left), get(this.right)];
+    return [
+      Math.floor(parseFloat(this.left.value)),
+      Math.ceil(parseFloat(this.right.value)),
+    ];
   }
 }

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -120,11 +120,19 @@ test("population filter updates markers", async ({ page }) => {
     }
   };
 
-  await testSlider(left, 5, false); // The slider interval is between 0 - 11
-  await testSlider(right, 10.5, false);
-  // NOTE: Due to the way the double slider is coded, the right slider only extends 0.5 step left from where the slider head is.
-  await testSlider(left, 9, false);
-  await testSlider(right, 9.5, false);
+  // The slider interval is between 0 - 11
+  // However, the each slider only renders a certain range.
+
+  // L: 0 - 5.5   R: 5.5 - 11
+  await testSlider(left, 5, false);
+  // L: 0 - 8   R: 8 - 11
+  await testSlider(right, 8, false);
+  // L: 0 - 6.5   R: 6.5 - 11
+  await testSlider(left, 6, false);
+  // L: 0 - 7   R: 7 - 11
+  await testSlider(right, 7, false);
+  // L: 0 - 7.5   R: 7.5 - 11
   await testSlider(right, 11, true);
+  // L: 0 - 8.5   R: 8.5 - 11
   await testSlider(left, 2, true);
 });


### PR DESCRIPTION
Resolves #241 
Resolves #249 

By simplifying slider render, so the sliders are joined down the middle. 