### PR TITLE
Inline population label

### DIFF
--- a/index.html
+++ b/index.html
@@ -230,33 +230,28 @@
         </label>
       </div>
 
-      <div>
-        <span>Population</span>
-        <div class="population-slider-container">
-          <div class="population-slider-label">
-            <span class="population-slider-label-min"></span>
-            <span> - </span>
-            <span class="population-slider-label-max"></span>
-          </div>
-          <div class="population-slider-controls">
-            <input
-              class="population-slider-left"
-              name="min"
-              type="range"
-              step="0.5"
-              min="0"
-              value="0"
-            />
-            <input
-              class="population-slider-right"
-              name="max"
-              type="range"
-              step="0.5"
-              min="0"
-            />
-          </div>
-          <div class="population-slider-legend"></div>
+      <div class="population-slider-container">
+        <div id="population-slider-label"></div>
+        <div class="population-slider-controls">
+          <input
+            aria-labelledby="population-slider-label"
+            class="population-slider-left"
+            name="min"
+            type="range"
+            step="0.5"
+            min="0"
+            value="0"
+          />
+          <input
+            aria-labelledby="population-slider-label"
+            class="population-slider-right"
+            name="max"
+            type="range"
+            step="0.5"
+            min="0"
+          />
         </div>
+        <div class="population-slider-legend"></div>
       </div>
 
       <fieldset class="filter filter-policy-change">

--- a/src/css/_filter.scss
+++ b/src/css/_filter.scss
@@ -10,6 +10,7 @@
   right: spacing.$map-controls-margin-x;
   top: calc(header.$header-height + spacing.$map-controls-margin-top);
   z-index: zindex.$filter-popup;
+  width: 310px;
 
   max-height: min(600px, 75vh);
   overflow-y: auto;
@@ -20,7 +21,7 @@
 }
 
 .filter-popup > * {
-  margin: 0.5em 1em;
+  margin: 0.5em;
 }
 
 .filter {

--- a/src/css/_no-requirements-toggle.scss
+++ b/src/css/_no-requirements-toggle.scss
@@ -4,7 +4,6 @@ $toggle-size: 0.4em;
 $toggle-circle: calc(2.4 * $toggle-size);
 
 .filter-no-requirements-container {
-  border: solid colors-original.$gray-light 1px;
   padding: 0.2em;
 }
 

--- a/src/css/_population-slider.scss
+++ b/src/css/_population-slider.scss
@@ -1,4 +1,5 @@
 @use "theme/colors-original";
+@use "theme/typography";
 
 // uncomment to visualize slider mechanism
 // input {
@@ -20,12 +21,6 @@
   align-items: center;
 }
 
-.population-slider-label {
-  height: 1.7em;
-  font-weight: bold;
-  display: inline-block;
-}
-
 .population-slider-legend {
   display: flex;
   justify-content: space-between;
@@ -33,7 +28,7 @@
   padding: 0;
 
   span {
-    font-size: 0.5em;
+    font-size: 10px;
     opacity: 1;
     flex: 1;
     text-align: left;

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -50,11 +50,10 @@ export function updateSlidersUI(state: FilterState): void {
   // everytime the range of the slider changes.
   sliders.right.style.left = `${leftWidth + THUMBSIZE}px`;
 
-  const updateLabel = (cls: string, index: number): void => {
-    document.querySelector(cls).innerHTML = POPULATION_INTERVALS[index][0];
-  };
-  updateLabel(".population-slider-label-min", leftIndex);
-  updateLabel(".population-slider-label-max", rightIndex);
+  const leftLabel = POPULATION_INTERVALS[leftIndex][0];
+  const rightLabel = POPULATION_INTERVALS[rightIndex][0];
+  document.querySelector("#population-slider-label").innerHTML =
+    `${leftLabel} - ${rightLabel} residents`;
 }
 
 export function initPopulationSlider(filterManager: PlaceFilterManager): void {


### PR DESCRIPTION
This makes the element blend in better with the rest of the UI and take less space. It follows Refactoring UI's advice "labels are a last resort". 

We no longer bold to better fit with the information hierarchy.

This PR also sets a fixed width for the filter popup to ensure it always fits on mobile. It increase the legend font from 9px to 10px; we need to remove intervals to get any bigger than that.

Before:

<img width="327" alt="Screenshot 2024-08-10 at 2 32 43 PM" src="https://github.com/user-attachments/assets/d11c08b0-72e2-47e1-b6b0-df05773cb030">

After:
<img width="308" alt="Screenshot 2024-08-10 at 2 31 52 PM" src="https://github.com/user-attachments/assets/6bc50294-6183-461b-8d02-b0f512469b3b">
