### PR TITLE
Rewrite testing of filter to be declarative

### DIFF
--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test";
+import { Page, test } from "@playwright/test";
 import { loadMap, assertNumCities, DEFAULT_CITY_RANGE } from "./utils";
 
 interface EdgeCase {
@@ -51,24 +51,25 @@ const TESTS: EdgeCase[] = [
   },
 ];
 
+const selectIfSet = async (
+  page: Page,
+  selector: string,
+  values?: string[]
+): Promise<void> => {
+  if (values !== undefined) {
+    await page.locator(selector).selectOption(values);
+  }
+};
+
 for (const edgeCase of TESTS) {
   test(`${edgeCase.desc}`, async ({ page }) => {
     await loadMap(page);
     await page.locator(".filters-popup-icon").click();
 
-    const selectIfSet = async (
-      selector: string,
-      values?: string[]
-    ): Promise<void> => {
-      if (values !== undefined) {
-        await page.locator(selector).selectOption(values);
-      }
-    };
-
-    await selectIfSet(".scope", edgeCase.scope);
-    await selectIfSet(".policy-change", edgeCase.policy);
-    await selectIfSet(".land-use", edgeCase.land);
-    await selectIfSet(".implementation-stage", edgeCase.implementation);
+    await selectIfSet(page, ".scope", edgeCase.scope);
+    await selectIfSet(page, ".policy-change", edgeCase.policy);
+    await selectIfSet(page, ".land-use", edgeCase.land);
+    await selectIfSet(page, ".implementation-stage", edgeCase.implementation);
 
     if (edgeCase.populationIntervals !== undefined) {
       const [leftInterval, rightInterval] = edgeCase.populationIntervals;

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -1,114 +1,85 @@
-import type { ElementHandle } from "@playwright/test";
-import { expect, test } from "@playwright/test";
-import { loadMap, getNumCities } from "./utils";
+import { test } from "@playwright/test";
+import { loadMap, assertNumCities, DEFAULT_CITY_RANGE } from "./utils";
 
-const openFilterPopup = async (page): Promise<void> => {
-  page.locator(".filters-popup-icon").click();
-};
+interface EdgeCase {
+  desc: string;
+  scope?: string[];
+  policy?: string[];
+  land?: string[];
+  implementation?: string[];
+  populationIntervals?: [number, number];
+  expectedRange: [number, number];
+}
 
-const findDiff = async (
-  page,
-  filterType: string,
-  optionText: string
-): Promise<number> => {
-  const citiesBefore = await getNumCities(page);
+// The expected ranges can be updated as the data is updated!
+const TESTS: EdgeCase[] = [
+  { desc: "default filters", expectedRange: DEFAULT_CITY_RANGE },
+  { desc: "disabled filter", scope: [], expectedRange: [0, 0] },
+  { desc: "scope filter", scope: ["Regional"], expectedRange: [3, 6] },
+  {
+    desc: "policy change filter",
+    policy: ["Parking Maximums"],
+    expectedRange: [125, 160],
+  },
+  { desc: "land use filter", land: ["Residential"], expectedRange: [15, 22] },
+  {
+    desc: "implementation filter",
+    implementation: ["Repealed"],
+    expectedRange: [1, 2],
+  },
+  {
+    desc: "population slider",
+    populationIntervals: [4, 8],
+    expectedRange: [580, 700],
+  },
+  {
+    desc: "all cities",
+    // The other filters already enable all options by default.
+    policy: [
+      "Reduce Parking Minimums",
+      "Eliminate Parking Minimums",
+      "Parking Maximums",
+    ],
+    implementation: [
+      "Implemented",
+      "Passed",
+      "Planned",
+      "Proposed",
+      "Repealed",
+    ],
+    expectedRange: [1850, 2200],
+  },
+];
 
-  // Find and click the scope option element
-  const optionElement = await page.$(
-    `.${filterType} option:has-text("${optionText}")`
-  );
-  await optionElement.click();
-
-  const citiesAfter = await getNumCities(page);
-  const citiesDiff = Math.abs(citiesAfter - citiesBefore);
-  return citiesDiff;
-};
-
-test.fixme(
-  "scope, policy, land, implementation filter updates markers",
-  async ({ page }) => {
+for (const edgeCase of TESTS) {
+  test(`${edgeCase.desc}`, async ({ page }) => {
     await loadMap(page);
-    await openFilterPopup(page);
-    const FILTER_OPTIONS = {
-      scope: { Regional: 41 },
-      "policy-change": { "Reduce Parking Minimums": 294 },
-      "land-use": { "All Uses": 1113 },
-      "implementation-stage": { Implemented: 433 },
+    await page.locator(".filters-popup-icon").click();
+
+    const selectIfSet = async (
+      selector: string,
+      values?: string[]
+    ): Promise<void> => {
+      if (values !== undefined) {
+        await page.locator(selector).selectOption(values);
+      }
     };
-    /* eslint-disable no-await-in-loop */
-    for (const filterType of Object.keys(FILTER_OPTIONS)) {
-      const optionDict = FILTER_OPTIONS[filterType];
-      const option = Object.keys(optionDict)[0];
-      const diff = await findDiff(page, filterType, option);
-      expect(diff >= optionDict[option]).toBe(true);
-    }
-    /* eslint-enable no-await-in-loop */
-  }
-);
 
-test.fixme("population slider updates markers", async ({ page }) => {
-  await loadMap(page);
-  await openFilterPopup(page);
-  const left = await page.$(".population-slider-left");
-  const right = await page.$(".population-slider-right");
+    await selectIfSet(".scope", edgeCase.scope);
+    await selectIfSet(".policy-change", edgeCase.policy);
+    await selectIfSet(".land-use", edgeCase.land);
+    await selectIfSet(".implementation-stage", edgeCase.implementation);
 
-  // min updated on 10/10/23
-  const populationDiff = [63, 119, 565, 253, 537, 142, 124, 28, 16, 4, 0];
-
-  /*
-    Moves slider to interval and checks to make sure the number of cities on the map is reasonable.
-
-    willIncrease is required because this function does not know if slider is the left or right slider.
-  */
-  const testSlider = async (
-    slider: ElementHandle,
-    moveToInterval: number,
-    willIncrease: boolean
-  ): Promise<void> => {
-    const citiesBefore = await getNumCities(page);
-    const sliderBefore = parseInt(await slider.inputValue(), 10);
-    await slider.fill(moveToInterval.toString());
-    const actualDiff = (await getNumCities(page)) - citiesBefore;
-
-    // Due to the way the right slider is drawn, we're only able to test the right slider by 0.5 increments.
-    // As a result, fullInterval is for the 0.5 moveToInterval values provided for the right slider.
-    const fullInterval = willIncrease
-      ? Math.ceil(moveToInterval)
-      : Math.floor(moveToInterval);
-    const lower = Math.min(fullInterval, sliderBefore);
-    const upper = Math.max(fullInterval, sliderBefore);
-
-    // Using true data, calculate threshold for difference.
-    let expectedDiff = 0;
-    for (let i = lower; i < upper; i += 1) {
-      expectedDiff += populationDiff[i];
+    if (edgeCase.populationIntervals !== undefined) {
+      const [leftInterval, rightInterval] = edgeCase.populationIntervals;
+      await page
+        .locator(".population-slider-left")
+        .fill(leftInterval.toString());
+      await page
+        .locator(".population-slider-right")
+        .fill(rightInterval.toString());
     }
 
-    // We cannot use absolute value. For example, the edge case actuallDiff = 100 and expectedDiff = -100.
-    if (willIncrease) {
-      expect(
-        actualDiff >= expectedDiff && actualDiff <= expectedDiff * 1.5
-      ).toBe(true);
-    } else {
-      expect(
-        actualDiff <= -expectedDiff && actualDiff >= -expectedDiff * 1.5
-      ).toBe(true);
-    }
-  };
-
-  // The slider interval is between 0 - 11
-  // However, the each slider only renders a certain range.
-
-  // L: 0 - 5.5   R: 5.5 - 11
-  await testSlider(left, 5, false);
-  // L: 0 - 8   R: 8 - 11
-  await testSlider(right, 8, false);
-  // L: 0 - 6.5   R: 6.5 - 11
-  await testSlider(left, 6, false);
-  // L: 0 - 7   R: 7 - 11
-  await testSlider(right, 7, false);
-  // L: 0 - 7.5   R: 7.5 - 11
-  await testSlider(right, 11, true);
-  // L: 0 - 8.5   R: 8.5 - 11
-  await testSlider(left, 2, true);
-});
+    await assertNumCities(page, edgeCase.expectedRange);
+  });
+}

--- a/tests/app/search.test.ts
+++ b/tests/app/search.test.ts
@@ -1,6 +1,6 @@
-import { expect, test } from "@playwright/test";
+import { test } from "@playwright/test";
 
-import { getNumCities, loadMap } from "./utils";
+import { assertNumCities, loadMap, DEFAULT_CITY_RANGE } from "./utils";
 
 test("search changes what is shown", async ({ page }) => {
   await loadMap(page);
@@ -10,13 +10,11 @@ test("search changes what is shown", async ({ page }) => {
     .locator(".choices__list--dropdown > .choices__list > .choices__item")
     .first()
     .click();
-  let cities = await getNumCities(page);
-  expect(cities).toBe(1);
+  await assertNumCities(page, [1, 1]);
 
   // Removing the selected cities restores all.
   await page
     .locator(".choices__inner > .choices__list > .choices__item > button")
     .click();
-  cities = await getNumCities(page);
-  expect(cities).toBeGreaterThan(1400);
+  await assertNumCities(page, DEFAULT_CITY_RANGE);
 });

--- a/tests/app/utils.ts
+++ b/tests/app/utils.ts
@@ -1,6 +1,8 @@
+import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
 const CITY_MARKER = "path.leaflet-interactive";
+const DEFAULT_CITY_RANGE: [number, number] = [1430, 1600];
 
 const loadMap = async (page: Page): Promise<void> => {
   await page.goto("");
@@ -8,7 +10,13 @@ const loadMap = async (page: Page): Promise<void> => {
   await page.waitForSelector(CITY_MARKER);
 };
 
-const getNumCities = async (page: Page): Promise<number> =>
-  page.locator(CITY_MARKER).count();
+const assertNumCities = async (
+  page: Page,
+  range: [number, number]
+): Promise<void> => {
+  const numCities = await page.locator(CITY_MARKER).count();
+  expect(numCities).toBeGreaterThanOrEqual(range[0]);
+  expect(numCities).toBeLessThanOrEqual(range[1]);
+};
 
-export { getNumCities, loadMap };
+export { assertNumCities, loadMap, DEFAULT_CITY_RANGE };


### PR DESCRIPTION
A declarative test defines the desired outcomes and conditions for a test scenario without specifying the step-by-step procedures to achieve them. It focuses on the "what" rather than the "how".

These tests should be easier to read and maintain.

Note that I considered unit testing `shouldBeRendered`, but it was way too hard to mock because the function interacts so strongly with the DOM. So I stuck with integration tests.
