### PR TITLE
Add toggle for table vs map view

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,23 @@
 
   <body>
     <header class="top-header">
+      <nav class="header-view-toggle" hidden>
+        <button
+          class="header-icon-container header-table-icon-container"
+          title="switch to table view"
+          aria-label="switch to table view from map view"
+        >
+          <i class="fa-solid fa-table" aria-hidden="true"></i>
+        </button>
+        <button
+          class="header-icon-container header-map-icon-container"
+          title="switch to map view"
+          aria-label="switch to map view from table view"
+          style="display: none"
+        >
+          <i class="fa-solid fa-earth-americas" aria-hidden="true"></i>
+        </button>
+      </nav>
       <nav class="header-control-icons">
         <button
           class="header-icon-container header-filter-icon-container"
@@ -344,6 +361,16 @@
       role="application"
       aria-label="interactive map showing places with parking reforms as clickable dots"
     ></div>
+
+    <div
+      id="table-view"
+      role="application"
+      aria-label="sortable table showing places selected by the filter and search controls"
+      hidden
+    >
+      Table view!
+    </div>
+
     <script type="module">
       import initApp from "./src/js/main";
 

--- a/src/css/_views.scss
+++ b/src/css/_views.scss
@@ -1,4 +1,5 @@
-#map {
+#map,
+#table-view {
   flex: 1;
   width: 100%;
 }

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -8,11 +8,11 @@
 @use "filter";
 @use "header";
 @use "logo";
-@use "map";
 @use "no-requirements-toggle";
 @use "population-slider";
 @use "scorecard";
 @use "search";
+@use "views";
 @use "zoom";
 
 @import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap");

--- a/src/js/fontAwesome.ts
+++ b/src/js/fontAwesome.ts
@@ -7,6 +7,8 @@ import {
   faUpRightFromSquare,
   faMagnifyingGlass,
   faSliders,
+  faTable,
+  faEarthAmericas,
   fas,
 } from "@fortawesome/free-solid-svg-icons";
 import "@fortawesome/fontawesome-svg-core/styles.css";
@@ -18,6 +20,8 @@ export default function initIcons(): void {
     faCircleXmark,
     faMagnifyingGlass,
     faSliders,
+    faTable,
+    faEarthAmericas,
     fas,
   );
   dom.watch();

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -11,6 +11,8 @@ import initFilterOptions from "./filterOptions";
 import initFilterPopup from "./filterPopup";
 import { PlaceFilterManager } from "./FilterState";
 import subscribeCounter from "./counter";
+import viewToggle from "./viewToggle";
+import initViewToggle from "./viewToggle";
 
 async function readData(): Promise<Record<PlaceId, PlaceEntry>> {
   // @ts-ignore
@@ -26,6 +28,7 @@ export default async function initApp(): Promise<void> {
   initIcons();
   maybeDisableFullScreenIcon();
   initAbout();
+  initViewToggle();
 
   const map = createMap();
   const data = await readData();

--- a/src/js/viewToggle.ts
+++ b/src/js/viewToggle.ts
@@ -1,0 +1,49 @@
+import Observable from "./Observable";
+
+type ViewState = "map" | "table";
+
+type ViewStateObservable = Observable<ViewState>;
+
+function updateUI(state: ViewState): void {
+  const tableIcon = document.querySelector<HTMLButtonElement>(
+    ".header-table-icon-container",
+  );
+  const mapIcon = document.querySelector<HTMLButtonElement>(
+    ".header-map-icon-container",
+  );
+  const tableView = document.querySelector<HTMLElement>("#table-view");
+  const mapView = document.querySelector<HTMLElement>("#map");
+  const mapCounter = document.querySelector<HTMLElement>("#counter");
+  if (state === "map") {
+    tableIcon.style.display = "inline-flex";
+    mapIcon.style.display = "none";
+    tableView.hidden = true;
+    mapView.hidden = false;
+    mapCounter.hidden = false;
+  } else {
+    tableIcon.style.display = "none";
+    mapIcon.style.display = "inline-flex";
+    tableView.hidden = false;
+    mapView.hidden = true;
+    mapCounter.hidden = true;
+  }
+}
+
+function updateOnIconClick(observable: ViewStateObservable): void {
+  const tableIcon = document.querySelector<HTMLButtonElement>(
+    ".header-table-icon-container",
+  );
+  tableIcon.addEventListener("click", () => observable.setValue("table"));
+
+  const mapIcon = document.querySelector<HTMLButtonElement>(
+    ".header-map-icon-container",
+  );
+  mapIcon.addEventListener("click", () => observable.setValue("map"));
+}
+
+export default function initViewToggle(): void {
+  const viewToggle = new Observable<ViewState>("map");
+  viewToggle.subscribe(updateUI);
+  updateOnIconClick(viewToggle);
+  viewToggle.initialize();
+}


### PR DESCRIPTION
We can now toggle between these two views:

<img width="328" alt="Screenshot 2024-08-02 at 9 46 33 PM" src="https://github.com/user-attachments/assets/3c9a7a73-0082-4786-8151-7f497397a654">
<img width="325" alt="Screenshot 2024-08-02 at 9 46 44 PM" src="https://github.com/user-attachments/assets/0e525b78-8e8c-49bd-ae53-614427d1139d">

The toggle is hidden so that users cannot yet access the control until we're ready. But this gets the first part of the change in-place.