### PR TITLE
Improve style of header

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,24 +35,23 @@
   </head>
 
   <body>
-    <header>
-      <div class="header-top">
-        <span class="header-title">Parking Reform Map</span>
-        <div class="header-icons">
-          <div class="header-about-icon-container">
-            <i
-              class="fa-regular fa-circle-question fa-lg"
-              title="about the map"
-            ></i>
-          </div>
-          <a href="https://parkingreform.org/mandates-map" target="_blank">
-            <i
-              class="fa-solid fa-up-right-from-square fa-lg"
-              title="View fullscreen"
-            ></i>
-          </a>
+    <header class="top-header">
+      <h1 class="header-title">Parking Reform Map</h1>
+      <nav class="header-icons">
+        <div class="header-about-icon-container">
+          <i class="fa-regular fa-circle-question" title="about the map"></i>
         </div>
-      </div>
+        <a
+          class="header-full-screen-icon-container"
+          href="https://parkingreform.org/mandates-map"
+          target="_blank"
+        >
+          <i
+            class="fa-solid fa-up-right-from-square"
+            title="view fullscreen"
+          ></i>
+        </a>
+      </nav>
     </header>
 
     <div class="alert" id="no-requirements-alert">

--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -1,35 +1,57 @@
-@use "theme/colors-original";
+@use "theme/borders";
+@use "theme/breakpoints";
+@use "theme/colors";
+@use "theme/spacing";
+@use "theme/icons";
+@use "theme/typography";
 
-header {
-  padding: 0.5rem 1rem;
+$header-y-padding: 0px;
+$header-border-bottom-size: 4px;
+$header-height: calc(
+  spacing.$min-touch-target + ($header-y-padding * 2) +
+    $header-border-bottom-size
+);
 
-  font-size: 1rem;
-  background: colors-original.$gray-dark-medium;
-  color: colors-original.$white;
-
-  svg {
-    color: colors-original.$white;
-  }
-
-  @media only screen and (min-width: 48em) {
-    font-size: 1.5rem;
-  }
-}
-
-.header-top {
+.top-header {
+  width: 100%;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+
+  padding: $header-y-padding spacing.$element-gap;
+
+  background-color: colors.$gray;
+  border-bottom: $header-border-bottom-size solid colors.$teal;
+}
+
+.header-title {
+  font-weight: normal;
+  color: colors.$white;
+  margin: 0px;
+
+  font-size: typography.$font-size-md;
+  @include breakpoints.gt-xs {
+    font-size: typography.$font-size-lg;
+  }
 }
 
 .header-icons {
   display: flex;
-  align-items: center;
-
+  margin-left: auto;
   cursor: pointer;
-  font-size: 1rem;
+
+  .header-about-icon-container,
+  .header-full-screen-icon-container {
+    height: spacing.$min-touch-target;
+    width: spacing.$min-touch-target;
+
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+  }
 
   svg {
-    padding: 0 0.5rem;
+    color: colors.$white;
+    height: icons.$icon-size-md;
+    width: icons.$icon-size-md;
   }
 }

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -1,3 +1,4 @@
+@use "theme/links";
 @use "theme/resets";
 @use "theme/typography";
 


### PR DESCRIPTION
Aligns the style with PLM and fixes touch targets to be 44px x 44px.

We'll certainly keep revamping this header, such as removing the iframe icon on mobile & probably moving the filter icon & search into the header. But this is a good first step.

Before:
<img width="337" alt="Screenshot 2024-07-19 at 7 49 01 AM" src="https://github.com/user-attachments/assets/1e29fef8-944b-4e79-b2a9-2943636ebfaf">

After:
<img width="336" alt="Screenshot 2024-07-19 at 7 49 23 AM" src="https://github.com/user-attachments/assets/c777e7c0-44f8-4be1-a8c4-dfa29d99dbab">

(The gear icon moving was due to https://github.com/ParkingReformNetwork/reform-map/pull/397 - I'll fix in a follow up.)