### PR TITLE
Remove 5 million population interval

### DIFF
--- a/src/css/_population-slider.scss
+++ b/src/css/_population-slider.scss
@@ -28,7 +28,7 @@
   padding: 0;
 
   span {
-    font-size: 10px;
+    font-size: typography.$font-size-xs;
     opacity: 1;
     flex: 1;
     text-align: left;

--- a/src/js/FilterState.ts
+++ b/src/js/FilterState.ts
@@ -10,7 +10,6 @@ export const POPULATION_INTERVALS: Array<[string, number]> = [
   ["100k", 100000],
   ["500k", 500000],
   ["1M", 1000000],
-  ["5M", 5000000],
   ["50M", 50000000],
 ];
 


### PR DESCRIPTION
This allows us to increase the legend font size from 10px to 12px. Tony and I agreed to remove 5M because there are not many entries between 1M-5M and 5M-50M, and they are all the same category of place: huge cities or states/countries.

We might want to remove future intervals, but not yet.

<img width="311" alt="Screenshot 2024-08-10 at 2 40 52 PM" src="https://github.com/user-attachments/assets/7728b88e-7389-4085-b03f-385bb35894c0">
