### PR TITLE
Clarify "Residential" option

### DIFF
--- a/src/js/data.ts
+++ b/src/js/data.ts
@@ -42,6 +42,7 @@ export default async function readData(): Promise<Record<PlaceId, PlaceEntry>> {
           "Main street/special": "Main street / special",
         }),
         landUse: splitStringArray(rawEntry.land_use, {
+          "Residential": "Residential, all uses",
           "Low density (sf) residential": "Residential, low-density",
           "High density residential": "Residential, high-density",
           "Multi-family residential": "Residential, multi-family",

--- a/src/js/data.ts
+++ b/src/js/data.ts
@@ -42,7 +42,7 @@ export default async function readData(): Promise<Record<PlaceId, PlaceEntry>> {
           "Main street/special": "Main street / special",
         }),
         landUse: splitStringArray(rawEntry.land_use, {
-          "Residential": "Residential, all uses",
+          Residential: "Residential, all uses",
           "Low density (sf) residential": "Residential, low-density",
           "High density residential": "Residential, high-density",
           "Multi-family residential": "Residential, multi-family",

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -34,7 +34,11 @@ const TESTS: EdgeCase[] = [
     policy: ["Add parking maximums"],
     expectedRange: [700, 1100],
   },
-  { desc: "land use filter", land: ["Residential"], expectedRange: [320, 550] },
+  {
+    desc: "land use filter",
+    land: ["Residential, all uses"],
+    expectedRange: [320, 550],
+  },
   {
     desc: "status filter",
     status: ["Repealed"],


### PR DESCRIPTION
Now we have these four land uses:

<img width="299" alt="Screenshot 2024-08-20 at 6 49 24 AM" src="https://github.com/user-attachments/assets/d6b08c61-68c0-4c53-bc32-7885474de166">
