### PR TITLE
Generate filter checkbox options

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,55 +254,7 @@
         <div class="population-slider-legend"></div>
       </div>
 
-      <fieldset class="filter filter-policy-change">
-        <legend>Policy Change</legend>
-        <!-- prettier-ignore -->
-        <label><input type="checkbox" name="policy-change" />Reduce Parking Minimums</label>
-        <!-- prettier-ignore -->
-        <label><input type="checkbox" name="policy-change" />Eliminate Parking Minimums</label>
-        <label
-          ><input type="checkbox" name="policy-change" />Parking Maximums</label
-        >
-      </fieldset>
-
-      <fieldset class="filter filter-scope">
-        <legend>Scope of Reform</legend>
-        <label><input type="checkbox" name="scope" />Regional</label>
-        <label><input type="checkbox" name="scope" />Citywide</label>
-        <!-- prettier-ignore -->
-        <label><input type="checkbox" name="scope" />City Center/Business District</label>
-        <label><input type="checkbox" name="scope" />Transit Oriented</label>
-        <label><input type="checkbox" name="scope" />Main Street/Special</label>
-      </fieldset>
-
-      <fieldset class="filter filter-land-use">
-        <legend>Affected Land Use</legend>
-        <label><input type="checkbox" name="land-use" />All Uses</label>
-        <label><input type="checkbox" name="land-use" />Commercial</label>
-        <label><input type="checkbox" name="land-use" />Residential</label>
-      </fieldset>
-
-      <fieldset class="filter filter-stage">
-        <legend>Implementation Stage</legend>
-        <label
-          ><input
-            type="checkbox"
-            name="implementation-stage"
-          />Implemented</label
-        >
-        <label
-          ><input type="checkbox" name="implementation-stage" />Passed</label
-        >
-        <label
-          ><input type="checkbox" name="implementation-stage" />Planned</label
-        >
-        <label
-          ><input type="checkbox" name="implementation-stage" />Proposed</label
-        >
-        <label
-          ><input type="checkbox" name="implementation-stage" />Repealed</label
-        >
-      </fieldset>
+      <div id="filter-accordion-options"></div>
     </form>
 
     <div id="search-popup" class="search-popup" hidden>

--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -1,11 +1,46 @@
 import { PlaceFilterManager } from "./FilterState";
 
