### PR TITLE
Use accordions for filter checkboxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
     <section id="map-counter" class="map-counter" role="region"></section>
 
     <form class="filter-popup" aria-label="filter options" hidden>
-      <div class="filter filter-no-requirements-container">
+      <div class="filter-no-requirements-container">
         <label class="toggle">
           <span class="toggle-label">No parking requirements</span>
           <input

--- a/src/css/_filter.scss
+++ b/src/css/_filter.scss
@@ -45,7 +45,6 @@
   align-items: center;
   justify-content: space-between;
 
-  border: none;
   border-top: borders.$component-inner-divider;
 
   .filter-accordion-title {

--- a/src/css/_filter.scss
+++ b/src/css/_filter.scss
@@ -7,12 +7,14 @@
 @use "theme/zindex";
 @use "header";
 
+$filter-width: 310px;
+
 .filter-popup {
   position: fixed;
   right: spacing.$map-controls-margin-x;
   top: calc(header.$header-height + spacing.$map-controls-margin-top);
   z-index: zindex.$filter-popup;
-  width: 310px;
+  width: $filter-width;
 
   max-height: min(600px, 75vh);
   overflow-y: auto;

--- a/src/css/_filter.scss
+++ b/src/css/_filter.scss
@@ -1,7 +1,9 @@
 @use "theme/borders";
 @use "theme/colors";
 @use "theme/colors-original";
+@use "theme/icons";
 @use "theme/spacing";
+@use "theme/typography";
 @use "theme/zindex";
 @use "header";
 
@@ -18,16 +20,52 @@
   background-color: colors.$white;
   border: borders.$component-border;
   border-radius: borders.$border-radius;
-}
-
-.filter-popup > * {
-  margin: 0.5em;
-}
-
-.filter {
-  border: solid colors-original.$gray-light 1px;
 
   label {
     display: block;
   }
+
+  fieldset {
+    border: none;
+  }
+}
+
+.filter-accordion-toggle {
+  height: spacing.$min-touch-target;
+  width: 100%;
+  padding: 0;
+
+  font-size: typography.$font-size-base;
+  cursor: pointer;
+  text-align: left;
+  padding-left: spacing.$container-edge-spacing;
+  padding-right: 0;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  border: none;
+  border-top: borders.$component-inner-divider;
+
+  .filter-accordion-title {
+    flex: 1;
+  }
+
+  .filter-accordion-icon-container {
+    height: spacing.$min-touch-target;
+    width: spacing.$min-touch-target;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    svg {
+      height: icons.$icon-size-sm;
+    }
+  }
+}
+
+.filter-accordion-content {
+  border-top: borders.$component-inner-divider;
+  padding-top: spacing.$element-gap;
 }

--- a/src/css/_no-requirements-toggle.scss
+++ b/src/css/_no-requirements-toggle.scss
@@ -4,7 +4,7 @@ $toggle-size: 0.4em;
 $toggle-circle: calc(2.4 * $toggle-size);
 
 .filter-no-requirements-container {
-  padding: 0.2em;
+  padding: 0.5em;
 }
 
 .toggle {

--- a/src/css/_population-slider.scss
+++ b/src/css/_population-slider.scss
@@ -11,6 +11,7 @@
   flex-direction: column;
   align-items: center;
   width: 18em;
+  margin: 0.5em 1em;
 }
 
 .population-slider-controls {

--- a/src/css/_population-slider.scss
+++ b/src/css/_population-slider.scss
@@ -1,5 +1,8 @@
 @use "theme/colors-original";
+@use "theme/spacing";
 @use "theme/typography";
+
+@use "filter";
 
 // uncomment to visualize slider mechanism
 // input {
@@ -10,8 +13,8 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: 18em;
-  margin: 0.5em 1em;
+  width: calc(filter.$filter-width - (spacing.$container-edge-spacing * 2) - 5px);
+  margin: spacing.$element-gap spacing.$container-edge-spacing;
 }
 
 .population-slider-controls {

--- a/src/css/_population-slider.scss
+++ b/src/css/_population-slider.scss
@@ -13,8 +13,10 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  width: calc(filter.$filter-width - (spacing.$container-edge-spacing * 2) - 5px);
-  margin: spacing.$element-gap spacing.$container-edge-spacing;
+  width: calc(filter.$filter-width - spacing.$container-edge-spacing - 5px);
+  margin-top: spacing.$element-gap;
+  margin-bottom: spacing.$element-gap;
+  margin-left: spacing.$container-edge-spacing;
 }
 
 .population-slider-controls {

--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -1,4 +1,5 @@
 import { PlaceFilterManager } from "./FilterState";
+import Observable from "./Observable";
 
 // The boolean next to each option is for whether it's selected by default.
 const FILTER_CONFIG = {
@@ -36,18 +37,102 @@ export function getDefaultFilterOptions(groupKey: FilterGroupKey): string[] {
     .map(([name]) => name);
 }
 
-function generateAccordionOptions(
+type CheckboxStats = {
+  total: number;
+  checked: number;
+};
+
+function getCheckboxStats(fieldset: HTMLFieldSetElement): CheckboxStats {
+  const checkboxes = fieldset.querySelectorAll<HTMLInputElement>(
+    'input[type="checkbox"]',
+  );
+  const total = checkboxes.length;
+  const checked = Array.from(checkboxes).filter(
+    (checkbox) => checkbox.checked,
+  ).length;
+  return { total, checked };
+}
+
+type AccordionElements = {
+  outerContainer: HTMLDivElement;
+  accordionTitle: HTMLSpanElement;
+  accordionButton: HTMLButtonElement;
+  contentContainer: HTMLDivElement;
+  fieldSet: HTMLFieldSetElement;
+};
+
+type AccordionState = {
+  expanded: boolean;
+  checkboxStats: CheckboxStats;
+};
+
+function updateAccordionUI(
+  elements: AccordionElements,
+  title: string,
+  state: AccordionState,
+): void {
+  elements.accordionTitle.textContent = `${title} (${state.checkboxStats.checked}/${state.checkboxStats.total})`;
+
+  const upIcon =
+    elements.accordionButton.querySelector<SVGElement>(".fa-chevron-up");
+  const downIcon =
+    elements.accordionButton.querySelector<SVGElement>(".fa-chevron-down");
+  if (!upIcon || !downIcon) return;
+
+  elements.accordionButton.setAttribute(
+    "aria-expanded",
+    state.expanded.toString(),
+  );
+  elements.contentContainer.hidden = !state.expanded;
+  upIcon.style.display = state.expanded ? "block" : "none";
+  downIcon.style.display = state.expanded ? "none" : "block";
+}
+
+function generateAccordion(
   name: string,
-  legend: string,
+  title: string,
   filterStateKey: FilterGroupKey,
-): HTMLFieldSetElement {
-  const fieldset = document.createElement("fieldset");
-  fieldset.className = `filter filter-${name}`;
+): [AccordionElements, Observable<AccordionState>] {
+  const outerContainer = document.createElement("div");
+  outerContainer.className = "filter-accordion";
 
-  const legendElement = document.createElement("legend");
-  legendElement.textContent = legend;
-  fieldset.appendChild(legendElement);
+  const contentId = `filter-accordion-content-${name}`;
+  const titleId = `filter-accordion-title-${name}`;
 
+  const accordionButton = document.createElement("button");
+  // Turn off clicking "submitting" the form, which reloads the page.
+  accordionButton.type = "button";
+  accordionButton.className = "filter-accordion-toggle";
+  accordionButton.ariaExpanded = "false";
+  accordionButton.setAttribute("aria-controls", contentId);
+
+  const accordionTitle = document.createElement("span");
+  accordionTitle.id = titleId;
+  accordionTitle.className = "filter-accordion-title";
+  accordionButton.appendChild(accordionTitle);
+
+  const accordionIconContainer = document.createElement("div");
+  accordionIconContainer.className = "filter-accordion-icon-container";
+  accordionIconContainer.ariaHidden = "true";
+  const downIcon = document.createElement("i");
+  downIcon.className = "fa-solid fa-chevron-down";
+  downIcon.title = "expand option checkboxes";
+  const upIcon = document.createElement("i");
+  upIcon.className = "fa-solid fa-chevron-up";
+  upIcon.title = "collapse option checkboxes";
+  accordionIconContainer.appendChild(downIcon);
+  accordionIconContainer.appendChild(upIcon);
+  accordionButton.appendChild(accordionIconContainer);
+
+  outerContainer.appendChild(accordionButton);
+
+  const contentContainer = document.createElement("div");
+  contentContainer.id = contentId;
+  contentContainer.className = "filter-accordion-content";
+  contentContainer.setAttribute("aria-describedby", titleId);
+
+  const fieldSet = document.createElement("fieldset");
+  fieldSet.className = `filter-${name}`;
   FILTER_CONFIG[filterStateKey].forEach(([val, isDefaultSelected]) => {
     const label = document.createElement("label");
 
@@ -59,10 +144,37 @@ function generateAccordionOptions(
     label.appendChild(input);
     label.appendChild(document.createTextNode(val));
 
-    fieldset.appendChild(label);
+    fieldSet.appendChild(label);
   });
 
-  return fieldset;
+  contentContainer.appendChild(fieldSet);
+  outerContainer.appendChild(contentContainer);
+
+  const elements = {
+    outerContainer,
+    accordionTitle,
+    accordionButton,
+    contentContainer,
+    fieldSet,
+  };
+
+  const accordionState = new Observable<AccordionState>({
+    expanded: false,
+    checkboxStats: getCheckboxStats(fieldSet),
+  });
+  accordionState.subscribe((state) =>
+    updateAccordionUI(elements, title, state),
+  );
+  accordionButton.addEventListener("click", () => {
+    const priorState = accordionState.getValue();
+    accordionState.setValue({
+      expanded: !priorState.expanded,
+      checkboxStats: priorState.checkboxStats,
+    });
+  });
+  accordionState.initialize();
+
+  return [elements, accordionState];
 }
 
 function initFilterGroup(
@@ -71,18 +183,26 @@ function initFilterGroup(
   filterStateKey: FilterGroupKey,
   legend: string,
 ): void {
-  const groupContainer = generateAccordionOptions(
+  const [accordionElements, accordionState] = generateAccordion(
     htmlName,
     legend,
     filterStateKey,
   );
 
   const outerContainer = document.getElementById("filter-accordion-options");
-  outerContainer.appendChild(groupContainer);
+  outerContainer.appendChild(accordionElements.outerContainer);
 
-  groupContainer.addEventListener("change", () => {
+  accordionElements.fieldSet.addEventListener("change", () => {
+    const accordionPriorState = accordionState.getValue();
+    accordionState.setValue({
+      expanded: accordionPriorState.expanded,
+      checkboxStats: getCheckboxStats(accordionElements.fieldSet),
+    });
+
     const checkedLabels = Array.from(
-      groupContainer.querySelectorAll('input[type="checkbox"]:checked'),
+      accordionElements.fieldSet.querySelectorAll(
+        'input[type="checkbox"]:checked',
+      ),
     ).map((input) => input.parentElement.textContent.trim());
     filterManager.update({ [filterStateKey]: checkedLabels });
   });

--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -96,12 +96,14 @@ function generateAccordion(
   const outerContainer = document.createElement("div");
   outerContainer.className = "filter-accordion";
 
+  const buttonId = `filter-accordion-toggle-${name}`;
   const contentId = `filter-accordion-content-${name}`;
   const titleId = `filter-accordion-title-${name}`;
 
   const accordionButton = document.createElement("button");
   // Turn off clicking "submitting" the form, which reloads the page.
   accordionButton.type = "button";
+  accordionButton.id = buttonId;
   accordionButton.className = "filter-accordion-toggle";
   accordionButton.ariaExpanded = "false";
   accordionButton.setAttribute("aria-controls", contentId);

--- a/src/js/fontAwesome.ts
+++ b/src/js/fontAwesome.ts
@@ -4,6 +4,8 @@ import {
   faCircleXmark,
 } from "@fortawesome/free-regular-svg-icons";
 import {
+  faChevronDown,
+  faChevronUp,
   faUpRightFromSquare,
   faMagnifyingGlass,
   faSliders,
@@ -15,6 +17,8 @@ import "@fortawesome/fontawesome-svg-core/styles.css";
 
 export default function initIcons(): void {
   library.add(
+    faChevronUp,
+    faChevronDown,
     faCircleQuestion,
     faUpRightFromSquare,
     faCircleXmark,

--- a/src/js/viewToggle.ts
+++ b/src/js/viewToggle.ts
@@ -50,6 +50,5 @@ export default function initViewToggle(table: Tabulator): ViewStateObservable {
   const viewToggle = new Observable<ViewState>("map");
   viewToggle.subscribe((state) => updateUI(table, state));
   updateOnIconClick(viewToggle);
-  viewToggle.initialize();
   return viewToggle;
 }

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -63,6 +63,9 @@ const selectIfSet = async (
   values?: string[],
 ): Promise<void> => {
   if (values !== undefined) {
+    // First, expand the accordion
+    await page.locator(`#filter-accordion-toggle-${selector}`).click();
+
     // Reset filters by unchecking all
     const checkboxesUncheck = await page.$$(
       `input[type="checkbox"][name="${selector}"]`,


### PR DESCRIPTION
This allows us to fit much more on the screen. That unblocks us from making the individual checkbox options larger in a follow up.

It's also useful that the title shows how many values are selected. That can help you realize that when something is set to 0, nothing is chosen.

We use the same style and accessibility / HTML structure as PLM.

<img width="318" alt="Screenshot 2024-08-18 at 7 19 31 AM" src="https://github.com/user-attachments/assets/3615d7aa-3b89-4fbc-98a1-947786933dd0">
<img width="311" alt="Screenshot 2024-08-18 at 7 19 43 AM" src="https://github.com/user-attachments/assets/f5302852-478c-4fc3-8750-ef64612a7ab8">
