### PR TITLE
Fix population slider only going halfway

### DIFF
--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -22,8 +22,7 @@ function getSliders(): Sliders {
   };
 }
 
-function updateSlidersUI(state: FilterState): void {
-  const [leftIndex, rightIndex] = state.populationSliderIndexes;
+function updateSlidersUI(leftIndex: number, rightIndex: number): void {
   const sliders = getSliders();
 
   sliders.left.value = leftIndex.toString();
@@ -91,8 +90,9 @@ export function initPopulationSlider(
   // Update UI whenever filter popup is visible. Note that
   // the popup must be visible for the width calculations to work.
   filterPopupIsVisible.subscribe((isVisible) => {
-    if (isVisible) {
-      updateSlidersUI(filterManager.getState());
-    }
+    if (!isVisible) return;
+    const [leftIndex, rightIndex] =
+      filterManager.getState().populationSliderIndexes;
+    updateSlidersUI(leftIndex, rightIndex);
   });
 }

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -22,7 +22,8 @@ function getSliders(): Sliders {
   };
 }
 
-function updateSlidersUI(leftIndex: number, rightIndex: number): void {
+function updateSlidersUI(state: FilterState): void {
+  const [leftIndex, rightIndex] = state.populationSliderIndexes;
   const sliders = getSliders();
 
   sliders.left.value = leftIndex.toString();
@@ -90,9 +91,8 @@ export function initPopulationSlider(
   // Update UI whenever filter popup is visible. Note that
   // the popup must be visible for the width calculations to work.
   filterPopupIsVisible.subscribe((isVisible) => {
-    if (!isVisible) return;
-    const [leftIndex, rightIndex] =
-      filterManager.getState().populationSliderIndexes;
-    updateSlidersUI(leftIndex, rightIndex);
+    if (isVisible) {
+      updateSlidersUI(filterManager.getState());
+    }
   });
 }

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -95,4 +95,10 @@ export function initPopulationSlider(
       updateSlidersUI(filterManager.getState());
     }
   });
+
+  // Also update UI when values change, but only if the filter popup is open.
+  filterManager.subscribe((state) => {
+    if (!filterPopupIsVisible.getValue()) return;
+    updateSlidersUI(state);
+  });
 }

--- a/src/js/viewToggle.ts
+++ b/src/js/viewToggle.ts
@@ -50,5 +50,6 @@ export default function initViewToggle(table: Tabulator): ViewStateObservable {
   const viewToggle = new Observable<ViewState>("map");
   viewToggle.subscribe((state) => updateUI(table, state));
   updateOnIconClick(viewToggle);
+  viewToggle.initialize();
   return viewToggle;
 }

--- a/src/js/viewToggle.ts
+++ b/src/js/viewToggle.ts
@@ -50,6 +50,5 @@ export default function initViewToggle(table: Tabulator): ViewStateObservable {
   const viewToggle = new Observable<ViewState>("map");
   viewToggle.subscribe((state) => updateUI(table, state));
   updateOnIconClick(viewToggle);
-  viewToggle.initialize();
   return viewToggle;
 }


### PR DESCRIPTION
This is a bug fix for https://github.com/ParkingReformNetwork/reform-map/pull/449. I unintentionally broke things by removing the `filterManager.subscribe()`, meaning we didn't redraw the sliders every time the slider values changed.

Also removes a double initialization of viewToggle.