### PR TITLE
Hide full-screen icon on mobile and non-iframes

### DIFF
--- a/src/css/_header.scss
+++ b/src/css/_header.scss
@@ -54,4 +54,16 @@ $header-height: calc(
     height: icons.$icon-size-md;
     width: icons.$icon-size-md;
   }
+
+  .header-full-screen-icon-container {
+    // We don't show the icon on small screens because it takes up
+    // too much screen real estate, and it's not very useful to see
+    // the map in full-screen vs iframe if you're on such a small screen.
+    //
+    // iframe.ts also disables the icon when the site is not in an iframe.
+    display: none;
+    @include breakpoints.gt-xxs {
+      display: inline-flex;
+    }
+  }
 }

--- a/src/js/iframe.ts
+++ b/src/js/iframe.ts
@@ -1,0 +1,25 @@
+/* global document, window */
+
+const isIFrame = (): boolean => {
+  try {
+    return window.self !== window.top;
+  } catch (e) {
+    return false;
+  }
+};
+
+/** If the site is not inside an iframe, disable the full-screen icon
+ * because it's redundant.
+ *
+ * Note that _header.scss also disables the icon on mobile.
+ */
+const maybeDisableFullScreenIcon = (): void => {
+  if (isIFrame()) return;
+  const iconContainer = document.querySelector(
+    ".header-full-screen-icon-container"
+  );
+  if (!(iconContainer instanceof HTMLAnchorElement)) return;
+  iconContainer.style.display = "none";
+};
+
+export default maybeDisableFullScreenIcon;

--- a/src/js/setUpSite.ts
+++ b/src/js/setUpSite.ts
@@ -5,6 +5,7 @@ import type { CityId, CityEntry } from "./types";
 import setUpIcons from "./fontAwesome";
 import addLegend from "./legend";
 import { createSearchElement, setUpSearch } from "./search";
+import maybeDisableFullScreenIcon from "./iframe";
 import setUpAbout from "./about";
 import setUpDetails from "./cityDetails";
 import { createPopulationSlider } from "./populationSlider";
@@ -88,8 +89,10 @@ const createCityMarkers = (
 
 const setUpSite = async (): Promise<void> => {
   setUpIcons();
+  maybeDisableFullScreenIcon();
   setUpAbout();
   setUpAlerts();
+
   const map = createMap();
   const markerGroup = new FeatureGroup();
   const sliders = createPopulationSlider();


### PR DESCRIPTION
We do this in PLM. If already not in an iframe, then there is no point to the icon to begin with. On mobile, it's not worth the screen real estate because the fullscreen view isn't much bigger.