### PR TITLE
Clarify the no requirements toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,8 +120,8 @@
       <p>
         Click the filter or search icons in the top-right to change which places
         are shown, such as to filter by population size. By default, the map
-        only shows places with all parking requirements removed, which you can
-        toggle with the "No parking requirements" toggle in the filter options.
+        only shows places with all parking minimums removed, which you can
+        change with the "All minimums removed" toggle in the filter options.
       </p>
       <p>
         Click the table icon in the top-left to switch from map view to table
@@ -223,13 +223,13 @@
     <section id="map-counter" class="map-counter" role="region"></section>
 
     <form class="filter-popup" aria-label="filter options" hidden>
-      <div class="filter-no-requirements-container">
+      <div class="filter-all-minimums-removed-container">
         <label class="toggle">
-          <span class="toggle-label">No parking requirements</span>
+          <span class="toggle-label">All minimums removed</span>
           <input
             type="checkbox"
             class="toggle-checkbox"
-            id="no-requirements-toggle"
+            id="all-minimums-removed-toggle"
           />
           <div class="toggle-switch"></div>
         </label>

--- a/src/css/_minimums-toggle.scss
+++ b/src/css/_minimums-toggle.scss
@@ -3,7 +3,7 @@
 $toggle-size: 0.4em;
 $toggle-circle: calc(2.4 * $toggle-size);
 
