### PR TITLE
Add a disclaimer about premature release

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,17 +36,28 @@
 
   <body>
     <header>
-      <span class="header-title">Parking Reform Map</span>
-      <div class="header-icons">
-        <div class="info-icon">
-          <i class="fa-solid fa-circle-info fa-lg" title="About" id="info"></i>
+      <div class="header-top">
+        <span class="header-title">Parking Reform Map</span>
+        <div class="header-icons">
+          <div class="info-icon">
+            <i
+              class="fa-solid fa-circle-info fa-lg"
+              title="About"
+              id="info"
+            ></i>
+          </div>
+          <a href="https://parkingreform.org/mandates-map" target="_blank">
+            <i
+              class="fa-solid fa-up-right-from-square fa-lg"
+              title="View fullscreen"
+            ></i>
+          </a>
         </div>
-        <a href="https://parkingreform.org/mandates-map" target="_blank">
-          <i
-            class="fa-solid fa-up-right-from-square fa-lg"
-            title="View fullscreen"
-          ></i>
-        </a>
+      </div>
+      <div class="header-disclaimer">
+        Disclaimer: We had to prematurely release our rewrite of this map due to
+        one of our data providers breaking. We will be releasing improvements to
+        this map throughout October.
       </div>
     </header>
 

--- a/src/css/_filter.scss
+++ b/src/css/_filter.scss
@@ -4,15 +4,19 @@ $gray: #737272;
 
 .filters-popup-container {
   position: absolute;
-  top: 3.8em;
+  top: 5.4em;
   left: 21em;
+
+  @media only screen and (min-width: 48em) {
+    top: 7em;
+  }
 }
 
 .filters-popup-icon {
   position: absolute;
   background-color: white;
   border: solid $gray 1px;
-  z-index: 1200;
+  z-index: 1000;
   right: 0;
   padding: 0.5em;
   border-radius: 0.25em;

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -2,9 +2,6 @@ $gray: #4d4d4d;
 
 header {
   padding: 0.5rem 1rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
 
   font-size: 1rem;
   background: $gray;
@@ -19,6 +16,12 @@ header {
   }
 }
 
+.header-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
 .header-icons {
   display: flex;
   align-items: center;
@@ -29,4 +32,9 @@ header {
   svg {
     padding: 0 0.5rem;
   }
+}
+
+.header-disclaimer {
+  margin-top: 0.3em;
+  font-size: 0.65em;
 }

--- a/src/css/_search.scss
+++ b/src/css/_search.scss
@@ -1,12 +1,12 @@
 div.choices {
   position: absolute;
-  top: 3.2em;
+  top: 5.4em;
   left: 3em;
   max-width: 250px;
   z-index: 1000;
 
   @media only screen and (min-width: 48em) {
-    top: 3.85em;
+    top: 7em;
   }
 
   &.is-open {


### PR DESCRIPTION
Closes https://github.com/ParkingReformNetwork/reform-map/issues/266. We should revert this once reaching feature parity.

<img width="1279" alt="Captura de pantalla 2023-10-14 a la(s) 11 43 35 p m" src="https://github.com/ParkingReformNetwork/reform-map/assets/14852634/396b8065-f388-43e5-8b4f-0bc84a4e7633">

This also improves the filter icon. It now is in the correct location on mobile, and it also doesn't sit on top of the site info popup improperly.