+function generateAccordionOptions(
+  name: string,
+  legend: string,
+  options: string[],
+): HTMLFieldSetElement {
+  const fieldset = document.createElement("fieldset");
+  fieldset.className = `filter filter-${name}`;
+
+  const legendElement = document.createElement("legend");
+  legendElement.textContent = legend;
+  fieldset.appendChild(legendElement);
+
+  options.forEach((val) => {
+    const label = document.createElement("label");
+
+    const input = document.createElement("input");
+    input.type = "checkbox";
+    input.name = name;
+
+    label.appendChild(input);
+    label.appendChild(document.createTextNode(val));
+
+    fieldset.appendChild(label);
+  });
+
+  return fieldset;
+}
+
 function initFilterGroup(
   filterManager: PlaceFilterManager,
-  filterClass: string,
+  htmlName: string,
   filterStateKey: string,
+  legend: string,
+  filterOptions: string[],
 ): void {
-  const container = document.querySelector(`.${filterClass}`);
+  const outerContainer = document.getElementById("filter-accordion-options");
+  outerContainer.appendChild(
+    generateAccordionOptions(htmlName, legend, filterOptions),
+  );
+
+  const container = document.querySelector(`.filter-${htmlName}`);
 
   // Set initial state.
   const initialState = filterManager.getState()[filterStateKey] as string[];
@@ -27,10 +62,36 @@ function initFilterGroup(
 export default function initFilterOptions(
   filterManager: PlaceFilterManager,
 ): void {
-  initFilterGroup(filterManager, "filter-scope", "scope");
-  initFilterGroup(filterManager, "filter-land-use", "landUse");
-  initFilterGroup(filterManager, "filter-policy-change", "policyChange");
-  initFilterGroup(filterManager, "filter-stage", "implementationStage");
+  initFilterGroup(
+    filterManager,
+    "policy-change",
+    "policyChange",
+    "Policy change",
+    [
+      "Reduce Parking Minimums",
+      "Eliminate Parking Minimums",
+      "Parking Maximums",
+    ],
+  );
+  initFilterGroup(filterManager, "scope", "scope", "Reform scope", [
+    "Regional",
+    "Citywide",
+    "City Center/Business District",
+    "Transit Oriented",
+    "Main Street/Special",
+  ]);
+  initFilterGroup(filterManager, "land-use", "landUse", "Affected land use", [
+    "All Uses",
+    "Commercial",
+    "Residential",
+  ]);
+  initFilterGroup(
+    filterManager,
+    "stage",
+    "implementationStage",
+    "Implementation stage",
+    ["Implemented", "Passed", "Planned", "Proposed", "Repealed"],
+  );
 
   const noRequirementsToggle = document.querySelector<HTMLInputElement>(
     "#no-requirements-toggle",

--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -99,7 +99,7 @@ export function initFilterOptions(filterManager: PlaceFilterManager): void {
   initFilterGroup(filterManager, "land-use", "landUse", "Affected land use");
   initFilterGroup(
     filterManager,
-    "stage",
+    "implementation-stage",
     "implementationStage",
     "Implementation stage",
   );

--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -1,5 +1,47 @@
 import { PlaceFilterManager } from "./FilterState";
 
+// The boolean next to each option is for whether it's selected by default.
+const FILTER_CONFIG = {
+  policyChange: [
+    ["Reduce Parking Minimums", true],
+    ["Eliminate Parking Minimums", true],
+    ["Parking Maximums", true],
+  ],
+  scope: [
+    ["Regional", true],
+    ["Citywide", true],
+    ["City Center/Business District", true],
+    ["Transit Oriented", true],
+    ["Main Street/Special", true],
+  ],
+  landUse: [
+    ["All Uses", true],
+    ["Commercial", true],
+    ["Residential", true],
+  ],
+  implementationStage: [
+    ["Implemented", true],
+    ["Passed", true],
+    ["Planned", false],
+    ["Proposed", false],
+    ["Repealed", false],
+  ],
+} as const;
+
+type FilterGroupKey = keyof typeof FILTER_CONFIG;
+
+export const FilterOptions = {
+  getAllOptions(fieldset: FilterGroupKey): string[] {
+    return FILTER_CONFIG[fieldset].map((option) => option[0]);
+  },
+
+  getDefaultSelected(fieldset: FilterGroupKey): string[] {
+    return FILTER_CONFIG[fieldset]
+      .filter(([, isDefaultSelected]) => isDefaultSelected)
+      .map(([name]) => name);
+  },
+};
+
 function generateAccordionOptions(
   name: string,
   legend: string,
@@ -31,13 +73,13 @@ function generateAccordionOptions(
 function initFilterGroup(
   filterManager: PlaceFilterManager,
   htmlName: string,
-  filterStateKey: string,
+  filterStateKey: FilterGroupKey,
   legend: string,
-  filterOptions: string[],
 ): void {
   const outerContainer = document.getElementById("filter-accordion-options");
+  const options = FilterOptions.getAllOptions(filterStateKey);
   outerContainer.appendChild(
-    generateAccordionOptions(htmlName, legend, filterOptions),
+    generateAccordionOptions(htmlName, legend, options),
   );
 
   const container = document.querySelector(`.filter-${htmlName}`);
@@ -59,38 +101,20 @@ function initFilterGroup(
   });
 }
 
-export default function initFilterOptions(
-  filterManager: PlaceFilterManager,
-): void {
+export function initFilterOptions(filterManager: PlaceFilterManager): void {
   initFilterGroup(
     filterManager,
     "policy-change",
     "policyChange",
     "Policy change",
-    [
-      "Reduce Parking Minimums",
-      "Eliminate Parking Minimums",
-      "Parking Maximums",
-    ],
   );
-  initFilterGroup(filterManager, "scope", "scope", "Reform scope", [
-    "Regional",
-    "Citywide",
-    "City Center/Business District",
-    "Transit Oriented",
-    "Main Street/Special",
-  ]);
-  initFilterGroup(filterManager, "land-use", "landUse", "Affected land use", [
-    "All Uses",
-    "Commercial",
-    "Residential",
-  ]);
+  initFilterGroup(filterManager, "scope", "scope", "Reform scope");
+  initFilterGroup(filterManager, "land-use", "landUse", "Affected land use");
   initFilterGroup(
     filterManager,
     "stage",
     "implementationStage",
     "Implementation stage",
-    ["Implemented", "Passed", "Planned", "Proposed", "Repealed"],
   );
 
   const noRequirementsToggle = document.querySelector<HTMLInputElement>(

--- a/src/js/filterPopup.ts
+++ b/src/js/filterPopup.ts
@@ -1,5 +1,4 @@
 import Observable from "./Observable";
-import { PlaceFilterManager } from "./FilterState";
 
 export type FilterPopupVisibleObservable = Observable<boolean>;
 

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -7,7 +7,7 @@ import maybeDisableFullScreenIcon from "./iframe";
 import initAbout from "./about";
 import initScorecard from "./scorecard";
 import { initPopulationSlider, POPULATION_MAX_INDEX } from "./populationSlider";
-import { FilterOptions, initFilterOptions } from "./filterOptions";
+import { getDefaultFilterOptions, initFilterOptions } from "./filterOptions";
 import initFilterPopup from "./filterPopup";
 import { PlaceFilterManager } from "./FilterState";
 import initCounters from "./counters";
@@ -37,12 +37,10 @@ export default async function initApp(): Promise<void> {
   const filterManager = new PlaceFilterManager(data, {
     searchInput: null,
     noRequirementsToggle: true,
-    policyChange: FilterOptions.getDefaultSelected("policyChange"),
-    scope: FilterOptions.getDefaultSelected("scope"),
-    landUse: FilterOptions.getDefaultSelected("landUse"),
-    implementationStage: FilterOptions.getDefaultSelected(
-      "implementationStage",
-    ),
+    policyChange: getDefaultFilterOptions("policyChange"),
+    scope: getDefaultFilterOptions("scope"),
+    landUse: getDefaultFilterOptions("landUse"),
+    implementationStage: getDefaultFilterOptions("implementationStage"),
     populationSliderIndexes: [0, POPULATION_MAX_INDEX],
   });
 

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -7,7 +7,7 @@ import maybeDisableFullScreenIcon from "./iframe";
 import initAbout from "./about";
 import initScorecard from "./scorecard";
 import { initPopulationSlider, POPULATION_MAX_INDEX } from "./populationSlider";
-import initFilterOptions from "./filterOptions";
+import { FilterOptions, initFilterOptions } from "./filterOptions";
 import initFilterPopup from "./filterPopup";
 import { PlaceFilterManager } from "./FilterState";
 import initCounters from "./counters";
@@ -37,20 +37,12 @@ export default async function initApp(): Promise<void> {
   const filterManager = new PlaceFilterManager(data, {
     searchInput: null,
     noRequirementsToggle: true,
-    policyChange: [
-      "Reduce Parking Minimums",
-      "Eliminate Parking Minimums",
-      "Parking Maximums",
-    ],
-    scope: [
-      "Regional",
-      "Citywide",
-      "City Center/Business District",
-      "Transit Oriented",
-      "Main Street/Special",
-    ],
-    landUse: ["All Uses", "Commercial", "Residential"],
-    implementationStage: ["Implemented", "Passed"],
+    policyChange: FilterOptions.getDefaultSelected("policyChange"),
+    scope: FilterOptions.getDefaultSelected("scope"),
+    landUse: FilterOptions.getDefaultSelected("landUse"),
+    implementationStage: FilterOptions.getDefaultSelected(
+      "implementationStage",
+    ),
     populationSliderIndexes: [0, POPULATION_MAX_INDEX],
   });
 


### PR DESCRIPTION
This is prework for converting the checkbox options into accordions. That code is quite complex, so we'll want to generate it with JavaScript rather than hardcoding HTML.

This also DRYs setting which options are pre-selected vs. what is the universe of valid options. We no longer duplicate the option names in main.ts.