### PR TITLE
Remove unnecessary font awesome load

### DIFF
--- a/src/js/fontAwesome.ts
+++ b/src/js/fontAwesome.ts
@@ -4,6 +4,7 @@ import {
   faCircleXmark,
 } from "@fortawesome/free-regular-svg-icons";
 import {
+  faArrowRight,
   faChevronDown,
   faChevronUp,
   faUpRightFromSquare,
@@ -16,6 +17,7 @@ import "@fortawesome/fontawesome-svg-core/styles.css";
 
 export default function initIcons(): void {
   library.add(
+    faArrowRight,
     faChevronUp,
     faChevronDown,
     faCircleQuestion,

--- a/src/js/fontAwesome.ts
+++ b/src/js/fontAwesome.ts
@@ -11,7 +11,6 @@ import {
   faSliders,
   faTable,
   faEarthAmericas,
-  fas,
 } from "@fortawesome/free-solid-svg-icons";
 import "@fortawesome/fontawesome-svg-core/styles.css";
 
@@ -26,7 +25,6 @@ export default function initIcons(): void {
     faSliders,
     faTable,
     faEarthAmericas,
-    fas,
   );
   dom.watch();
 }


### PR DESCRIPTION
We were accidentally loading every single Font Awesome free icon. This PR lowers index.html from 1.8MB to 0.2MB.