### PR TITLE
Revamp all minimums toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -120,8 +120,9 @@
       <p>
         Click the filter or search icons in the top-right to change which places
         are shown, such as to filter by population size. By default, the map
-        only shows places with all parking minimums removed, which you can
-        change with the "All minimums removed" toggle in the filter options.
+        only shows places with all parking minimums removed. You can instead see
+        all places with any parking reform by clicking the toggle at the top of
+        the filter.
       </p>
       <p>
         Click the table icon in the top-left to switch from map view to table

--- a/index.html
+++ b/index.html
@@ -223,17 +223,11 @@
     <section id="map-counter" class="map-counter" role="region"></section>
 
     <form class="filter-popup" aria-label="filter options" hidden>
-      <div class="filter-all-minimums-removed-container">
-        <label class="toggle">
-          <span class="toggle-label">All minimums removed</span>
-          <input
-            type="checkbox"
-            class="toggle-checkbox"
-            id="all-minimums-removed-toggle"
-          />
-          <div class="toggle-switch"></div>
-        </label>
-      </div>
+      <label class="all-minimums-toggle">
+        <input type="checkbox" id="all-minimums-toggle-checkbox" />
+        <span>Only places with all minimums removed</span>
+        <div class="all-minimums-toggle-switch"></div>
+      </label>
 
       <div class="population-slider-container">
         <div id="population-slider-label"></div>

--- a/src/css/_filter.scss
+++ b/src/css/_filter.scss
@@ -79,7 +79,7 @@ $filter-width: 310px;
   border: borders.$component-border;
   border-radius: borders.$border-radius;
 
-  height: spacing.$min-touch-target;
+  min-height: spacing.$min-touch-target;
   margin: spacing.$element-gap;
 
   display: flex;
@@ -126,6 +126,8 @@ $filter-width: 310px;
   span {
     flex: 1;
     margin-left: spacing.$element-gap;
+    margin-top: spacing.$element-gap;
+    margin-bottom: spacing.$element-gap;
     line-height: 1.1;
   }
 }

--- a/src/css/_filter.scss
+++ b/src/css/_filter.scss
@@ -70,6 +70,10 @@ $filter-width: 310px;
 
 .filter-accordion-content {
   border-top: borders.$component-inner-divider;
+
+  .filter-checkbox:last-child {
+    margin-bottom: spacing.$container-edge-spacing;
+  }
 }
 
 .filter-checkbox {
@@ -80,7 +84,7 @@ $filter-width: 310px;
   border-radius: borders.$border-radius;
 
   min-height: spacing.$min-touch-target;
-  margin: spacing.$element-gap;
+  margin: spacing.$element-gap spacing.$container-edge-spacing;
 
   display: flex;
   align-items: center;
@@ -125,9 +129,7 @@ $filter-width: 310px;
 
   span {
     flex: 1;
-    margin-left: spacing.$element-gap;
-    margin-top: spacing.$element-gap;
-    margin-bottom: spacing.$element-gap;
+    margin: spacing.$element-gap;
     line-height: 1.1;
   }
 }
@@ -143,15 +145,15 @@ $filter-width: 310px;
 
     border: borders.$component-border;
     border-radius: borders.$border-radius;
