### PR TITLE
Set table height and add counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -368,7 +368,10 @@
       aria-label="sortable table showing places selected by the filter and search controls"
       hidden
     >
-      <div id="table"></div>
+      <section id="table-counter" class="table-counter" role="region"></section>
+      <div id="table-container">
+        <div id="table"></div>
+      </div>
     </div>
 
     <script type="module">

--- a/src/css/_counters.scss
+++ b/src/css/_counters.scss
@@ -6,9 +6,9 @@
 @use "theme/zindex";
 @use "header";
 
-$font-size: typography.$font-size-md;
-
 .map-counter {
+  $font-size: typography.$font-size-md;
+
   z-index: zindex.$map-counter;
   position: fixed;
   right: spacing.$map-controls-margin-x;
@@ -28,4 +28,10 @@ $font-size: typography.$font-size-md;
   color: colors.$black;
   border: borders.$component-border;
   border-radius: borders.$border-radius;
+}
+
+.table-counter {
+  $font-size: typography.$font-size-base;
+  padding: spacing.$element-gap spacing.$container-edge-spacing;
+  line-height: 1.3;
 }

--- a/src/css/_table.scss
+++ b/src/css/_table.scss
@@ -1,0 +1,28 @@
+@use "theme/colors";
+@use "theme/typography";
+
+#table-view {
+  // This is the default - it gets set to `flex` in viewToggle.ts
+  display: none;
+  flex-direction: column;
+}
+
+#table-counter {
+  flex-shrink: 0;
+}
+
+#table-container {
+  flex-grow: 1;
+  // This must be set to px or vh for Tabulator to correctly compute the table size.
+  // It doesn't seem to actually matter what we set here, so set it to 0px.
+  height: 0;
+}
+
+div.tabulator {
+  font-size: typography.$font-size-base;
+  max-height: 100%;
+  background-color: colors.$white;
+
+  border-left-width: 0px;
+  border-right-width: 0px;
+}

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -4,7 +4,7 @@
 
 @use "about";
 @use "attribution";
-@use "map-counter";
+@use "counters";
 @use "filter";
 @use "header";
 @use "logo";

--- a/src/js/counters.ts
+++ b/src/js/counters.ts
@@ -1,6 +1,6 @@
 import { PlaceFilterManager } from "./FilterState";
 
-export default function subscribeMapCounter(manager: PlaceFilterManager): void {
+export default function subscribeCounters(manager: PlaceFilterManager): void {
   manager.subscribe((state) => {
     let text: string;
     const numPlaces = manager.placeIds.size;
@@ -20,5 +20,6 @@ export default function subscribeMapCounter(manager: PlaceFilterManager): void {
     }
 
     document.getElementById("map-counter").innerText = text;
+    document.getElementById("table-counter").innerText = text;
   });
 }

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -10,7 +10,7 @@ import { initPopulationSlider, POPULATION_MAX_INDEX } from "./populationSlider";
 import initFilterOptions from "./filterOptions";
 import initFilterPopup from "./filterPopup";
 import { PlaceFilterManager } from "./FilterState";
-import subscribeMapCounter from "./mapCounter";
+import subscribeCounters from "./counters";
 import initViewToggle from "./viewToggle";
 import initTable from "./table";
 
@@ -53,7 +53,7 @@ export default async function initApp(): Promise<void> {
   });
 
   const markerGroup = initPlaceMarkers(filterManager, map);
-  subscribeMapCounter(filterManager);
+  subscribeCounters(filterManager);
   initScorecard(markerGroup, data);
   initSearch(filterManager);
   initFilterOptions(filterManager);

--- a/src/js/table.ts
+++ b/src/js/table.ts
@@ -6,16 +6,13 @@ import { PlaceFilterManager } from "./FilterState";
 export default function initTable(
   filterManager: PlaceFilterManager,
 ): Tabulator {
-  // TODO: counter
-  // TODO: styling, including y scrolling
+  // TODO: limit column width for state & country
   // TODO: figure out how to display details
-  // TODO: placeholder value
 
   // TODO: freeze columns? https://tabulator.info/docs/6.2/layout#frozen-column
   // TODO: allow resizing columns? https://tabulator.info/docs/6.2/modules#module-resizeColumns
   // TODO: moveable columns? https://tabulator.info/docs/6.2/modules#module-moveColumn
   // TODO: responsive layout https://tabulator.info/docs/6.2/modules#module-responsiveLayout
-  // TODO: downloads?
   Tabulator.registerModule([FilterModule, SortModule]);
 
   const data = Object.entries(filterManager.entries).map(

--- a/src/js/viewToggle.ts
+++ b/src/js/viewToggle.ts
@@ -15,18 +15,21 @@ function updateUI(table: Tabulator, state: ViewState): void {
   const tableView = document.querySelector<HTMLElement>("#table-view");
   const mapView = document.querySelector<HTMLElement>("#map");
   const mapCounter = document.querySelector<HTMLElement>("#map-counter");
+  const prnLogo = document.querySelector<HTMLElement>(".prn-logo");
   if (state === "map") {
     tableIcon.style.display = "inline-flex";
     mapIcon.style.display = "none";
-    tableView.hidden = true;
+    tableView.style.display = "none";
     mapView.hidden = false;
     mapCounter.hidden = false;
+    prnLogo.hidden = false;
   } else {
     tableIcon.style.display = "none";
     mapIcon.style.display = "inline-flex";
-    tableView.hidden = false;
+    tableView.style.display = "flex";
     mapView.hidden = true;
     mapCounter.hidden = true;
+    prnLogo.hidden = true;
     table.redraw();
   }
 }


### PR DESCRIPTION
<img width="337" alt="Screenshot 2024-08-03 at 5 32 06 PM" src="https://github.com/user-attachments/assets/7f646d11-52f4-416d-810b-7dca9cdc49d4">
<img width="337" alt="Screenshot 2024-08-03 at 5 32 20 PM" src="https://github.com/user-attachments/assets/254fe594-dade-468b-9e4a-ebb31d954338">
<img width="338" alt="Screenshot 2024-08-03 at 5 32 36 PM" src="https://github.com/user-attachments/assets/66019028-4465-4997-ab58-9e5ca7dcc8e6">

I at first tried setting the counter on the table itself as a footer element, but I couldn't get it to be sticky. I think it's a better UI to be at the top near the filter icon, anyways.