### PR TITLE
Add share icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,17 @@
               id="info"
             ></i>
           </div>
+          <a href="#" class="share-icon"
+            ><i
+              class="share-link-icon fa-solid fa-link fa-lg"
+              title="Copy link"
+            ></i
+            ><i
+              class="share-check-icon fa-solid fa-check fa-lg"
+              title="Link Copied!"
+              style="display: none"
+            ></i>
+          </a>
           <a href="https://parkingreform.org/mandates-map" target="_blank">
             <i
               class="fa-solid fa-up-right-from-square fa-lg"

--- a/src/js/fontAwesome.ts
+++ b/src/js/fontAwesome.ts
@@ -1,5 +1,6 @@
 import { library, dom } from "@fortawesome/fontawesome-svg-core";
 import {
+  faCheck,
   faCircleInfo,
   faLink,
   faUpRightFromSquare,
@@ -13,6 +14,7 @@ import "@fortawesome/fontawesome-svg-core/styles.css";
 
 const setUpIcons = (): void => {
   library.add(
+    faCheck,
     faCircleInfo,
     faLink,
     faUpRightFromSquare,

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -5,6 +5,7 @@ import type { CityId, CityEntry } from "./types";
 import setUpIcons from "./fontAwesome";
 import addLegend from "./legend";
 import { createSearchElement, setUpSearch } from "./search";
+import { setUpShareIcon } from "./share";
 import setUpAbout from "./about";
 import setUpDetails from "./cityDetails";
 import { createPopulationSlider } from "./populationSlider";
@@ -83,6 +84,7 @@ const createCityMarkers = (
 const setUpSite = async (): Promise<void> => {
   setUpIcons();
   setUpAbout();
+  setUpShareIcon();
   const map = createMap();
   const markerGroup = new FeatureGroup();
   const sliders = createPopulationSlider();

--- a/src/js/share.ts
+++ b/src/js/share.ts
@@ -1,0 +1,33 @@
+const SHARE_URL = "https://parkingreform.org/resources/mandates-map";
+
+const copyToClipboard = async (value: string): Promise<void> => {
+  try {
+    await navigator.clipboard.writeText(value);
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error("Failed to write to clipboard: ", err);
+  }
+};
+
+const switchIcons = (shareIcon: HTMLAnchorElement): void => {
+  const linkIcon = shareIcon.querySelector("svg.share-link-icon") as SVGElement;
+  const checkIcon = shareIcon.querySelector(
+    "svg.share-check-icon"
+  ) as SVGElement;
+  linkIcon.style.display = "none";
+  checkIcon.style.display = "inline-block";
+  setTimeout(() => {
+    linkIcon.style.display = "inline-block";
+    checkIcon.style.display = "none";
+  }, 1000);
+};
+
+const setUpShareIcon = (): void => {
+  const shareIcon = document.querySelector(".share-icon") as HTMLAnchorElement;
+  shareIcon.addEventListener("click", async () => {
+    await copyToClipboard(SHARE_URL);
+    switchIcons(shareIcon);
+  });
+};
+
+export { setUpShareIcon, SHARE_URL };

--- a/tests/app/share.test.ts
+++ b/tests/app/share.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from "@playwright/test";
+import { SHARE_URL } from "../../src/js/share";
+
+test("share button writes the URL to the clipboard", async ({ browser }) => {
+  const context = await browser.newContext();
+  await context.grantPermissions(["clipboard-read", "clipboard-write"]);
+  const page = await context.newPage();
+  await page.goto("");
+
+  await page.click(".share-icon");
+  const copied = await page.evaluate(() => navigator.clipboard.readText());
+  expect(copied).toEqual(SHARE_URL);
+});


### PR DESCRIPTION
Closes https://github.com/ParkingReformNetwork/reform-map/issues/271.

<img width="169" alt="Captura de pantalla 2023-10-16 a la(s) 9 26 49 p m" src="https://github.com/ParkingReformNetwork/reform-map/assets/14852634/7ca7ada4-bb4c-430c-b72b-b89d59e0a7bf">

When you click it, we copy https://parkingreform.org/resources/mandates-map to the clipboard. We also for 1 second change the icon to a check:

<img width="130" alt="Captura de pantalla 2023-10-16 a la(s) 9 27 49 p m" src="https://github.com/ParkingReformNetwork/reform-map/assets/14852634/974fccdd-5bb5-4616-ade5-ce4dcf36f226">
