### PR TITLE
Fix font for attribution and atlas

### DIFF
--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -30,7 +30,7 @@ body {
 }
 
 body,
-.leaflet-container {
+div.leaflet-container {
   font-family: Poppins, Helvetica, Arial, sans-serif;
 }
 


### PR DESCRIPTION
It's why the attribution looked smaller on this map compared to PLM.