### PR TITLE
Fix reform type on details pages

### DIFF
--- a/scripts/updateCityDetail.ts
+++ b/scripts/updateCityDetail.ts
@@ -191,7 +191,7 @@ function renderHandlebars(
     placeId,
     summary: entry.summary,
     status: entry.status,
-    reformType: entry.policyChange,
+    policyChange: entry.policyChange,
     landUse: entry.landUse,
     scope: entry.scope,
     requirements: entry.requirements,


### PR DESCRIPTION
This resulted in the field being left empty.