### PR TITLE
Improve marker styling

### DIFF
--- a/src/js/map.ts
+++ b/src/js/map.ts
@@ -1,6 +1,10 @@
 import { Map, TileLayer } from "leaflet";
 import "leaflet/dist/leaflet.css";
 
+export const NO_MANDATES_MARKERS_PANE = "noMandatesMarkers";
+const MIN_ZOOM = 3;
+const MAX_ZOOM = 10;
+
 const BASE_LAYER = new TileLayer(
   "https://tiles.stadiamaps.com/tiles/stamen_toner_lite/{z}/{x}/{y}{r}.png",
   {
@@ -9,8 +13,8 @@ const BASE_LAYER = new TileLayer(
         &copy; <a href="https://www.stadiamaps.com/" target="_blank">Stadia Maps</a>
         &copy; <a href="https://www.stamen.com/" target="_blank">Stamen Design</a>`,
     subdomains: "abcd",
-    minZoom: 0,
-    maxZoom: 10,
+    minZoom: MIN_ZOOM,
+    maxZoom: MAX_ZOOM,
   },
 );
 
@@ -19,6 +23,7 @@ export default function createMap(): Map {
     layers: [BASE_LAYER],
     worldCopyJump: true,
   });
+
   // Set default view show all the US on mobile. While this is fairly zoomed out,
   // the main purpose of the map on initial load is to tell the narrative that parking
   // reform is popular, i.e. there are a lot of dots. Search, filter, and table view are
@@ -27,5 +32,10 @@ export default function createMap(): Map {
   map.attributionControl.setPrefix(
     '<a href="https://parkingreform.org/support/">Parking Reform Network</a>',
   );
+
+  // Workaround for no mandates markers appearing at the top of the map
+  // https://stackoverflow.com/a/49501320
+  map.createPane(NO_MANDATES_MARKERS_PANE);
+  map.getPane(NO_MANDATES_MARKERS_PANE).style.zIndex = "900";
   return map;
 }

--- a/src/js/mapMarkers.ts
+++ b/src/js/mapMarkers.ts
@@ -1,15 +1,37 @@
 import { CircleMarker, FeatureGroup, Map } from "leaflet";
 
+import { NO_MANDATES_MARKERS_PANE } from "./map";
 import { PlaceFilterManager } from "./FilterState";
 
-const MARKER_STYLE = {
-  radius: 7,
-  stroke: true,
-  weight: 0.9,
-  color: "#FFFFFF",
+const PRIMARY_MARKER_STYLE = {
+  weight: 1,
+  color: "white",
   fillColor: "#d7191c",
   fillOpacity: 1,
+  pane: NO_MANDATES_MARKERS_PANE,
 } as const;
+
+const SECONDARY_MARKER_STYLE = {
+  weight: 1,
+  color: "white",
+  fillColor: "#fdae61",
+  fillOpacity: 1,
+} as const;
+
+function radiusGivenZoom(options: {
+  zoom: number;
+  isPrimary: boolean;
+}): number {
+  const { zoom, isPrimary } = options;
+  // This formula comes from Claude to go from radius 5 to 21 between zoom 3 to 10
+  // with roughly linear growth.
+  //
+  // 21px radius => 42px diameter + 2px stroke == 4px. That meets the accessibility
+  // requirement of 44px touch target size, while balancing the dot not being too big
+  // on the screen when zoomed out.
+  const base = Math.round(2.37 * zoom - 2.29);
+  return isPrimary ? base + 2 : base;
+}
 
 export default function initPlaceMarkers(
   filterManager: PlaceFilterManager,
@@ -20,9 +42,15 @@ export default function initPlaceMarkers(
   const placesToMarkers: Record<string, CircleMarker> = Object.entries(
     filterManager.entries,
   ).reduce((acc, [placeId, entry]) => {
+    const isPrimary = entry.is_no_mandate_city === "1";
+    const style = isPrimary ? PRIMARY_MARKER_STYLE : SECONDARY_MARKER_STYLE;
+
     // @ts-ignore: passing strings to CircleMarker for lat/lng is valid, and
     // parsing to ints would lose precision.
-    const marker = new CircleMarker([entry.lat, entry.long], MARKER_STYLE);
+    const marker = new CircleMarker([entry.lat, entry.long], {
+      ...style,
+      radius: radiusGivenZoom({ zoom: map.getZoom(), isPrimary }),
+    });
     acc[placeId] = marker;
 
     marker.bindTooltip(placeId);
@@ -39,6 +67,17 @@ export default function initPlaceMarkers(
         // @ts-ignore the API allows passing a LayerGroup, but the type hint doesn't show this.
         marker.removeFrom(markerGroup);
       }
+    });
+  });
+
+  // Adjust marker size on zoom changes.
+  map.addEventListener("zoomend", () => {
+    const zoom = map.getZoom();
+    Object.entries(placesToMarkers).forEach(([placeId, marker]) => {
+      const isPrimary =
+        filterManager.entries[placeId].is_no_mandate_city === "1";
+      const newRadius = radiusGivenZoom({ zoom, isPrimary });
+      marker.setRadius(newRadius);
     });
   });
 


### PR DESCRIPTION
Improvements:

* Increases marker size when you zoom in
* Differentiates no-mandates places from other places
     * red vs orange
     * no-mandates guaranteed to be on top (z-index)
     * no-mandates have 2px larger radius
* turns off zoom past level 3 (default), since it is too big to be useful and it does not render Asia correctly until you zoom to the left

Orange was chosen to be accessible for color blindness; it contrasts well with the red on grayscale.

<img width="322" alt="Screenshot 2024-08-01 at 10 43 43 PM" src="https://github.com/user-attachments/assets/53cdefc5-ef0a-4502-b7c9-37a7de61dac6">

<img width="330" alt="Screenshot 2024-08-01 at 10 44 12 PM" src="https://github.com/user-attachments/assets/10d66064-fdc7-488c-8496-9473c91296da">
