### PR TITLE
Revamp the about popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <title>Parking Reform Map</title>
+    <title>Parking mandates map | Parking Reform Network</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
@@ -36,11 +36,13 @@
 
   <body>
     <header class="top-header">
-      <h1 class="header-title">Parking Reform Map</h1>
+      <h1 class="header-title">Parking Mandates Map</h1>
       <nav class="header-icons">
         <button
           class="header-icon-container header-about-icon-container"
           title="about the map"
+          aria-expanded="false"
+          aria-controls="about-popup"
         >
           <i class="fa-regular fa-circle-question" aria-hidden="true"></i>
           <span class="sr-only">toggle a popup describing the map</span>
@@ -57,55 +59,94 @@
       </nav>
     </header>
 
-    <div class="about-popup">
-      <div class="about-popup-close-icon-container">
-        <i
-          class="fa-regular fa-circle-xmark fa-lg"
+    <section
+      id="about-popup"
+      class="about-popup"
+      aria-label="about the map"
+      hidden
+    >
+      <header class="about-popup-header">
+        <h2>About the Parking Mandates Map</h2>
+        <button
+          class="about-popup-close-icon-container"
           title="close the about popup"
-        ></i>
+          aria-label="close the about popup"
+        >
+          <i class="fa-regular fa-circle-xmark" aria-hidden="true"></i>
+        </button>
+      </header>
+
+      <h3>Instructions</h3>
+      <p>
+        The map shows places that have enacted parking reforms. Click on one of
+        the red dots for additional information about that place's reforms.
+      </p>
+      <p>
+        Click the filter icon in the top-left to change which places are shown,
+        such as to filter by population size. By default, the map only shows
+        places with all parking requirements removed, which you can toggle with
+        the "No parking requirements" toggle in the filter options.
+      </p>
+
+      <div role="region" aria-labelledby="about-popup-links-heading">
+        <h3 id="about-popup-links-heading">Relevant links</h3>
+        <ul class="about-popup-links-list">
+          <li>
+            <a
+              class="external-link"
+              href="https://parkingreform.org/resources/mandates-map/"
+              >Methodology and key takeaways
+              <i aria-hidden="true" class="fa-solid fa-arrow-right"></i
+            ></a>
+          </li>
+          <li>
+            <a class="external-link" href="https://forms.gle/PaYXUP5J7YR1Zi6q6"
+              >Submit a report
+              <i aria-hidden="true" class="fa-solid fa-arrow-right"></i
+            ></a>
+          </li>
+          <li>
+            <a
+              class="external-link"
+              href="https://raw.githubusercontent.com/ParkingReformNetwork/mandates-map/main/map/trimmed_map_data.csv"
+              >Download the data set (CSV file)
+              <i aria-hidden="true" class="fa-solid fa-arrow-right"></i
+            ></a>
+          </li>
+          <li>
+            <a
+              class="external-link"
+              href="https://parkingreform.org/resources/parking-lot-map"
+              >PRN's Parking Lot Map
+              <i aria-hidden="true" class="fa-solid fa-arrow-right"></i
+            ></a>
+          </li>
+          <li>
+            <a class="external-link" href="https://parkingreform.org/support/"
+              >Support this project with a donation
+              <i aria-hidden="true" class="fa-solid fa-arrow-right"></i
+            ></a>
+          </li>
+        </ul>
       </div>
 
-      <h2>Map Information</h2>
-      <hr />
+      <h3>Acknowledgments</h3>
       <p>
-        Built and hosted by the
-        <a href="https://parkingreform.org" target="_blank"
-          >Parking Reform Network</a
-        >
-      </p>
-
-      <h3>Concept and Initial Report</h3>
-      <hr />
-      <p>
-        This project is based on "A Map of Cities That Got Rid of Parking
-        Minimums" initially published by
+        This project is built and hosted by the
+        <a href="https://parkingreform.org/support/">Parking Reform Network</a>.
+        It is based on "A Map of Cities That Got Rid of Parking Minimums",
+        initially published by
         <a href="https://strongtowns.org" target="_blank">StrongTowns</a> in
         November 2015. Reports have been submitted by many StrongTowns readers
-        over the years and reporters are, generally, credited on the city
-        detailed information pages.
+        and Parking Reform Network members over the years; reporters are
+        credited on the detailed information pages for each place.
       </p>
-
-      <ul>
-        <li>
-          <a href="https://parkingreform.org/mandates-map/acknowledgments.html"
-            >Acknowlegments</a
-          >
-        </li>
-        <li>
-          <a href="https://forms.gle/PaYXUP5J7YR1Zi6q6" target="_blank"
-            >Submit a report</a
-          >
-        </li>
-        <li>
-          <a href="https://parkingreform.org/mandates-map/faq.html">FAQ</a>
-        </li>
-      </ul>
-      <hr />
       <p>
-        <i class="fas fa-lightbulb"></i> Tip: Click the city name in the summary
-        box for a detailed report.
+        The source code is maintained at
+        <a href="https://github.com/ParkingReformNetwork/reform-map">GitHub</a>,
+        where you can see the code contributors under the "Insights" tab.
       </p>
-    </div>
+    </section>
 
     <div class="city-details-popup">
       <div class="city-details-popup-close-icon">

--- a/src/css/_about.scss
+++ b/src/css/_about.scss
@@ -1,31 +1,81 @@
-@use "theme/colors-original";
+@use "theme/borders";
+@use "theme/breakpoints";
+@use "theme/colors";
+@use "theme/icons";
+@use "theme/spacing";
+@use "theme/typography";
 @use "theme/zindex";
