### PR TITLE
Search box is expanded by default

### DIFF
--- a/src/css/_search.scss
+++ b/src/css/_search.scss
@@ -1,20 +1,24 @@
+$width: 250px;
+
 div.choices {
   position: absolute;
   top: 5.4em;
   left: 3em;
-  max-width: 250px;
+  max-width: $width;
   z-index: 1000;
 
   @media only screen and (min-width: 48em) {
     top: 7em;
   }
 
+  // Changes the search list.
   &.is-open {
-    width: 250px;
+    width: $width;
   }
 }
 
+// Changes the search box.
 div.choices__inner {
   min-height: unset;
-  width: unset;
+  width: $width - 20px;
 }


### PR DESCRIPTION
Closes https://github.com/ParkingReformNetwork/reform-map/issues/264.

<img width="383" alt="Captura de pantalla 2023-10-15 a la(s) 12 25 44 a m" src="https://github.com/ParkingReformNetwork/reform-map/assets/14852634/0906e492-2c9e-491a-b301-6a6087fd2cd5">

For some reason, I couldn't get the expanded search list to line up perfectly with the search box. I figured it's not a very big deal.

<img width="362" alt="Captura de pantalla 2023-10-15 a la(s) 12 26 02 a m" src="https://github.com/ParkingReformNetwork/reform-map/assets/14852634/4e9b9329-9e80-4b73-83a8-f8f232861495">
