### PR TITLE
Show all types of reforms by default

### DIFF
--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -35,7 +35,11 @@ export default async function initApp(): Promise<void> {
   const filterManager = new PlaceFilterManager(data, {
     searchInput: [],
     noRequirementsToggle: true,
-    policyChange: ["Eliminate Parking Minimums"],
+    policyChange: [
+      "Reduce Parking Minimums",
+      "Eliminate Parking Minimums",
+      "Parking Maximums",
+    ],
     scope: [
       "Regional",
       "Citywide",

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -36,7 +36,7 @@ const TESTS: EdgeCase[] = [
   {
     desc: "population slider",
     populationIntervals: [3, 6],
-    expectedRange: [750, 1400],
+    expectedRange: [480, 700],
   },
   {
     desc: "no requirements",

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -21,13 +21,13 @@ interface EdgeCase {
 const TESTS: EdgeCase[] = [
   { desc: "default filters", expectedRange: DEFAULT_PLACE_RANGE },
   { desc: "disabled filter", scope: [], expectedRange: [0, 0] },
-  { desc: "scope filter", scope: ["Regional"], expectedRange: [4, 15] },
+  { desc: "scope filter", scope: ["Regional"], expectedRange: [8, 20] },
   {
     desc: "policy change filter",
     policy: ["Parking Maximums"],
-    expectedRange: [420, 800],
+    expectedRange: [700, 1100],
   },
-  { desc: "land use filter", land: ["Residential"], expectedRange: [90, 250] },
+  { desc: "land use filter", land: ["Residential"], expectedRange: [320, 550] },
   {
     desc: "implementation filter",
     implementation: ["Repealed"],
@@ -36,21 +36,16 @@ const TESTS: EdgeCase[] = [
   {
     desc: "population slider",
     populationIntervals: [3, 6],
-    expectedRange: [295, 800],
+    expectedRange: [750, 1400],
   },
   {
     desc: "no requirements",
     noRequirements: true,
-    expectedRange: [65, 250],
+    expectedRange: [80, 250],
   },
   {
     desc: "all places",
     // The other filters already enable all options by default.
-    policy: [
-      "Reduce Parking Minimums",
-      "Eliminate Parking Minimums",
-      "Parking Maximums",
-    ],
     implementation: [
       "Implemented",
       "Passed",
@@ -58,7 +53,7 @@ const TESTS: EdgeCase[] = [
       "Proposed",
       "Repealed",
     ],
-    expectedRange: [2150, 4000],
+    expectedRange: [2900, 4000],
   },
 ];
 

--- a/tests/app/utils.ts
+++ b/tests/app/utils.ts
@@ -2,7 +2,7 @@ import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
 const PLACE_MARKER = "path.leaflet-interactive";
-const DEFAULT_PLACE_RANGE: [number, number] = [1600, 2600];
+const DEFAULT_PLACE_RANGE: [number, number] = [2930, 4000];
 
 const loadMap = async (page: Page): Promise<void> => {
   await page.goto("");


### PR DESCRIPTION
Closes https://github.com/ParkingReformNetwork/reform-map/issues/257. As described elsewhere, we have a more clear vision for the product's two user stories:

1. Casual user: be impressed by how many dots there are and want to add your place
2. Power user: research specifics, such as all reforms in 2023

The initial app should be oriented towards the casual user story, then you use the filter for power users. So, we should show all cities with passed reforms by default, including tiny places.