### PR TITLE
Revamp data model for update-city-detail

### DIFF
--- a/scripts/city_detail.html.handlebars
+++ b/scripts/city_detail.html.handlebars
@@ -21,7 +21,7 @@
       border: none; color: white; padding: 7px 16px; text-align: center;
       text-decoration: none; display: inline-block; font-size: 16px; }
     </style>
-    <title>Parking Reform Network - Reforms in {{city}}{{state}}</title>
+    <title>Parking Reform Network - Reforms in {{placeId}}</title>
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=G-5MFS4ZVMY3"
@@ -45,7 +45,7 @@
         <div class="row">
           <div class="col-sm-8">
             <header>
-              <h1 class="display-3">{{city}}{{state}}</h1>
+              <h1 class="display-3">{{placeId}}</h1>
             </header>
           </div>
           <div class="col-sm-4" align="center">
@@ -66,11 +66,11 @@
         <dt class="col-12 col-sm-4 col-lg-3">Implementation Status</dt>
         <dd class="col-12 col-sm-8 col-lg-9">{{status}}</dd>
         <dt class="col-12 col-sm-4 col-lg-3">Reform Type</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">{{reformType}}</dd>
+        <dd class="col-12 col-sm-8 col-lg-9">{{policyChange}}</dd>
         <dt class="col-12 col-sm-4 col-lg-3">Land Uses</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">{{uses}}</dd>
+        <dd class="col-12 col-sm-8 col-lg-9">{{landUse}}</dd>
         <dt class="col-12 col-sm-4 col-lg-3">Scope of Reform</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">{{magnitude}}</dd>
+        <dd class="col-12 col-sm-8 col-lg-9">{{scope}}</dd>
         <dt class="col-12 col-sm-4 col-lg-3">Requirements</dt>
         <dd class="col-12 col-sm-8 col-lg-9">{{requirements}}</dd>
         <dt class="col-12 col-sm-4 col-lg-3">Reporter</dt>
@@ -83,7 +83,7 @@
           </header>
           <dl class="row">
             <dt class="col-12 col-sm-4 col-lg-3">Source Description</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">{{sourceDescription}}</dd>
+            <dd class="col-12 col-sm-8 col-lg-9">{{description}}</dd>
             <dt class="col-12 col-sm-4 col-lg-3">Type</dt>
             <dd class="col-12 col-sm-8 col-lg-9">{{type}}</dd>
             <dt class="col-12 col-sm-4 col-lg-3">URL</dt>

--- a/scripts/updateCityDetail.ts
+++ b/scripts/updateCityDetail.ts
@@ -48,8 +48,8 @@ const TIME_ZONE_MAPPING: Partial<Record<string, string>> = {
   PST: "America/Los_Angeles",
 };
 
