### PR TITLE
Add continuous deployment for map rewrite

### DIFF
--- a/.github/workflows/deploy-city-details-prod.yaml
+++ b/.github/workflows/deploy-city-details-prod.yaml
@@ -1,4 +1,4 @@
-name: Deploy to prod
+name: Deploy city details to prod
 on:
   push:
     branches: [main]

--- a/.github/workflows/deploy-map-prod.yaml
+++ b/.github/workflows/deploy-map-prod.yaml
@@ -1,0 +1,17 @@
+name: Deploy map to prod
+on: [workflow_dispatch]
+jobs:
+  deploy_prod:
+    if: github.repository_owner == 'ParkingReformNetwork'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Copy from staging to production
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.PRN_SERVER_HOST }}
+          username: ${{ secrets.PRN_SERVER_USERNAME }}
+          key: ${{ secrets.PRN_SERVER_PRIVATE_KEY }}
+          script: |
+            rsync --archive --verbose --compress --delete \
+              /var/www/${{ secrets.PRN_SERVER_HOST }}/mandates-map-staging/ \
+              /var/www/${{ secrets.PRN_SERVER_HOST }}/mandates-map/

--- a/.github/workflows/deploy-map-staging.yaml
+++ b/.github/workflows/deploy-map-staging.yaml
@@ -1,4 +1,4 @@
-name: Deploy to staging
+name: Deploy map to staging
 on:
   push:
     branches: [main]


### PR DESCRIPTION
We won't actually do the deploy yet, but this gets it set up.

The map will only be deployed by a human after verifying staging is good to go. But we'll continue pushing city details updates automatically, at least for now.