### PR TITLE
Adding form element removes extra whitespace in Safari

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,94 +147,102 @@
       <div class="filters-popup-window">
         <div class="filters-popup-flex">
           <div class="filter scope">
-            <fieldset>
-              <legend>Scope of Reform</legend>
-              <label
-                ><input type="checkbox" name="scope" checked />Regional</label
-              >
-              <label
-                ><input type="checkbox" name="scope" checked />Citywide</label
-              >
-              <!-- ignore lines in which the text may be split up into multiple lines -->
-              <!-- prettier-ignore -->
-              <label><input type="checkbox" name="scope" checked />City Center/Business District</label>
-              <!-- prettier-ignore -->
-              <label><input type="checkbox" name="scope" checked />Transit Oriented</label>
-              <!-- prettier-ignore -->
-              <label><input type="checkbox" name="scope" checked />Main Street/Special</label>
-            </fieldset>
+            <form>
+              <fieldset>
+                <legend>Scope of Reform</legend>
+                <label
+                  ><input type="checkbox" name="scope" checked />Regional</label
+                >
+                <label
+                  ><input type="checkbox" name="scope" checked />Citywide</label
+                >
+                <!-- ignore lines in which the text may be split up into multiple lines -->
+                <!-- prettier-ignore -->
+                <label><input type="checkbox" name="scope" checked />City Center/Business District</label>
+                <!-- prettier-ignore -->
+                <label><input type="checkbox" name="scope" checked />Transit Oriented</label>
+                <!-- prettier-ignore -->
+                <label><input type="checkbox" name="scope" checked />Main Street/Special</label>
+              </fieldset>
+            </form>
           </div>
 
           <div class="filter policy-change">
-            <fieldset>
-              <legend>Policy Change</legend>
-              <!-- prettier-ignore -->
-              <label><input type="checkbox" name="policy-change"  />Reduce Parking Minimums</label>
-              <!-- prettier-ignore -->
-              <label><input type="checkbox" name="policy-change" checked />Eliminate Parking Minimums</label>
-              <!-- prettier-ignore -->
-              <label><input type="checkbox" name="policy-change"  />Parking Maximums</label>
-            </fieldset>
+            <form>
+              <fieldset>
+                <legend>Policy Change</legend>
+                <!-- prettier-ignore -->
+                <label><input type="checkbox" name="policy-change"  />Reduce Parking Minimums</label>
+                <!-- prettier-ignore -->
+                <label><input type="checkbox" name="policy-change" checked />Eliminate Parking Minimums</label>
+                <!-- prettier-ignore -->
+                <label><input type="checkbox" name="policy-change"  />Parking Maximums</label>
+              </fieldset>
+            </form>
           </div>
 
           <div class="filter land-use">
-            <fieldset>
-              <legend>Affected Land Use</legend>
-              <!-- prettier-ignore -->
-              <label><input type="checkbox" name="land-use" checked />All Uses</label>
-              <label
-                ><input
-                  type="checkbox"
-                  name="land-use"
-                  checked
-                />Commercial</label
-              >
-              <label
-                ><input
-                  type="checkbox"
-                  name="land-use"
-                  checked
-                />Residential</label
-              >
-            </fieldset>
+            <form>
+              <fieldset>
+                <legend>Affected Land Use</legend>
+                <!-- prettier-ignore -->
+                <label><input type="checkbox" name="land-use" checked />All Uses</label>
+                <label
+                  ><input
+                    type="checkbox"
+                    name="land-use"
+                    checked
+                  />Commercial</label
+                >
+                <label
+                  ><input
+                    type="checkbox"
+                    name="land-use"
+                    checked
+                  />Residential</label
+                >
+              </fieldset>
+            </form>
           </div>
 
           <div class="filter implementation-stage">
-            <fieldset>
-              <legend>Implementation Stage</legend>
-              <label
-                ><input
-                  type="checkbox"
-                  name="implementation-stage"
-                  checked
-                />Implemented</label
-              >
-              <label
-                ><input
-                  type="checkbox"
-                  name="implementation-stage"
-                  checked
-                />Passed</label
-              >
-              <label
-                ><input
-                  type="checkbox"
-                  name="implementation-stage"
-                />Planned</label
-              >
-              <label
-                ><input
-                  type="checkbox"
-                  name="implementation-stage"
-                />Proposed</label
-              >
-              <label
-                ><input
-                  type="checkbox"
-                  name="implementation-stage"
-                />Repealed</label
-              >
-            </fieldset>
+            <form>
+              <fieldset>
+                <legend>Implementation Stage</legend>
+                <label
+                  ><input
+                    type="checkbox"
+                    name="implementation-stage"
+                    checked
+                  />Implemented</label
+                >
+                <label
+                  ><input
+                    type="checkbox"
+                    name="implementation-stage"
+                    checked
+                  />Passed</label
+                >
+                <label
+                  ><input
+                    type="checkbox"
+                    name="implementation-stage"
+                  />Planned</label
+                >
+                <label
+                  ><input
+                    type="checkbox"
+                    name="implementation-stage"
+                  />Proposed</label
+                >
+                <label
+                  ><input
+                    type="checkbox"
+                    name="implementation-stage"
+                  />Repealed</label
+                >
+              </fieldset>
+            </form>
           </div>
           <div>
             <span>Population</span>


### PR DESCRIPTION
Apparently, adding `<form>` element around `<fieldset>` solved the problem.
Tested using WebKit through Playwright. 

Closes https://github.com/ParkingReformNetwork/reform-map/issues/265

Old Render:
![image](https://github.com/ParkingReformNetwork/reform-map/assets/86996158/d12d058d-4c8d-4527-90f2-0538783fa20d)


New Render: 
![image](https://github.com/ParkingReformNetwork/reform-map/assets/86996158/f209b4a9-b2f9-4352-b0f6-586ca1f6a057)
