### PR TITLE
Remove times from rsync

### DIFF
--- a/.github/workflows/deploy-map-prod.yaml
+++ b/.github/workflows/deploy-map-prod.yaml
@@ -12,6 +12,6 @@ jobs:
           username: ${{ secrets.PRN_SERVER_USERNAME }}
           key: ${{ secrets.PRN_SERVER_PRIVATE_KEY }}
           script: |
-            rsync --archive --verbose --compress \
+            rsync --archive --verbose --compress --no-times \
               /var/www/${{ secrets.PRN_SERVER_HOST }}/mandates-map-staging/ \
               /var/www/${{ secrets.PRN_SERVER_HOST }}/mandates-map/


### PR DESCRIPTION
See if this fixes this issue with prod map deploys:

> err: rsync: failed to set times on "/var/www/***/mandates-map/.": Operation not permitted (1)