### PR TITLE
Fix filter for large cities & multiple reform types

### DIFF
--- a/src/js/filter.ts
+++ b/src/js/filter.ts
@@ -35,6 +35,9 @@ const shouldBeRendered = (
 
   // Else, search is not used and the filters should apply.
   const matchesSelected = (selector: string, entryKey: string): boolean => {
+    const cityValues: string[] = entry[entryKey]
+      .split(",")
+      .map((x: string) => x.trim());
     const selectedValues = new Set(
       Array.from(
         document.querySelectorAll(`input[type=checkbox][name=${selector}]`)
@@ -44,9 +47,7 @@ const shouldBeRendered = (
           option.parentElement.textContent.trim()
         )
     );
-    return entry[entryKey]
-      .split(",")
-      .some((value: string) => selectedValues.has(value));
+    return cityValues.some((val) => selectedValues.has(val));
   };
 
   const isScope = matchesSelected("scope", "report_magnitude");

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -50,6 +50,7 @@ const createPopulationSlider = (): PopulationSliders => {
 
   sliders.left.setAttribute("max", RANGE_MAX.toString());
   sliders.right.setAttribute("max", RANGE_MAX.toString());
+  sliders.right.setAttribute("value", RANGE_MAX.toString());
 
   const legend = document.querySelector(".population-slider-legend");
   POPULATION_INTERVALS.forEach(([intervalText]) => {

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -20,9 +20,9 @@ const TESTS: EdgeCase[] = [
   {
     desc: "policy change filter",
     policy: ["Parking Maximums"],
-    expectedRange: [125, 160],
+    expectedRange: [322, 375],
   },
-  { desc: "land use filter", land: ["Residential"], expectedRange: [15, 22] },
+  { desc: "land use filter", land: ["Residential"], expectedRange: [66, 90] },
   {
     desc: "implementation filter",
     implementation: ["Repealed"],


### PR DESCRIPTION
Fixes https://github.com/ParkingReformNetwork/reform-map/issues/302. 

There were two issues:

1. We weren't trimming the leading space from the CSV, so certain cities like San Francisco with two types of policy reforms weren't working properly.
2. We weren't setting the `value` for the population slider's right index until the first time opening up the filter box. So, big cities weren't being set on the initial load properly.