+
+@use "header";
 
 .about-popup {
   position: absolute;
+  left: spacing.$map-controls-margin-x;
+  right: spacing.$map-controls-margin-x;
+  margin-left: spacing.$map-controls-margin-x;
+  margin-right: spacing.$map-controls-margin-x;
+
+  @include breakpoints.gt-sm {
+    margin-left: 10%;
+  }
+
+  min-height: 50%;
+  max-height: 70%;
+  min-width: 200px;
+  max-width: 800px;
+  top: calc(header.$header-height + 25px);
   z-index: zindex.$about;
-  background-color: colors-original.$white;
-  border: 1px solid colors-original.$gray-neutral;
-  width: 80%;
-  height: 60%;
 
-  top: 50%;
-  left: 50%;
-  transform: translate(-50%, -50%);
+  background-color: colors.$white;
+  font-size: typography.$font-size-base;
+  padding: spacing.$container-edge-spacing;
 
-  overflow: auto;
-  display: none;
+  border: borders.$component-border;
+  border-radius: borders.$border-radius;
 
-  font-size: 1rem;
-  padding: 1rem;
+  overflow-y: auto;
+  overflow-wrap: break-word;
 
-  @media only screen and (min-width: 48em) {
-    height: auto;
+  h3 {
+    margin: 0;
+    font-size: typography.$font-size-lg;
+  }
+}
+
+.about-popup-header {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+
+  h2 {
+    flex: 1;
+    margin: 0;
+    margin-right: spacing.$element-gap;
+    line-height: 1.3;
+    font-size: typography.$font-size-xl;
+    font-weight: 500;
   }
 }
 
 .about-popup-close-icon-container {
-  position: absolute;
-  right: 1em;
   cursor: pointer;
+  height: spacing.$min-touch-target;
+  width: spacing.$min-touch-target;
+  margin-left: auto;
+
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+
+  svg {
+    height: icons.$icon-size-lg;
+    width: icons.$icon-size-lg;
+  }
+}
+
+.about-popup-links-list {
+  margin-top: spacing.$element-gap;
+  padding: 0;
+  padding-inline-start: 20px; // Default is 40px
 }

--- a/src/css/theme/_links.scss
+++ b/src/css/theme/_links.scss
@@ -1,3 +1,14 @@
+a {
+  color: #337ab7;
+  text-decoration: none;
+
+  &:hover,
+  &:focus {
+    color: #23527c;
+    text-decoration: underline;
+  }
+}
+
 .external-link {
   &:hover {
     // We disable underlining because the font awesome icon won't

--- a/src/css/theme/_resets.scss
+++ b/src/css/theme/_resets.scss
@@ -23,3 +23,13 @@ button {
   color: inherit;
   cursor: pointer;
 }
+
+p {
+  margin: 0 0 10px;
+}
+
+ul,
+ol {
+  margin-top: 0;
+  margin-bottom: 10px;
+}

--- a/src/js/about.ts
+++ b/src/js/about.ts
@@ -1,36 +1,50 @@
 /* global document, window */
+
 const setUpAbout = () => {
   const aboutPopup = document.querySelector(".about-popup");
   const aboutHeaderIcon = document.querySelector(
     ".header-about-icon-container"
   );
+  const closeIcon = document.querySelector(".about-popup-close-icon-container");
   if (
     !(aboutPopup instanceof HTMLElement) ||
-    !(aboutHeaderIcon instanceof HTMLElement)
+    !(aboutHeaderIcon instanceof HTMLElement) ||
+    !(closeIcon instanceof HTMLElement)
   )
     return;
 
+  const closePopup = () => {
+    aboutPopup.hidden = true;
+    aboutHeaderIcon.setAttribute("aria-expanded", "false");
+  };
+
+  const openPopup = () => {
+    aboutPopup.hidden = false;
+    aboutHeaderIcon.setAttribute("aria-expanded", "true");
+  };
+
   aboutHeaderIcon.addEventListener("click", () => {
-    aboutPopup.style.display =
-      aboutPopup.style.display !== "block" ? "block" : "none";
+    if (aboutPopup.hidden) {
+      openPopup();
+    } else {
+      closePopup();
+    }
   });
 
   // closes window on clicks outside the info popup
   window.addEventListener("click", (event) => {
     if (
-      aboutPopup.style.display === "block" &&
+      !aboutPopup.hidden &&
       event.target instanceof Element &&
       !aboutHeaderIcon.contains(event.target) &&
       !aboutPopup.contains(event.target)
     ) {
-      aboutPopup.style.display = "none";
+      closePopup();
     }
   });
 
-  const closeIcon = document.querySelector(".about-popup-close-icon-container");
-  if (!(closeIcon instanceof HTMLElement)) return;
   closeIcon.addEventListener("click", () => {
-    aboutPopup.style.display = "none";
+    closePopup();
   });
 };
 

--- a/tests/app/about.test.ts
+++ b/tests/app/about.test.ts
@@ -6,7 +6,7 @@ test("about popup can be opened and closed", async ({ page }) => {
   const aboutIcon = ".header-about-icon-container";
 
   const aboutIsVisible = async () =>
-    page.$eval(".about-popup", (el) => el.style.display === "block");
+    page.$eval(".about-popup", (el) => el instanceof HTMLElement && !el.hidden);
 
   // before click
   expect(await aboutIsVisible()).toBe(false);


### PR DESCRIPTION
Aligns style with PLM and revamps the content.

This also changes the title back to Parking Mandates Map for now. It was premature to have renamed it Reform without updating the URL and everything else. That was confusing.

<img width="800" alt="Screenshot 2024-07-21 at 4 56 44 PM" src="https://github.com/user-attachments/assets/c586f17f-8c7e-4c70-bab4-20908774b479">
<img width="796" alt="Screenshot 2024-07-21 at 4 57 23 PM" src="https://github.com/user-attachments/assets/2970b949-e247-42e6-b66a-915bd31b9b18">