-.filter-no-requirements-container {
+.filter-all-minimums-removed-container {
   padding: 0.5em;
 }
 

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -8,7 +8,7 @@
 @use "filter";
 @use "header";
 @use "logo";
-@use "no-requirements-toggle";
+@use "minimums-toggle";
 @use "population-slider";
 @use "scorecard";
 @use "search";

--- a/src/js/FilterState.ts
+++ b/src/js/FilterState.ts
@@ -16,7 +16,7 @@ export const POPULATION_INTERVALS: Array<[string, number]> = [
 
 export interface FilterState {
   searchInput: string | null;
-  allMinimumsRepealedToggle: boolean;
+  allMinimumsRemovedToggle: boolean;
   policyChange: string[];
   scope: string[];
   landUse: string[];
@@ -103,7 +103,7 @@ export class PlaceFilterManager {
     );
 
     const isAllMinimumsRepealed =
-      !state.allMinimumsRepealedToggle || entry.allMinimumsRepealed;
+      !state.allMinimumsRemovedToggle || entry.allMinimumsRemoved;
 
     const [sliderLeftIndex, sliderRightIndex] = state.populationSliderIndexes;
     const isPopulation =

--- a/src/js/counters.ts
+++ b/src/js/counters.ts
@@ -7,8 +7,8 @@ function determineHtml(state: FilterState, numPlaces: number): string {
   if (state.searchInput) {
     return `Showing ${state.searchInput} from search — <a class="counter-search-reset" role="button" aria-label="reset search">reset</a>`;
   }
-  const suffix = state.allMinimumsRepealedToggle
-    ? "without parking requirements"
+  const suffix = state.allMinimumsRemovedToggle
+    ? "with all parking minimums removed"
     : "with parking reforms";
   const placesWord = numPlaces === 1 ? "place" : "places";
   return `Showing ${numPlaces} ${placesWord} ${suffix}`;

--- a/src/js/data.ts
+++ b/src/js/data.ts
@@ -45,7 +45,7 @@ export default async function readData(): Promise<Record<PlaceId, PlaceEntry>> {
           "High density residential": "Residential, high-density",
           "Multi-family residential": "Residential, multi-family",
         }),
-        allMinimumsRepealed: rawEntry.all_minimums_repealed === "1",
+        allMinimumsRemoved: rawEntry.all_minimums_repealed === "1",
         reformDate: date.isValid ? date : null,
       };
       const placeId = `${entry.place}, ${entry.state}`;

--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -272,12 +272,12 @@ export function initFilterOptions(
   initFilterGroup(filterManager, "year", "year", filterOptions, "Year");
 
   const minimumsToggle = document.querySelector<HTMLInputElement>(
-    "#no-requirements-toggle",
+    "#all-minimums-removed-toggle",
   );
-  minimumsToggle.checked = filterManager.getState().allMinimumsRepealedToggle;
+  minimumsToggle.checked = filterManager.getState().allMinimumsRemovedToggle;
   minimumsToggle.addEventListener("change", () => {
     filterManager.update({
-      allMinimumsRepealedToggle: minimumsToggle.checked,
+      allMinimumsRemovedToggle: minimumsToggle.checked,
     });
   });
 }

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -28,7 +28,7 @@ export default async function initApp(): Promise<void> {
 
   const filterManager = new PlaceFilterManager(data, {
     searchInput: null,
-    allMinimumsRepealedToggle: true,
+    allMinimumsRemovedToggle: true,
     policyChange: filterOptions.default("policyChange"),
     scope: filterOptions.default("scope"),
     landUse: filterOptions.default("landUse"),

--- a/src/js/mapMarkers.ts
+++ b/src/js/mapMarkers.ts
@@ -42,7 +42,7 @@ export default function initPlaceMarkers(
   const placesToMarkers: Record<string, CircleMarker> = Object.entries(
     filterManager.entries,
   ).reduce((acc, [placeId, entry]) => {
-    const isPrimary = entry.allMinimumsRepealed;
+    const isPrimary = entry.allMinimumsRemoved;
     const style = isPrimary ? PRIMARY_MARKER_STYLE : SECONDARY_MARKER_STYLE;
 
     // @ts-ignore: passing strings to CircleMarker for lat/lng is valid, and
@@ -74,7 +74,7 @@ export default function initPlaceMarkers(
   map.addEventListener("zoomend", () => {
     const zoom = map.getZoom();
     Object.entries(placesToMarkers).forEach(([placeId, marker]) => {
-      const isPrimary = filterManager.entries[placeId].allMinimumsRepealed;
+      const isPrimary = filterManager.entries[placeId].allMinimumsRemoved;
       const newRadius = radiusGivenZoom({ zoom, isPrimary });
       marker.setRadius(newRadius);
     });

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -12,7 +12,7 @@ export interface PlaceEntry {
   scope: string[];
   landUse: string[];
   reformDate: DateTime | null;
-  allMinimumsRepealed: boolean;
+  allMinimumsRemoved: boolean;
   population: number;
   url: string;
   lat: string;

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -17,7 +17,7 @@ interface EdgeCase {
   country?: string[];
   year?: string[];
   populationIntervals?: [number, number];
-  noRequirements?: boolean;
+  allMinimumsRemoved?: boolean;
   expectedRange: [number, number] | "all";
 }
 
@@ -53,8 +53,8 @@ const TESTS: EdgeCase[] = [
     expectedRange: [480, 700],
   },
   {
-    desc: "no requirements",
-    noRequirements: true,
+    desc: "all minimums removed",
+    allMinimumsRemoved: true,
     expectedRange: [80, 250],
   },
   {
@@ -111,7 +111,7 @@ for (const edgeCase of TESTS) {
 
     await deselectToggle(page);
 
-    if (edgeCase.noRequirements !== undefined) {
+    if (edgeCase.allMinimumsRemoved !== undefined) {
       // Force clicking because the checkbox is hidden (opacity: 0)
       await page.locator("#all-minimums-removed-toggle").click({ force: true });
     }

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -113,7 +113,7 @@ for (const edgeCase of TESTS) {
 
     if (edgeCase.noRequirements !== undefined) {
       // Force clicking because the checkbox is hidden (opacity: 0)
-      await page.locator("#no-requirements-toggle").click({ force: true });
+      await page.locator("#all-minimums-removed-toggle").click({ force: true });
     }
 
     await selectIfSet(page, "scope", edgeCase.scope);

--- a/tests/app/utils.ts
+++ b/tests/app/utils.ts
@@ -40,5 +40,5 @@ export const assertNumPlaces = async (
 export const deselectToggle = async (page: Page): Promise<void> => {
   // Default has requirement toggle on, so first de-select it by opening filter pop-up and clicking toggle.
   await page.locator(".header-filter-icon-container").click();
-  await page.locator("#no-requirements-toggle").click({ force: true });
+  await page.locator("#all-minimums-removed-toggle").click({ force: true });
 };


### PR DESCRIPTION
Saying "no requirements" is not true; some cities have parking maximums! More accurate is that _all_ parking minimums have been removed.

This PR updates the toggle label & the counter text. In the filter, we don't have enough space for the word "parking" - we have to rely on the counter and about button giving context.

<img width="314" alt="Screenshot 2024-08-18 at 4 57 51 PM" src="https://github.com/user-attachments/assets/272d3587-4743-4b8b-b074-c8920612a663">

<img width="316" alt="Screenshot 2024-08-18 at 4 57 33 PM" src="https://github.com/user-attachments/assets/0e2272ae-4aa3-4ce0-bc12-2531f5e0f91c">
