### PR TITLE
Use pagination to fix performance

### DIFF
--- a/src/css/_table.scss
+++ b/src/css/_table.scss
@@ -26,3 +26,7 @@ div.tabulator {
   border-left-width: 0px;
   border-right-width: 0px;
 }
+
+.tabulator-paginator button {
+  font-weight: normal;
+}

--- a/src/js/table.ts
+++ b/src/js/table.ts
@@ -7,6 +7,7 @@ import {
   MoveColumnsModule,
   ColumnDefinition,
   FrozenColumnsModule,
+  PageModule,
 } from "tabulator-tables";
 import "tabulator-tables/dist/css/tabulator.min.css";
 import { DateTime } from "luxon";
@@ -31,6 +32,7 @@ export default function initTable(
     SortModule,
     ResizeColumnsModule,
     MoveColumnsModule,
+    PageModule,
   ]);
 
   const data = Object.entries(filterManager.entries).map(
@@ -106,6 +108,16 @@ export default function initTable(
     columns,
     layout: "fitColumns",
     movableColumns: true,
+    // We use pagination to avoid performance issues.
+    pagination: true,
+    paginationSize: 100,
+    paginationCounter: (
+      _pageSize,
+      _currentRow,
+      currentPage,
+      _totalRows,
+      totalPages,
+    ) => `Page ${currentPage} of ${totalPages}`,
   });
 
   let tableBuilt = false;


### PR DESCRIPTION
Without this, loading all the places (no filter) takes several seconds and hangs the overall app.

Pagination is neat in that sorting will still sort through the entire dataset, not ony the current page. We also still have vertical scrolling for the page if it can't all fit. It's great!

<img width="376" alt="Screenshot 2024-08-03 at 8 42 51 PM" src="https://github.com/user-attachments/assets/fab162e6-8b98-4cf9-8145-9a1263e7cf99">
