### PR TITLE
Set up remaining columns for table

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "choices.js": "^10.2.0",
         "leaflet": "^1.9.4",
         "lodash-es": "^4.17.21",
+        "luxon": "^3.3.0",
         "tabulator-tables": "^6.2.5"
       },
       "devDependencies": {
@@ -24,6 +25,7 @@
         "@types/jsdom": "^21.1.7",
         "@types/leaflet": "^1.9.4",
         "@types/lodash-es": "^4.17.12",
+        "@types/luxon": "^3.4.2",
         "@types/node-fetch": "^2.6.11",
         "@types/node-geocoder": "^4.2.6",
         "@types/papaparse": "^5.3.14",
@@ -36,7 +38,6 @@
         "handlebars": "^4.7.7",
         "http-server": "^14.1.1",
         "jsdom": "^24.1.1",
-        "luxon": "^3.3.0",
         "node-fetch": "^2.6.11",
         "node-geocoder": "^4.2.0",
         "papaparse": "^5.4.1",
@@ -13586,6 +13587,13 @@
         "@types/lodash": "*"
       }
     },
+    "node_modules/@types/luxon": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
+      "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "20.5.1",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.1.tgz",
@@ -16787,7 +16795,6 @@
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.0.tgz",
       "integrity": "sha512-7eDo4Pt7aGhoCheGFIuq4Xa2fJm4ZpmldpGhjTYBNUYNCN6TIEP6v7chwwwt3KRp7YR+rghbfvjyo3V5y9hgBw==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@types/jsdom": "^21.1.7",
     "@types/leaflet": "^1.9.4",
     "@types/lodash-es": "^4.17.12",
+    "@types/luxon": "^3.4.2",
     "@types/node-fetch": "^2.6.11",
     "@types/node-geocoder": "^4.2.6",
     "@types/papaparse": "^5.3.14",
@@ -38,7 +39,6 @@
     "handlebars": "^4.7.7",
     "http-server": "^14.1.1",
     "jsdom": "^24.1.1",
-    "luxon": "^3.3.0",
     "node-fetch": "^2.6.11",
     "node-geocoder": "^4.2.0",
     "papaparse": "^5.4.1",
@@ -61,6 +61,7 @@
     "choices.js": "^10.2.0",
     "leaflet": "^1.9.4",
     "lodash-es": "^4.17.21",
+    "luxon": "^3.3.0",
     "tabulator-tables": "^6.2.5"
   }
 }

--- a/src/js/table.ts
+++ b/src/js/table.ts
@@ -1,38 +1,111 @@
-import { Tabulator, FilterModule, SortModule } from "tabulator-tables";
+import {
+  Tabulator,
+  FilterModule,
+  FormatModule,
+  SortModule,
+  ResizeColumnsModule,
+  MoveColumnsModule,
+  ColumnDefinition,
+  FrozenColumnsModule,
+} from "tabulator-tables";
 import "tabulator-tables/dist/css/tabulator.min.css";
+import { DateTime } from "luxon";
 
 import { PlaceFilterManager } from "./FilterState";
+
+function compareDates(a: string, b: string): number {
+  const dateA = DateTime.fromFormat(a, "LLL d, yyyy");
+  const dateB = DateTime.fromFormat(b, "LLL d, yyyy");
+  if (!dateA.isValid) return 1;
+  if (!dateB.isValid) return -1;
+  return dateA.valueOf() - dateB.valueOf();
+}
 
 export default function initTable(
   filterManager: PlaceFilterManager,
 ): Tabulator {
-  // TODO: limit column width for state & country
-  // TODO: figure out how to display details
-
-  // TODO: freeze columns? https://tabulator.info/docs/6.2/layout#frozen-column
-  // TODO: allow resizing columns? https://tabulator.info/docs/6.2/modules#module-resizeColumns
-  // TODO: moveable columns? https://tabulator.info/docs/6.2/modules#module-moveColumn
-  // TODO: responsive layout https://tabulator.info/docs/6.2/modules#module-responsiveLayout
-  Tabulator.registerModule([FilterModule, SortModule]);
+  Tabulator.registerModule([
+    FilterModule,
+    FormatModule,
+    FrozenColumnsModule,
+    SortModule,
+    ResizeColumnsModule,
+    MoveColumnsModule,
+  ]);
 
   const data = Object.entries(filterManager.entries).map(
     ([placeId, entry]) => ({
       id: placeId,
-      city: entry.city,
+      place: entry.city,
       state: entry.state,
       country: entry.country,
+      population: parseInt(entry.population).toLocaleString("en-us"),
+      date: entry.date_of_reform,
+      citationUrl: entry.citation_url,
+      status: entry.report_status,
+      landUse: entry.land_uses,
+      policyChange: entry.report_type,
+      scope: entry.report_magnitude,
     }),
   );
-  const columns = [
-    { title: "City", field: "city" },
-    { title: "State", field: "state" },
-    { title: "Country", field: "country" },
+  const columns: ColumnDefinition[] = [
+    {
+      title: "Place",
+      field: "place",
+      width: 180,
+      frozen: true,
+      formatter: "link",
+      formatterParams: {
+        urlField: "citationUrl",
+        labelField: "place",
+        target: "_blank",
+      },
+    },
+    { title: "State", field: "state", width: 70 },
+    { title: "Country", field: "country", width: 70 },
+    {
+      title: "Population",
+      field: "population",
+      sorter: "number",
+      sorterParams: {
+        // @ts-ignore
+        thousandSeparator: ",",
+      },
+      width: 90,
+    },
+    {
+      title: "Date",
+      field: "date",
+      width: 110,
+      sorter: compareDates,
+    },
+    {
+      title: "Policy change",
+      field: "policyChange",
+      width: 260,
+    },
+    {
+      title: "Scope",
+      field: "scope",
+      width: 260,
+    },
+    {
+      title: "Land use",
+      field: "landUse",
+      width: 160,
+    },
+    {
+      title: "Status",
+      field: "status",
+      width: 120,
+    },
   ];
 
   const table = new Tabulator("#table", {
     data,
     columns,
     layout: "fitColumns",
+    movableColumns: true,
   });
 
   let tableBuilt = false;


### PR DESCRIPTION
Some decisions:

* Don't show the description. It would make it impossible to fit everything in one line, which gets in the way of scanning the table
* Call it "Place" rather than "City" to account for states/countries/counties. This will need to be improved throughout the data model in general, but this is a good first step. Note that the Place is always defined in our dataset currently.
* Freeze the Place column because this is useful on mobile
* Don't hide any rows on mobile - it may still be useful to see them
* Let the users resize and rearrange columns
* Use fixed width, and don't show the entire row by default. The edge cases make the table too sparse otherwise if we want to fit everything. Users can either resize the column or go to the details page

<img width="1374" alt="Screenshot 2024-08-03 at 7 56 34 PM" src="https://github.com/user-attachments/assets/14fe5ce5-8bd3-4e47-85e8-6c190253d380">

<img width="376" alt="Screenshot 2024-08-03 at 7 56 48 PM" src="https://github.com/user-attachments/assets/ea8cdeb3-dca2-405d-ac86-3959c8ce35a8">

The app is too slow when there are lots of rows. It was slow before, and this PR makes it even worse where it hangs. This needs to be fixed before the table view goes live.