### PR TITLE
Fix search and scorecard for countries

### DIFF
--- a/src/js/data.ts
+++ b/src/js/data.ts
@@ -41,7 +41,7 @@ export default async function readData(): Promise<Record<PlaceId, PlaceEntry>> {
       const date = DateTime.fromFormat(rawEntry.reform_date, DATE_REPR);
       const entry = {
         place: rawEntry.place,
-        state: rawEntry.state,
+        state: rawEntry.state || null,
         country: countryMapping[rawEntry.country] ?? rawEntry.country,
         summary: rawEntry.summary,
         status: rawEntry.status,
@@ -66,7 +66,9 @@ export default async function readData(): Promise<Record<PlaceId, PlaceEntry>> {
         allMinimumsRemoved: rawEntry.all_minimums_repealed === "1",
         reformDate: date.isValid ? date : null,
       };
-      const placeId = `${entry.place}, ${entry.state}`;
+      const placeId = entry.state
+        ? `${entry.place}, ${entry.state}`
+        : entry.place;
       acc[placeId] = entry;
       return acc;
     },

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -72,11 +72,11 @@ export default function initScorecard(
 
   // Clicking a city marker opens up the scorecard.
   markerGroup.on("click", (e) => {
-    const cityState = e.sourceTarget.getTooltip().getContent();
+    const placeId = e.sourceTarget.getTooltip().getContent();
     scorecardState.setValue({
       type: "visible",
-      placeId: cityState,
-      entry: data[cityState],
+      placeId,
+      entry: data[placeId],
     });
   });
 

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -4,7 +4,7 @@ export type PlaceId = string;
 
 export interface PlaceEntry {
   place: string;
-  state: string;
+  state: string | null;
   country: string;
   summary: string;
   status: string;

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -3,8 +3,12 @@ import type { DateTime } from "luxon";
 export type PlaceId = string;
 
 export interface PlaceEntry {
+  // Full name of the town, city, county, province, state, or country.
+  // Must always be set.
   place: string;
+  // State or province abbreviation. Not set for countries.
   state: string | null;
+  // Country abbreviation. Must always be set.
   country: string;
   summary: string;
   status: string;


### PR DESCRIPTION
We have four countries, which don't set `State`. Their scorecard and search were broken because we'd set the value as `Canada, `. Now it's `Canada`. 

Turns out the city detail HTML pages were already correct, including the link to those pages.