### PR TITLE
Use HEAD with link checker

### DIFF
--- a/scripts/brokenLinks.ts
+++ b/scripts/brokenLinks.ts
@@ -49,6 +49,7 @@ async function findDeadLinks(
       }
       try {
         const response = await fetch(link, {
+          method: "HEAD",
           headers: { "User-Agent": "prn-broken-links-finder" },
         });
         if (response.status >= 300) {


### PR DESCRIPTION
HEAD uses less data than GET. This should be faster and reduce the chance of rate limiting.