### PR TITLE
Add no requirements toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -202,6 +202,11 @@
 
     <select multiple class="city-search"></select>
 
+    <div class="no-requirements-toggle-container">
+      <label for="no-requirements-toggle">No parking requirements</label>
+      <input id="no-requirements-toggle" type="checkbox" />
+    </div>
+
     <div class="donate-button">
       <a href="https://parkingreform.org/support/"
         ><img src="./assets/donate.png"

--- a/src/css/_filter.scss
+++ b/src/css/_filter.scss
@@ -1,6 +1,6 @@
 $unchecked: "\2610";
 $checked: "\2611";
-$gray: #737272;
+$gray: rgb(204, 204, 204);
 
 .filters-popup-container {
   position: absolute;
@@ -19,7 +19,7 @@ $gray: #737272;
   z-index: 1000;
   right: 0;
   padding: 0.5em;
-  border-radius: 0.25em;
+  border-radius: 2px;
   cursor: pointer;
 }
 

--- a/src/css/_no-requirements-toggle.scss
+++ b/src/css/_no-requirements-toggle.scss
@@ -1,0 +1,17 @@
+$gray: rgb(204, 204, 204);
+
+.no-requirements-toggle-container {
+  position: absolute;
+  background-color: white;
+  top: 8.4em;
+  left: 3em;
+  z-index: 900;
+  padding: 0.2em 0.4em;
+
+  border: solid $gray 1px;
+  border-radius: 2px;
+
+  @media only screen and (min-width: 48em) {
+    top: 11em;
+  }
+}

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -3,6 +3,7 @@
 @use "donate";
 @use "header";
 @use "legend";
+@use "no-requirements-toggle";
 @use "search";
 @use "filter";
 @use "population-slider";

--- a/src/js/filter.ts
+++ b/src/js/filter.ts
@@ -56,13 +56,26 @@ const shouldBeRendered = (
     "report_status"
   );
 
+  const noRequirementsToggleElement = document.getElementById(
+    "no-requirements-toggle"
+  ) as HTMLInputElement;
+  const isNoRequirementsToggle =
+    !noRequirementsToggleElement.checked || entry.is_no_mandate_city === "1";
+
   const population = parseInt(entry["population"]);
   const [sliderLeftIndex, sliderRightIndex] = sliders.getCurrentIndexes();
   const isPopulation =
     population >= POPULATION_INTERVALS[sliderLeftIndex][1] &&
     population <= POPULATION_INTERVALS[sliderRightIndex][1];
 
-  return isScope && isPolicy && isLand && isStage && isPopulation;
+  return (
+    isScope &&
+    isPolicy &&
+    isLand &&
+    isStage &&
+    isNoRequirementsToggle &&
+    isPopulation
+  );
 };
 
 /**
@@ -96,19 +109,23 @@ const setUpAllFilters = (
   searchElement: Choices,
   sliders: PopulationSliders
 ): void => {
-  [".scope", ".policy-change", ".land-use", ".implementation-stage"].forEach(
-    (filter) => {
-      document.querySelector(filter).addEventListener("change", () => {
-        changeSelectedMarkers(
-          markerGroup,
-          citiesToMarkers,
-          data,
-          searchElement,
-          sliders
-        );
-      });
-    }
-  );
+  [
+    ".scope",
+    ".policy-change",
+    ".land-use",
+    ".implementation-stage",
+    "#no-requirements-toggle",
+  ].forEach((selector) => {
+    document.querySelector(selector).addEventListener("change", () => {
+      changeSelectedMarkers(
+        markerGroup,
+        citiesToMarkers,
+        data,
+        searchElement,
+        sliders
+      );
+    });
+  });
 };
 
 export { changeSelectedMarkers, POPULATION_INTERVALS, setUpAllFilters };

--- a/src/js/filterPopup.ts
+++ b/src/js/filterPopup.ts
@@ -27,14 +27,9 @@ const setUpFilterPopup = (
   filterIcon.addEventListener(
     "click",
     () => {
+      // This happens here because the filter popup must be displayed for
+      // the offsetWidth calculation to work properly.
       setUpPopulationSlider(
-        markerGroup,
-        citiesToMarkers,
-        data,
-        searchElement,
-        sliders
-      );
-      setUpAllFilters(
         markerGroup,
         citiesToMarkers,
         data,

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -8,7 +8,7 @@ import { createSearchElement, setUpSearch } from "./search";
 import setUpAbout from "./about";
 import setUpDetails from "./cityDetails";
 import { createPopulationSlider } from "./populationSlider";
-import { changeSelectedMarkers } from "./filter";
+import { changeSelectedMarkers, setUpAllFilters } from "./filter";
 import setUpFilterPopup from "./filterPopup";
 
 const BASE_LAYER = new TileLayer(
@@ -94,6 +94,7 @@ const setUpSite = async (): Promise<void> => {
 
   setUpDetails(markerGroup, data);
   setUpSearch(markerGroup, citiesToMarkers, data, searchElement, sliders);
+  setUpAllFilters(markerGroup, citiesToMarkers, data, searchElement, sliders);
   setUpFilterPopup(markerGroup, citiesToMarkers, data, searchElement, sliders);
 
   // Finally, apply our default filters to change what is pre-selected,

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -8,6 +8,7 @@ interface EdgeCase {
   land?: string[];
   implementation?: string[];
   populationIntervals?: [number, number];
+  noRequirements?: boolean;
   expectedRange: [number, number];
 }
 
@@ -31,6 +32,11 @@ const TESTS: EdgeCase[] = [
     desc: "population slider",
     populationIntervals: [4, 8],
     expectedRange: [580, 700],
+  },
+  {
+    desc: "no requirements",
+    noRequirements: true,
+    expectedRange: [45, 55],
   },
   {
     desc: "all cities",
@@ -64,6 +70,13 @@ const selectIfSet = async (
 for (const edgeCase of TESTS) {
   test(`${edgeCase.desc}`, async ({ page }) => {
     await loadMap(page);
+
+    // Deal with the requirements toggle before the filter popup, since the
+    // filter popup covers it.
+    if (edgeCase.noRequirements !== undefined) {
+      await page.locator("#no-requirements-toggle").check();
+    }
+
     await page.locator(".filters-popup-icon").click();
 
     await selectIfSet(page, ".scope", edgeCase.scope);


### PR DESCRIPTION
Closes https://github.com/ParkingReformNetwork/reform-map/issues/187. Turns out this feature was really important.

This toggle is simply another filter, but it appears on its own rather than being in the filter popup. That's a little weird, but we need to keep it for now until we can redesign the UI.

Also fixes the border color for the filter icon to match Leaflet's gray color.

<img width="363" alt="Captura de pantalla 2023-10-15 a la(s) 10 02 14 p m" src="https://github.com/ParkingReformNetwork/reform-map/assets/14852634/8df47fb6-d310-4ddc-93e4-b0aa5ad05ba3">

The UI is a little awkward because search will cover the toggle, just like the old UI. Tony said that's fine for now. 

Also, it's only a checkbox and not yet a toggle to unblock adding this critical feature. We need to switch to a toggle in https://github.com/ParkingReformNetwork/reform-map/issues/285.