### PR TITLE
Generate CSV from JSON

### DIFF
--- a/.github/workflows/deploy-map-staging.yaml
+++ b/.github/workflows/deploy-map-staging.yaml
@@ -8,13 +8,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 18
+          node-version: 20
       - name: Install dependencies
         run: npm ci
+
       - name: Build
         run: npm run build
       - name: Run tests on dist

--- a/.github/workflows/deploy-static-pages.yaml
+++ b/.github/workflows/deploy-static-pages.yaml
@@ -1,4 +1,4 @@
-name: Deploy city details to prod
+name: Deploy static pages to prod
 on:
   push:
     branches: [main]
@@ -9,7 +9,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate CSV
+        run: npm run gen-csv
+      - name: Copy CSV to server
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{ secrets.PRN_FTP_HOST }}
+          username: ${{ secrets.PRN_SERVER_USERNAME }}
+          key: ${{ secrets.PRN_SERVER_PRIVATE_KEY }}
+          source: data/data.csv
+          target: /var/www/${{ secrets.PRN_SERVER_HOST }}/mandates-map/data.csv
+
       - name: Archive city_detail/ contents
         run: |
           cd city_detail

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -6,13 +6,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Install dependencies
         run: npm ci
+
       - name: Typecheck
         run: npm run check
       - name: Lint

--- a/.github/workflows/update-data.yaml
+++ b/.github/workflows/update-data.yaml
@@ -9,13 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
-          node-version: 18
+          node-version: 20
       - name: Install dependencies
         run: npm ci
+
       - name: Run update-city-detail
         run: npm run update-city-detail
       - name: Run update-map-data

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /update-lat-lng.csv
 /city.csv
 /report.csv
+/data/data.csv
 
 /node_modules
 tsconfig.tsbuildinfo

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "fmt": "prettier --write .",
     "fix": "prettier --write .; eslint --fix scripts/  tests/",
     "lint": "prettier --check . && eslint scripts/ tests/",
+    "gen-csv": "tsx scripts/generateCsv.ts",
     "update-city-detail": "tsx scripts/updateCityDetail.ts",
     "update-map-data": "tsx scripts/updateMapData.ts",
     "sync-lat-lng": "tsx scripts/syncLatLng.ts",

--- a/scripts/generateCsv.ts
+++ b/scripts/generateCsv.ts
@@ -1,3 +1,6 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-console */
+
 import fs from "fs/promises";
 
 import Papa from "papaparse";
@@ -6,25 +9,23 @@ import { readCompleteData } from "./lib/data";
 
 async function main(): Promise<void> {
   const completeData = await readCompleteData();
-  const data = Object.values(completeData).map((row) => {
-    return {
-      place: row.place,
-      state: row.state,
-      country: row.country,
-      all_minimums_repealed: row.repeal ? "TRUE" : "FALSE",
-      status: row.status,
-      policy_change: row.policy,
-      scope: row.scope,
-      land_uses: row.land,
-      reform_date: row.date,
-      population: row.pop,
-      lat: row.coord[0],
-      long: row.coord[1],
-      url: row.url,
-      reporter: row.reporter,
-      summary: row.summary,
-    };
-  });
+  const data = Object.values(completeData).map((row) => ({
+    place: row.place,
+    state: row.state,
+    country: row.country,
+    all_minimums_repealed: row.repeal ? "TRUE" : "FALSE",
+    status: row.status,
+    policy_change: row.policy,
+    scope: row.scope,
+    land_uses: row.land,
+    reform_date: row.date,
+    population: row.pop,
+    lat: row.coord[0],
+    long: row.coord[1],
+    url: row.url,
+    reporter: row.reporter,
+    summary: row.summary,
+  }));
   const csv = Papa.unparse(Object.values(data));
   await fs.writeFile("data/data.csv", csv);
 }

--- a/scripts/generateCsv.ts
+++ b/scripts/generateCsv.ts
@@ -1,0 +1,37 @@
+import fs from "fs/promises";
+
+import Papa from "papaparse";
+
+import { readCompleteData } from "./lib/data";
+
+async function main(): Promise<void> {
+  const completeData = await readCompleteData();
+  const data = Object.values(completeData).map((row) => {
+    return {
+      place: row.place,
+      state: row.state,
+      country: row.country,
+      all_minimums_repealed: row.repeal ? "TRUE" : "FALSE",
+      status: row.status,
+      policy_change: row.policy,
+      scope: row.scope,
+      land_uses: row.land,
+      reform_date: row.date,
+      population: row.pop,
+      lat: row.coord[0],
+      long: row.coord[1],
+      url: row.url,
+      reporter: row.reporter,
+      summary: row.summary,
+    };
+  });
+  const csv = Papa.unparse(Object.values(data));
+  await fs.writeFile("data/data.csv", csv);
+}
+
+if (process.env.NODE_ENV !== "test") {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}

--- a/scripts/lib/data.ts
+++ b/scripts/lib/data.ts
@@ -2,7 +2,36 @@ import fs from "fs/promises";
 
 import { RawEntry, PlaceId } from "../../src/js/types";
 
+export type ExtendedEntry = {
+  reporter: string | null;
+  updated: string;
+};
+
+export type CompleteEntry = RawEntry & ExtendedEntry;
+
 export async function readCoreData(): Promise<Record<PlaceId, RawEntry>> {
   const raw = await fs.readFile("data/core.json", "utf8");
   return JSON.parse(raw);
+}
+
+export async function readExtendedData(): Promise<
+  Record<PlaceId, ExtendedEntry>
+> {
+  const raw = await fs.readFile("data/extended.json", "utf8");
+  return JSON.parse(raw);
+}
+
+export async function readCompleteData(): Promise<
+  Record<PlaceId, CompleteEntry>
+> {
+  const [coreData, extendedData] = await Promise.all([
+    readCoreData(),
+    readExtendedData(),
+  ]);
+  return Object.fromEntries(
+    Object.entries(coreData).map(([placeId, core]) => [
+      placeId,
+      { ...core, ...extendedData[placeId] },
+    ]),
+  );
 }


### PR DESCRIPTION
Follow up to https://github.com/ParkingReformNetwork/reform-map/pull/494. This will allow us to make JSON the source of truth, rather than `map/data.csv`.

Note that we can now be much more flexible with what we put in the CSV. In the future, we can add more data to the CSV without worrying about bloating our runtime app. We also now do data transformations like how we handle booleans.