-function rmSpace(v: string): string {
-  return v.replace(/ /g, "");
+function escapePlaceId(v: string): string {
+  return v.replace(/ /g, "").replace(",", "_");
 }
 
 export function parseDatetime(
@@ -91,7 +91,7 @@ async function loadData(): Promise<Record<string, PlaceEntry>> {
   gTablesData.forEach((row) => {
     if (!row.City) return;
 
-    const placeId = row.State ? `${row.City}_${row.State}` : row.City;
+    const placeId = row.State ? `${row.City}, ${row.State}` : row.City;
     const citationIdx = result[placeId]
       ? result[placeId].citations.length + 1
       : 1;
@@ -158,7 +158,7 @@ export function normalizeAttachments(
       url: val,
       fileName: new URL(val).pathname.split("/").pop()!,
       isDoc: fileType === ".docx" || fileType === ".pdf",
-      outputPath: `attachment_images/${rmSpace(placeId)}_${citationIdx}_${
+      outputPath: `attachment_images/${escapePlaceId(placeId)}_${citationIdx}_${
         j + 1
       }${fileType}`,
     };
@@ -216,7 +216,7 @@ async function processPlace(
     entry.citations.flatMap((citation) => citation.attachments),
   );
   await fs.writeFile(
-    `city_detail/${rmSpace(placeId)}.html`,
+    `city_detail/${escapePlaceId(placeId)}.html`,
     renderHandlebars(placeId, entry, template),
   );
 }

--- a/scripts/updateCityDetail.ts
+++ b/scripts/updateCityDetail.ts
@@ -10,29 +10,29 @@ import Handlebars from "handlebars";
 import { DateTime } from "luxon";
 
 export type PlaceEntry = {
-  City: string;
-  State: string;
-  Summary: string;
-  "Verified By": string;
-  "Source Description": string;
-  Type: string;
-  URL: string;
-  Notes: string;
-  Attachments: string;
-  "Last updated": string;
-  "Create Time": string;
-  Status: string;
-  Uses: string;
-  "Reform Type": string;
-  Magnitude: string;
-  Requirements: string;
-  Reporter: string;
-  "Report Last updated": string;
-  "City Last Updated": string;
-  CitationID: string;
+  summary: string;
+  status: string;
+  policyChange: string;
+  landUse: string;
+  scope: string;
+  requirements: string;
+  reporter: string;
+  reportLastUpdated: DateTime<true>;
+  cityLastUpdated: DateTime<true>;
+  citations: Citation[];
 };
 
-type NormalizedAttachment = {
+type Citation = {
+  idx: number;
+  description: string;
+  type: string;
+  url: string;
+  notes: string;
+  lastUpdated: DateTime<true>;
+  attachments: Attachment[];
+};
+
+type Attachment = {
   url: string;
   fileName: string;
   isDoc: boolean;
@@ -47,6 +47,10 @@ const TIME_ZONE_MAPPING: Partial<Record<string, string>> = {
   PDT: "America/Los_Angeles",
   PST: "America/Los_Angeles",
 };
+
+function rmSpace(v: string): string {
+  return v.replace(/ /g, "");
+}
 
 export function parseDatetime(
   val: string,
@@ -67,7 +71,7 @@ export function parseDatetime(
   return result;
 }
 
-async function fetchData(): Promise<PlaceEntry[]> {
+async function fetchGTablesData(): Promise<Record<string, any>[]> {
   const response = await fetch(
     "https://area120tables.googleapis.com/link/aUJhBkwwY9j1NpD-Enh4WU/export?key=aasll5u2e8Xf-jxNNGlk3vbnOYcDsJn-JbgeI3z6IkPk8z5CxpWOLEp5EXd8iMF_bc",
     {
@@ -75,24 +79,63 @@ async function fetchData(): Promise<PlaceEntry[]> {
     },
   );
   const rawData = await response.text();
-  return Papa.parse(rawData, { header: true }).data as PlaceEntry[];
+  return Papa.parse(rawData, { header: true }).data as Record<string, any>[];
+}
+
+async function loadData(): Promise<Record<string, PlaceEntry>> {
+  // Google Tables stores one row per citation. A place may have >1 citation,
+  // but they share the same PlaceEntry data otherwise.
+  const gTablesData = await fetchGTablesData();
+
+  const result: Record<string, PlaceEntry> = {};
+  gTablesData.forEach((row) => {
+    if (!row.City) return;
+
+    const placeId = row.State ? `${row.City}_${row.State}` : row.City;
+    const citationIdx = result[placeId]
+      ? result[placeId].citations.length + 1
+      : 1;
+
+    const citation = {
+      idx: citationIdx,
+      description: row["Source Description"],
+      type: row.Type,
+      url: row.URL,
+      notes: row.Notes,
+      lastUpdated: parseDatetime(row["Last updated"]),
+      attachments: normalizeAttachments(row.Attachments, citationIdx, placeId),
+    };
+
+    if (result[placeId]) {
+      result[placeId].citations.push(citation);
+      return;
+    }
+
+    result[placeId] = {
+      summary: row.Summary,
+      status: row.Status,
+      policyChange: row["Reform Type"],
+      landUse: row.Uses,
+      scope: row.Magnitude,
+      requirements: row.Requirements,
+      reporter: row.Reporter,
+      reportLastUpdated: parseDatetime(row["Report Last updated"]),
+      cityLastUpdated: parseDatetime(row["City Last Updated"]),
+      citations: [citation],
+    };
+  });
+
+  return result;
 }
 
 export function needsUpdate(
-  placeEntries: PlaceEntry[],
+  entry: PlaceEntry,
   globalLastUpdated: DateTime<true>,
 ): boolean {
-  const lastUpdatedDates = placeEntries.map((row) =>
-    parseDatetime(row["Last updated"]),
-  );
-  const reportLastUpdated = parseDatetime(
-    placeEntries[0]["Report Last updated"],
-  );
-  const cityLastUpdated = parseDatetime(placeEntries[0]["City Last Updated"]);
   const maxLastUpdated = DateTime.max(
-    ...lastUpdatedDates,
-    reportLastUpdated,
-    cityLastUpdated,
+    ...entry.citations.map((x) => x.lastUpdated),
+    entry.reportLastUpdated,
+    entry.cityLastUpdated,
   );
   return maxLastUpdated >= globalLastUpdated;
 }
@@ -101,34 +144,29 @@ export function needsUpdate(
  Rewrite the entries' attachments field to a normalized object.
  */
 export function normalizeAttachments(
-  placeEntries: PlaceEntry[],
-  placeIdNoSpace: string,
-): NormalizedAttachment[] {
-  return placeEntries.reduce(
-    (result: NormalizedAttachment[], entry: PlaceEntry, i: number) => {
-      if (!entry.Attachments) {
-        return result;
-      }
-      const attachments = entry.Attachments.split(/\s+/).map((val, j) => {
-        const fileTypeMatch = val.match(/\.[a-zA-Z_]+$/);
-        const fileType = fileTypeMatch ? fileTypeMatch[0] : null;
-        return {
-          url: val,
-          fileName: new URL(val).pathname.split("/").pop()!,
-          isDoc: fileType === ".docx" || fileType === ".pdf",
-          outputPath: `attachment_images/${placeIdNoSpace}_${i + 1}_${
-            j + 1
-          }${fileType}`,
-        };
-      });
-      return [...result, ...attachments];
-    },
-    [],
-  );
+  attachments: string,
+  citationIdx: number,
+  placeId: string,
+): Attachment[] {
+  if (!attachments) {
+    return [];
+  }
+  return attachments.split(/\s+/).map((val, j) => {
+    const fileTypeMatch = val.match(/\.[a-zA-Z_]+$/);
+    const fileType = fileTypeMatch ? fileTypeMatch[0] : null;
+    return {
+      url: val,
+      fileName: new URL(val).pathname.split("/").pop()!,
+      isDoc: fileType === ".docx" || fileType === ".pdf",
+      outputPath: `attachment_images/${rmSpace(placeId)}_${citationIdx}_${
+        j + 1
+      }${fileType}`,
+    };
+  });
 }
 
 async function setupAttachmentDownloads(
-  attachments: NormalizedAttachment[],
+  attachments: Attachment[],
 ): Promise<void> {
   // Use await in a for loop to avoid making too many calls -> rate limiting.
   for (const attachment of attachments) {
@@ -144,53 +182,42 @@ async function setupAttachmentDownloads(
 }
 
 function renderHandlebars(
-  placeEntries: PlaceEntry[],
+  placeId: string,
+  entry: PlaceEntry,
   template: HandlebarsTemplateDelegate,
 ): string {
-  const citations = placeEntries.map((entry, i) => ({
-    idx: i + 1,
-    sourceDescription: entry["Source Description"],
-    type: entry.Type,
-    notes: entry.Notes,
-    url: entry.URL,
-    attachments: entry.Attachments,
-  }));
-  // The entries duplicate a lot of cells, so it's safe to simply look at the first
-  // entry to get the following information.
-  const entry0 = placeEntries[0];
   return template({
-    city: entry0.City,
-    state: entry0.State ? `, ${entry0.State}` : "",
-    summary: entry0.Summary,
-    status: entry0.Status,
-    reformType: entry0["Reform Type"],
-    uses: entry0.Uses,
-    magnitude: entry0.Magnitude,
-    requirements: entry0.Requirements,
-    reporter: entry0.Reporter,
-    citations,
+    placeId,
+    summary: entry.summary,
+    status: entry.status,
+    reformType: entry.policyChange,
+    landUse: entry.landUse,
+    scope: entry.scope,
+    requirements: entry.requirements,
+    reporter: entry.reporter,
+    citations: entry.citations,
   });
 }
 
 async function processPlace(
   placeId: string,
-  placeEntries: PlaceEntry[],
+  entry: PlaceEntry,
   template: HandlebarsTemplateDelegate,
   globalLastUpdated: DateTime<true>,
 ): Promise<void> {
-  if (!needsUpdate(placeEntries, globalLastUpdated)) {
+  if (!needsUpdate(entry, globalLastUpdated)) {
     console.log(`Skipping ${placeId}`);
     return;
   }
 
   console.log(`Updating ${placeId}`);
 
-  const placeIdNoSpace = placeId.replace(/ /g, "");
-  const attachments = normalizeAttachments(placeEntries, placeIdNoSpace);
-  await setupAttachmentDownloads(attachments);
+  await setupAttachmentDownloads(
+    entry.citations.flatMap((citation) => citation.attachments),
+  );
   await fs.writeFile(
-    `city_detail/${placeIdNoSpace}.html`,
-    renderHandlebars(placeEntries, template),
+    `city_detail/${rmSpace(placeId)}.html`,
+    renderHandlebars(placeId, entry, template),
   );
 }
 
@@ -207,25 +234,14 @@ async function main(): Promise<void> {
   const [rawGlobalLastUpdated, rawTemplate, data] = await Promise.all([
     fs.readFile(GLOBAL_LAST_UPDATED_FP, "utf-8"),
     fs.readFile("scripts/city_detail.html.handlebars", "utf-8"),
-    fetchData(),
+    loadData(),
   ]);
   const template = Handlebars.compile(rawTemplate);
   const globalLastUpdated = parseDatetime(rawGlobalLastUpdated, false);
 
-  // A place will have one entry per citation.
-  const entriesByPlaceId: Record<string, PlaceEntry[]> = {};
-  data.forEach((row) => {
-    if (!row.City) return;
-    const placeId = row.State ? `${row.City}_${row.State}` : row.City;
-    if (!entriesByPlaceId[placeId]) {
-      entriesByPlaceId[placeId] = [];
-    }
-    entriesByPlaceId[placeId].push(row);
-  });
-
   // Use await in a for loop to avoid making too many calls -> rate limiting.
-  for (const [placeId, placeEntries] of Object.entries(entriesByPlaceId)) {
-    await processPlace(placeId, placeEntries, template, globalLastUpdated);
+  for (const [placeId, entry] of Object.entries(data)) {
+    await processPlace(placeId, entry, template, globalLastUpdated);
   }
 
   await updateLastUpdatedFile();

--- a/tests/scripts/updateCityDetail.test.ts
+++ b/tests/scripts/updateCityDetail.test.ts
@@ -100,10 +100,10 @@ test.describe("needsUpdate()", () => {
 });
 
 test("normalizeAttachments() converts string entries into objects", () => {
-  expect(normalizeAttachments("", 1, "My City_AZ")).toEqual([]);
+  expect(normalizeAttachments("", 1, "My City, AZ")).toEqual([]);
 
   expect(
-    normalizeAttachments("https://prn.org/photo1.png", 1, "My City_AZ"),
+    normalizeAttachments("https://prn.org/photo1.png", 1, "My City, AZ"),
   ).toEqual([
     {
       url: "https://prn.org/photo1.png",
@@ -117,7 +117,7 @@ test("normalizeAttachments() converts string entries into objects", () => {
     normalizeAttachments(
       "https://prn.org/doc1.pdf https://prn.org/img2.jpg",
       2,
-      "My City_AZ",
+      "My City, AZ",
     ),
   ).toEqual([
     {

--- a/tests/scripts/updateCityDetail.test.ts
+++ b/tests/scripts/updateCityDetail.test.ts
@@ -12,130 +12,125 @@ import { readDataCsv } from "../../scripts/syncLatLng";
 
 test.describe("needsUpdate()", () => {
   test("returns false if everything is older than globalLastUpdated", () => {
-    const entryTime = "May 5, 2023, 8:00:00 AM PDT";
-    const entries = [
-      {
-        "Last updated": entryTime,
-        "Report Last updated": entryTime,
-        "City Last Updated": entryTime,
-      },
-      {
-        "Last updated": "May 4, 2023, 8:00:00 AM PDT",
-        "Report Last updated": entryTime,
-        "City Last Updated": entryTime,
-      },
-    ] as PlaceEntry[];
+    const entryTime = parseDatetime("May 5, 2023, 8:00:00 AM PDT");
+    const entry = {
+      reportLastUpdated: entryTime,
+      cityLastUpdated: entryTime,
+      citations: [
+        {
+          lastUpdated: entryTime,
+        },
+      ],
+    } as PlaceEntry;
     const globalLastUpdated = parseDatetime("May 8, 2023, 8:00:00 AM PDT");
-    expect(needsUpdate(entries, globalLastUpdated)).toBe(false);
+    expect(needsUpdate(entry, globalLastUpdated)).toBe(false);
   });
 
   test("returns true if the report has been updated recently", () => {
-    const entryTime = "May 5, 2023, 8:00:00 AM PDT";
-    const entries = [
-      {
-        "Last updated": entryTime,
-        "Report Last updated": "May 10, 2023, 8:00:00 AM PDT",
-        "City Last Updated": entryTime,
-      },
-      {
-        "Last updated": entryTime,
-        "Report Last updated": "May 10, 2023, 8:00:00 AM PDT",
-        "City Last Updated": entryTime,
-      },
-    ] as PlaceEntry[];
+    const entryTime = parseDatetime("May 5, 2023, 8:00:00 AM PDT");
+    const entry = {
+      reportLastUpdated: parseDatetime("May 10, 2023, 8:00:00 AM PDT"),
+      cityLastUpdated: entryTime,
+      citations: [
+        {
+          lastUpdated: entryTime,
+        },
+      ],
+    } as PlaceEntry;
     const globalLastUpdated = parseDatetime("May 6, 2023, 8:00:00 AM PDT");
-    expect(needsUpdate(entries, globalLastUpdated)).toBe(true);
+    expect(needsUpdate(entry, globalLastUpdated)).toBe(true);
   });
 
   test("returns true if the city has been updated recently", () => {
-    const entryTime = "May 5, 2023, 8:00:00 AM PDT";
-    const entries = [
-      {
-        "Last updated": entryTime,
-        "Report Last updated": entryTime,
-        "City Last Updated": "May 10, 2023, 8:00:00 AM PDT",
-      },
-      {
-        "Last updated": entryTime,
-        "Report Last updated": entryTime,
-        "City Last Updated": "May 10, 2023, 8:00:00 AM PDT",
-      },
-    ] as PlaceEntry[];
+    const entryTime = parseDatetime("May 5, 2023, 8:00:00 AM PDT");
+    const entry = {
+      reportLastUpdated: entryTime,
+      cityLastUpdated: parseDatetime("May 10, 2023, 8:00:00 AM PDT"),
+      citations: [
+        {
+          lastUpdated: entryTime,
+        },
+      ],
+    } as PlaceEntry;
     const globalLastUpdated = parseDatetime("May 6, 2023, 8:00:00 AM PDT");
-    expect(needsUpdate(entries, globalLastUpdated)).toBe(true);
+    expect(needsUpdate(entry, globalLastUpdated)).toBe(true);
   });
 
   test("returns true if at least one of the citations has been updated recently", () => {
-    const entryTime = "May 5, 2023, 8:00:00 AM PDT";
-    const entries = [
-      {
-        "Last updated": entryTime,
-        "Report Last updated": entryTime,
-        "City Last Updated": entryTime,
-      },
-      {
-        "Last updated": "May 10, 2023, 8:00:00 AM PDT",
-        "Report Last updated": entryTime,
-        "City Last Updated": entryTime,
-      },
-    ] as PlaceEntry[];
+    const entryTime = parseDatetime("May 5, 2023, 8:00:00 AM PDT");
+    const entry = {
+      reportLastUpdated: entryTime,
+      cityLastUpdated: entryTime,
+      citations: [
+        {
+          lastUpdated: entryTime,
+        },
+        {
+          lastUpdated: parseDatetime("May 10, 2023, 8:00:00 AM PDT"),
+        },
+      ],
+    } as PlaceEntry;
     const globalLastUpdated = parseDatetime("May 6, 2023, 8:00:00 AM PDT");
-    expect(needsUpdate(entries, globalLastUpdated)).toBe(true);
+    expect(needsUpdate(entry, globalLastUpdated)).toBe(true);
   });
 
   test("can handle different time zones", () => {
-    const entryTime = "May 5, 2023, 8:00:00 AM PDT";
-    const entries = [
-      {
-        "Last updated": "May 6, 2023, 12:00:00 PM PDT",
-        "Report Last updated": entryTime,
-        "City Last Updated": entryTime,
-      },
-      {
-        "Last updated": entryTime,
-        "Report Last updated": entryTime,
-        "City Last Updated": entryTime,
-      },
-    ] as PlaceEntry[];
+    const entryTime = parseDatetime("May 5, 2023, 8:00:00 AM PDT");
+    const entry = {
+      reportLastUpdated: entryTime,
+      cityLastUpdated: parseDatetime("May 6, 2023, 12:00:00 PM PDT"),
+      citations: [
+        {
+          lastUpdated: entryTime,
+        },
+      ],
+    } as PlaceEntry;
     // Even though 11 AM is naively earlier than 12 PM, due to time zones, the globalLastUpdated
     // happens after any of the city updates.
     let globalLastUpdated = parseDatetime(
       "May 6, 2023, 11:00:00 AM Pacific/Honolulu",
       false,
     );
-    expect(needsUpdate(entries, globalLastUpdated)).toBe(false);
+    expect(needsUpdate(entry, globalLastUpdated)).toBe(false);
 
-    // To be extra sure, we ensure that the time zone would return true.
+    // To be extra sure, we ensure that the same time zone would return true.
     globalLastUpdated = parseDatetime("May 6, 2023, 11:00:00 AM PDT");
-    expect(needsUpdate(entries, globalLastUpdated)).toBe(true);
+    expect(needsUpdate(entry, globalLastUpdated)).toBe(true);
   });
 });
 
 test("normalizeAttachments() converts string entries into objects", () => {
-  const input = [
-    { Attachments: "" },
-    { Attachments: "https://prn.org/photo1.png" },
-    { Attachments: "https://prn.org/doc1.pdf https://prn.org/img2.jpg" },
-  ] as PlaceEntry[];
-  const result = normalizeAttachments(input, "MyCity_AZ");
-  expect(result).toEqual([
+  expect(normalizeAttachments("", 1, "My City_AZ")).toEqual([]);
+
+  expect(
+    normalizeAttachments("https://prn.org/photo1.png", 1, "My City_AZ"),
+  ).toEqual([
     {
       url: "https://prn.org/photo1.png",
       fileName: "photo1.png",
       isDoc: false,
-      outputPath: "attachment_images/MyCity_AZ_2_1.png",
+      outputPath: "attachment_images/MyCity_AZ_1_1.png",
     },
+  ]);
+
+  expect(
+    normalizeAttachments(
+      "https://prn.org/doc1.pdf https://prn.org/img2.jpg",
+      2,
+      "My City_AZ",
+    ),
+  ).toEqual([
     {
       url: "https://prn.org/doc1.pdf",
       fileName: "doc1.pdf",
       isDoc: true,
-      outputPath: "attachment_images/MyCity_AZ_3_1.pdf",
+      outputPath: "attachment_images/MyCity_AZ_2_1.pdf",
     },
     {
       url: "https://prn.org/img2.jpg",
       fileName: "img2.jpg",
       isDoc: false,
-      outputPath: "attachment_images/MyCity_AZ_3_2.jpg",
+      outputPath: "attachment_images/MyCity_AZ_2_2.jpg",
     },
   ]);
 });


### PR DESCRIPTION
The modeling is complicated because a place may have >1 citation. The Google Table we use returns a row per citation, and those rows duplicate a lot of the core data about the city. Before, we were handling each row in the script throughout its lifetime. 

Now, we better pre-process the data to have one entry per place. The data now gets put into the shape of our Handlebars template. 

This change will unblock us storing the supplemental information we need to generate HTML pages into a JSON file.