### PR TITLE
Refactor shouldBeRendered

### DIFF
--- a/src/js/filter.ts
+++ b/src/js/filter.ts
@@ -115,5 +115,4 @@ export {
   changeSelectedMarkers,
   POPULATION_INTERVALS,
   setUpAllFilters,
-  shouldBeRendered,
 };

--- a/src/js/filter.ts
+++ b/src/js/filter.ts
@@ -37,29 +37,24 @@ const shouldBeRendered = (
   }
 
   // Else, search is not used and the filters should apply.
-  const getSelected = (cls: string): Set<string> =>
-    new Set(
-      Array.from(document.querySelectorAll(cls)).map(
+  const matchesSelected = (selector: string, entryKey: string): boolean => {
+    const selectedValues = new Set(
+      Array.from(document.querySelectorAll(selector)).map(
         (option: HTMLInputElement) => option.value
       )
     );
+    return entry[entryKey]
+      .split(",")
+      .some((value: string) => selectedValues.has(value));
+  };
 
-  const scopeSelected = getSelected(".scope :checked");
-  const isScope = entry["report_magnitude"]
-    .split(",")
-    .some((scope) => scopeSelected.has(scope));
-  const policySelected = getSelected(".policy-change :checked");
-  const isPolicy = entry["report_type"]
-    .split(",")
-    .some((policy) => policySelected.has(policy));
-  const landSelected = getSelected(".land-use :checked");
-  const isLand = entry["land_uses"]
-    .split(",")
-    .some((land) => landSelected.has(land));
-  const stageSelected = getSelected(".implementation-stage :checked");
-  const isStage = entry["report_status"]
-    .split(",")
-    .some((stage) => stageSelected.has(stage));
+  const isScope = matchesSelected(".scope :checked", "report_magnitude");
+  const isPolicy = matchesSelected(".policy-change :checked", "report_type");
+  const isLand = matchesSelected(".land-use :checked", "land_uses");
+  const isStage = matchesSelected(
+    ".implementation-stage :checked",
+    "report_status"
+  );
 
   const population = parseInt(entry["population"]);
   const [sliderLeftIndex, sliderRightIndex] = sliders.getCurrentIndexes();
@@ -101,26 +96,19 @@ const setUpAllFilters = (
   searchElement: Choices,
   sliders: PopulationSliders
 ): void => {
-  // We don't want each click to reset the selection. Instead, each click updates the selection by adding or removing a single selection.
-  // As a result, the user won't have to use shift, ctrl/cmd to make complicated selections.
-  const FILTER_TYPE = [
-    "scope",
-    "policy-change",
-    "land-use",
-    "implementation-stage",
-  ];
-
-  FILTER_TYPE.forEach((filterType: string): void => {
-    document.querySelector(`.${filterType}`).addEventListener("change", () => {
-      changeSelectedMarkers(
-        markerGroup,
-        citiesToMarkers,
-        data,
-        searchElement,
-        sliders
-      );
-    });
-  });
+  [".scope", ".policy-change", ".land-use", ".implementation-stage"].forEach(
+    (filter) => {
+      document.querySelector(filter).addEventListener("change", () => {
+        changeSelectedMarkers(
+          markerGroup,
+          citiesToMarkers,
+          data,
+          searchElement,
+          sliders
+        );
+      });
+    }
+  );
 };
 
 export {

--- a/src/js/filter.ts
+++ b/src/js/filter.ts
@@ -111,8 +111,4 @@ const setUpAllFilters = (
   );
 };
 
-export {
-  changeSelectedMarkers,
-  POPULATION_INTERVALS,
-  setUpAllFilters,
-};
+export { changeSelectedMarkers, POPULATION_INTERVALS, setUpAllFilters };


### PR DESCRIPTION
Better deduplicates code:

* shouldBeRendered uses the new helper function `matchesSelected`
* `setUpAllFilters` inlines the variable `FILTER_TYPE` and directly puts the `.` in the values; it wasn't worth the extra indirection to only save typing one character.

Note that I was considering refactoring `shouldBeRendered` so that it could be better unit tested, but it's looking like it's still probably not very appropriate to unit test given how much it depends on side effects, that the page is set up a specific way. TBD.