### PR TITLE
Go back to using personal access token

### DIFF
--- a/.github/workflows/update-data.yaml
+++ b/.github/workflows/update-data.yaml
@@ -32,6 +32,7 @@ jobs:
         if: steps.git_status.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
+          token: ${{ secrets.UPDATE_DATA_GITHUB_TOKEN }}
           commit-message: "Update data"
           title: "Update data"
           body: "This PR adds the latest data."


### PR DESCRIPTION
Reverts https://github.com/ParkingReformNetwork/reform-map/pull/347. Turns out we do indeed need to use a personal access token to trigger CI.