### PR TITLE
Use full names for countries

### DIFF
--- a/src/js/data.ts
+++ b/src/js/data.ts
@@ -5,6 +5,22 @@ import { PlaceId, PlaceEntry } from "./types";
 
 export const DATE_REPR = "LLL d, yyyy";
 
+const countryMapping = {
+  AU: "Australia",
+  BR: "Brazil",
+  CA: "Canada",
+  CN: "China",
+  DE: "Germany",
+  FR: "France",
+  IE: "Ireland",
+  IL: "Israel",
+  MX: "Mexico",
+  NZ: "New Zealand",
+  SE: "Sweden",
+  UK: "United Kingdom",
+  US: "United States",
+};
+
 function splitStringArray(
   val: string,
   transform: Record<string, string> = {},
@@ -26,7 +42,7 @@ export default async function readData(): Promise<Record<PlaceId, PlaceEntry>> {
       const entry = {
         place: rawEntry.place,
         state: rawEntry.state,
-        country: rawEntry.country,
+        country: countryMapping[rawEntry.country] ?? rawEntry.country,
         summary: rawEntry.summary,
         status: rawEntry.status,
         lat: rawEntry.lat,

--- a/src/js/table.ts
+++ b/src/js/table.ts
@@ -73,7 +73,7 @@ export default function initTable(
       },
     },
     { title: "State", field: "state", width: 70 },
-    { title: "Country", field: "country", width: 70 },
+    { title: "Country", field: "country", width: 110 },
     {
       title: "Population",
       field: "population",

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -46,7 +46,7 @@ const TESTS: EdgeCase[] = [
   },
   {
     desc: "country filter",
-    country: ["MX"],
+    country: ["Mexico"],
     expectedRange: [2, 7],
   },
   {


### PR DESCRIPTION
This is much more accessible.

It's plausible we will still want to use the two-letter code for the citation_url once revisiting how those URLs are formed. We can still do that with this implementation because the database still uses the two letter code; in `data.ts`, we can save for example `country_code` as another field.