### PR TITLE
Remove unnecessary padding in clear all button

### DIFF
--- a/src/css/_filter.scss
+++ b/src/css/_filter.scss
@@ -137,7 +137,6 @@ $filter-width: 310px;
   button {
     flex: 1;
     height: spacing.$min-touch-target;
-    padding: spacing.$element-gap;
     cursor: pointer;
 
     border: borders.$component-border;


### PR DESCRIPTION
There's no reason to have it. We already set the height of the button and everything is centered.