### PR TITLE
Move population above policy reform type

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,17 +230,6 @@
         </label>
       </div>
 
-      <fieldset class="filter filter-policy-change">
-        <legend>Policy Change</legend>
-        <!-- prettier-ignore -->
-        <label><input type="checkbox" name="policy-change" />Reduce Parking Minimums</label>
-        <!-- prettier-ignore -->
-        <label><input type="checkbox" name="policy-change" />Eliminate Parking Minimums</label>
-        <label
-          ><input type="checkbox" name="policy-change" />Parking Maximums</label
-        >
-      </fieldset>
-
       <div>
         <span>Population</span>
         <div class="population-slider-container">
@@ -269,6 +258,17 @@
           <div class="population-slider-legend"></div>
         </div>
       </div>
+
+      <fieldset class="filter filter-policy-change">
+        <legend>Policy Change</legend>
+        <!-- prettier-ignore -->
+        <label><input type="checkbox" name="policy-change" />Reduce Parking Minimums</label>
+        <!-- prettier-ignore -->
+        <label><input type="checkbox" name="policy-change" />Eliminate Parking Minimums</label>
+        <label
+          ><input type="checkbox" name="policy-change" />Parking Maximums</label
+        >
+      </fieldset>
 
       <fieldset class="filter filter-scope">
         <legend>Scope of Reform</legend>


### PR DESCRIPTION
Now that we select all the reform types by default, it's less important that we show it right away. 

The benefit of this change is that all checkboxes now appear together, which makes more sense visually. It's also prework for the filter redesign, where I'm proposing putting the checkboxes behind expandable accordions.