### PR TITLE
Fix bug with population slider having bad size

### DIFF
--- a/src/js/filterPopup.ts
+++ b/src/js/filterPopup.ts
@@ -14,13 +14,13 @@ export default function initFilterPopup(filterManager: PlaceFilterManager) {
   const isVisible = new Observable<boolean>(false);
   isVisible.subscribe(updateFilterPopupUI);
 
-  // We redraw the population slider on the first load because it requires the popup
-  // to be displayed to compute offsetWidth.
-  let hasInitedPopulation = false;
+  // We redraw the population slider every time the filter popup opens up
+  // because it requires the popup to be displayed to compute offsetWidth.
+  // Otherwise, it can become borked when the FilterState changes and the filter
+  // popup is not open.
   isVisible.subscribe((visible) => {
-    if (!hasInitedPopulation && visible) {
+    if (visible) {
       updateSlidersUI(filterManager.getState());
-      hasInitedPopulation = true;
     }
   });
 

--- a/src/js/filterPopup.ts
+++ b/src/js/filterPopup.ts
@@ -1,6 +1,7 @@
-import { updateSlidersUI } from "./populationSlider";
 import Observable from "./Observable";
 import { PlaceFilterManager } from "./FilterState";
+
+export type FilterPopupVisibleObservable = Observable<boolean>;
 
 function updateFilterPopupUI(isVisible: boolean): void {
   const popup = document.querySelector<HTMLElement>(".filter-popup");
@@ -10,19 +11,9 @@ function updateFilterPopupUI(isVisible: boolean): void {
   icon.ariaExpanded = isVisible.toString();
 }
 
-export default function initFilterPopup(filterManager: PlaceFilterManager) {
+export default function initFilterPopup(): FilterPopupVisibleObservable {
   const isVisible = new Observable<boolean>(false);
   isVisible.subscribe(updateFilterPopupUI);
-
-  // We redraw the population slider every time the filter popup opens up
-  // because it requires the popup to be displayed to compute offsetWidth.
-  // Otherwise, it can become borked when the FilterState changes and the filter
-  // popup is not open.
-  isVisible.subscribe((visible) => {
-    if (visible) {
-      updateSlidersUI(filterManager.getState());
-    }
-  });
 
   const popup = document.querySelector(".filter-popup");
   const icon = document.querySelector(".header-filter-icon-container");
@@ -43,5 +34,5 @@ export default function initFilterPopup(filterManager: PlaceFilterManager) {
     }
   });
 
-  isVisible.initialize();
+  return isVisible;
 }

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -29,6 +29,7 @@ export default async function initApp(): Promise<void> {
   initIcons();
   maybeDisableFullScreenIcon();
   initAbout();
+  const filterPopupIsVisible = initFilterPopup();
 
   const map = createMap();
   const data = await readData();
@@ -58,13 +59,14 @@ export default async function initApp(): Promise<void> {
   initCounters(filterManager);
   initSearch(filterManager);
   initFilterOptions(filterManager);
-  initPopulationSlider(filterManager);
-  initFilterPopup(filterManager);
+  initPopulationSlider(filterManager, filterPopupIsVisible);
 
   const table = initTable(filterManager);
   const viewToggle = initViewToggle(table);
 
   initScorecard(filterManager, viewToggle, markerGroup, data);
 
+  viewToggle.initialize();
+  filterPopupIsVisible.initialize();
   filterManager.initialize();
 }

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -1,3 +1,4 @@
+import { FilterPopupVisibleObservable } from "./filterPopup";
 import {
   FilterState,
   PlaceFilterManager,
@@ -21,7 +22,7 @@ function getSliders(): Sliders {
   };
 }
 
-export function updateSlidersUI(state: FilterState): void {
+function updateSlidersUI(state: FilterState): void {
   const [leftIndex, rightIndex] = state.populationSliderIndexes;
   const sliders = getSliders();
 
@@ -56,8 +57,10 @@ export function updateSlidersUI(state: FilterState): void {
     `${leftLabel} - ${rightLabel} residents`;
 }
 
-export function initPopulationSlider(filterManager: PlaceFilterManager): void {
-  filterManager.subscribe(updateSlidersUI);
+export function initPopulationSlider(
+  filterManager: PlaceFilterManager,
+  filterPopupIsVisible: FilterPopupVisibleObservable,
+): void {
   const sliders = getSliders();
 
   // Create legend
@@ -76,6 +79,7 @@ export function initPopulationSlider(filterManager: PlaceFilterManager): void {
   sliders.right.setAttribute("max", maxIndex);
   sliders.right.setAttribute("value", maxIndex);
 
+  // Add event listeners.
   const onChange = (): void => {
     const leftIndex = Math.floor(parseFloat(sliders.left.value));
     const rightIndex = Math.ceil(parseFloat(sliders.right.value));
@@ -83,4 +87,12 @@ export function initPopulationSlider(filterManager: PlaceFilterManager): void {
   };
   sliders.left.addEventListener("input", onChange);
   sliders.right.addEventListener("input", onChange);
+
+  // Update UI whenever filter popup is visible. Note that
+  // the popup must be visible for the width calculations to work.
+  filterPopupIsVisible.subscribe((isVisible) => {
+    if (isVisible) {
+      updateSlidersUI(filterManager.getState());
+    }
+  });
 }


### PR DESCRIPTION
Before, you could get into a weird state with the population slider where it didn't have proper width. That's because the slider requires the popup is open to calculate widths. So, the slider needs to be redrawn every time the filter popup is opened up, since the values might have changed since the last time the popup was one.