-    margin-top: spacing.$element-gap;
+    margin-top: spacing.$container-edge-spacing;
 
     &:first-child {
-      margin-left: spacing.$element-gap;
+      margin-left: spacing.$container-edge-spacing;
       margin-right: spacing.$element-gap;
     }
 
     &:last-child {
-      margin-right: spacing.$element-gap;
+      margin-right: spacing.$container-edge-spacing;
     }
 
     &:hover {

--- a/src/css/_minimums-toggle.scss
+++ b/src/css/_minimums-toggle.scss
@@ -1,65 +1,87 @@
-@use "theme/colors-original";
+@use "theme/borders";
+@use "theme/colors";
+@use "theme/icons";
+@use "theme/spacing";
+@use "theme/typography";
 
-$toggle-size: 0.4em;
+$toggle-size: 8px;
 $toggle-circle: calc(2.4 * $toggle-size);
 
-.filter-all-minimums-removed-container {
-  padding: 0.5em;
+.all-minimums-toggle {
+  cursor: pointer;
+  font-size: typography.$font-size-base;
 
-  label {
-    display: block;
+  border: borders.$component-border;
+  border-radius: borders.$border-radius;
+
+  min-height: spacing.$min-touch-target;
+  margin: spacing.$container-edge-spacing;
+
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  &:hover {
+    background-color: colors.$hover;
+  }
+
+  input {
+    position: absolute;
+    opacity: 0;
+    height: 0;
+    width: 0;
+    margin: 0;
+  }
+
+  svg {
+    height: icons.$icon-size-md;
+    width: icons.$icon-size-md;
+    margin-left: spacing.$element-gap;
+    color: colors.$gray;
+  }
+
+  span {
+    flex: 1;
+    margin-left: spacing.$container-edge-spacing;
+    margin-top: spacing.$element-gap;
+    margin-bottom: spacing.$element-gap;
+    line-height: 1.2;
   }
 }
 
-.toggle {
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  width: 17em;
-}
-
-.toggle-switch {
+.all-minimums-toggle-switch {
   display: inline-block;
-  background: colors-original.$gray-light;
-  border-radius: 1em;
+  position: relative;
   width: calc(5.8 * $toggle-size);
   height: calc(3.2 * $toggle-size);
-  position: relative;
-  vertical-align: middle;
+
+  margin-left: spacing.$element-gap;
+  margin-right: spacing.$container-edge-spacing;
+
+  background: colors.$gray-light;
+  border-radius: 16px;
   transition: 0.25s;
-}
-.toggle-switch::before,
-.toggle-switch::after {
-  content: "";
-}
-.toggle-switch::before {
-  display: block;
-  background: colors-original.$white;
-  border-radius: 50%;
-  width: $toggle-circle;
-  height: $toggle-circle;
-  position: absolute;
-  top: calc(0.4 * $toggle-size);
-  left: calc(0.4 * $toggle-size);
-  transition: left 0.25s;
-}
-.toggle:hover .toggle-switch::before {
-  background: colors-original.$white;
-}
-.toggle-checkbox:checked + .toggle-switch {
-  background: colors-original.$blue;
-}
-.toggle-checkbox:checked + .toggle-switch::before {
-  left: calc(3 * $toggle-size);
+
+  &::before {
+    content: "";
+    display: block;
+    width: $toggle-circle;
+    height: $toggle-circle;
+
+    position: absolute;
+    top: calc(0.4 * $toggle-size);
+    left: calc(0.4 * $toggle-size);
+
+    background: colors.$white;
+    border-radius: 50%;
+    transition: left 0.25s;
+  }
 }
 
-.toggle-checkbox {
-  position: absolute;
-  visibility: hidden;
-}
+#all-minimums-toggle-checkbox:checked ~ .all-minimums-toggle-switch {
+  background: colors.$gray;
 
-.toggle-label {
-  margin-right: 0.5em;
-  margin-left: 0.5em;
+  &::before {
+    left: calc(3 * $toggle-size);
+  }
 }

--- a/src/css/theme/_colors.scss
+++ b/src/css/theme/_colors.scss
@@ -3,4 +3,5 @@ $white: hsl(0, 0%, 100%);
 $hover: hsl(0, 0%, 96%);
 $black: hsl(0, 0%, 0%);
 $gray: hsl(0, 0%, 25.88%); // Color comes from the logo
+$gray-light: hsl(0, 0%, 80%);
 $black-translucent: hsla(0, 0%, 0%, 0.4);

--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -191,8 +191,10 @@ function generateAccordion(
 
     const squareIcon = document.createElement("i");
     squareIcon.className = "fa-regular fa-square";
+    squareIcon.ariaHidden = "true";
     const checkedIcon = document.createElement("i");
     checkedIcon.className = "fa-solid fa-square-check";
+    checkedIcon.ariaHidden = "true";
 
     const description = document.createElement("span");
     description.textContent = val;

--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -337,7 +337,7 @@ export function initFilterOptions(
   initFilterGroup(filterManager, "year", "year", filterOptions, "Year");
 
   const minimumsToggle = document.querySelector<HTMLInputElement>(
-    "#all-minimums-removed-toggle",
+    "#all-minimums-toggle-checkbox",
   );
   minimumsToggle.checked = filterManager.getState().allMinimumsRemovedToggle;
   minimumsToggle.addEventListener("change", () => {

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -108,9 +108,7 @@ for (const edgeCase of TESTS) {
     await deselectToggle(page);
 
     if (edgeCase.allMinimumsRemoved !== undefined) {
-      await page
-        .locator("#all-minimums-toggle-checkbox")
-        .click({ force: true });
+      await page.locator(".all-minimums-toggle").click();
     }
 
     await selectIfSet(page, "scope", edgeCase.scope);

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -108,8 +108,9 @@ for (const edgeCase of TESTS) {
     await deselectToggle(page);
 
     if (edgeCase.allMinimumsRemoved !== undefined) {
-      // Force clicking because the checkbox is hidden (opacity: 0)
-      await page.locator("#all-minimums-removed-toggle").click({ force: true });
+      await page
+        .locator("#all-minimums-toggle-checkbox")
+        .click({ force: true });
     }
 
     await selectIfSet(page, "scope", edgeCase.scope);

--- a/tests/app/utils.ts
+++ b/tests/app/utils.ts
@@ -40,5 +40,5 @@ export const assertNumPlaces = async (
 export const deselectToggle = async (page: Page): Promise<void> => {
   // Default has requirement toggle on, so first de-select it by opening filter pop-up and clicking toggle.
   await page.locator(".header-filter-icon-container").click();
-  await page.locator("#all-minimums-removed-toggle").click({ force: true });
+  await page.locator("#all-minimums-toggle-checkbox").click({ force: true });
 };

--- a/tests/app/utils.ts
+++ b/tests/app/utils.ts
@@ -40,5 +40,5 @@ export const assertNumPlaces = async (
 export const deselectToggle = async (page: Page): Promise<void> => {
   // Default has requirement toggle on, so first de-select it by opening filter pop-up and clicking toggle.
   await page.locator(".header-filter-icon-container").click();
-  await page.locator("#all-minimums-toggle-checkbox").click({ force: true });
+  await page.locator(".all-minimums-toggle").click();
 };


### PR DESCRIPTION
Goals:

* Clarify what the option does. We always show cities w/o mininums! This is about whether to show everything else.
* Make it more obvious where the touch target is
* Align style with rest of filter

I considered using a checkbox, but the internet strongly recommends using a switch for this use-case because the option immediately has an effect, i.e. there is no submit button.

Before:

<img width="307" alt="Screenshot 2024-08-19 at 8 50 51 PM" src="https://github.com/user-attachments/assets/7864390f-aee0-4907-bf7a-70c1fd3387a0">

After:

<img width="311" alt="Screenshot 2024-08-19 at 8 51 40 PM" src="https://github.com/user-attachments/assets/a7057d1d-1e88-4e9c-a4e9-a1328ac1a44c">

This PR also adds more whitespace around the new options so that things are less crowded.
