### PR TITLE
Make scorecard wider on mobile

### DIFF
--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -17,9 +17,9 @@
   overflow-y: auto;
 
   padding: spacing.$container-edge-spacing;
-  width: 260px;
+  width: 300px;
   @include breakpoints.gt-xxs {
-    width: 320px;
+    width: 340px;
   }
   @include breakpoints.gt-xs {
     width: 400px;


### PR DESCRIPTION
Request from Tony. We don't need to worry about covering the zoom buttons because the scorecard is not always present, i.e. it can be closed, unlike PLM.