### PR TITLE
Remove `updated` from extended.json

### DIFF
--- a/data/extended.json
+++ b/data/extended.json
@@ -1,7 +1,6 @@
 {
   "29 Palms, CA": {
     "reporter": "Ellen Schwartz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21,7 +20,6 @@
   },
   "Abbottstown, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 12, 2024, 4:29:40 PM UTC",
     "requirements": ["Other", "Frequent Transit"],
     "citations": [
       {
@@ -46,7 +44,6 @@
   },
   "Aberdeen, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 2, 2024, 10:38:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66,7 +63,6 @@
   },
   "Aberdeen, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -86,7 +82,6 @@
   },
   "Abilene, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -106,7 +101,6 @@
   },
   "Abilene, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 10:26:01 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -126,7 +120,6 @@
   },
   "Ackley, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -146,7 +139,6 @@
   },
   "Ada Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 4, 2024, 10:44:28 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -166,7 +158,6 @@
   },
   "Ada, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 5, 2024, 6:11:57 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -186,7 +177,6 @@
   },
   "Ada, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -206,7 +196,6 @@
   },
   "Adams County, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 7:30:18 PM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -252,7 +241,6 @@
   },
   "Adrian, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 31, 2024, 6:50:26 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -272,7 +260,6 @@
   },
   "Aiken, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -292,7 +279,6 @@
   },
   "Aitkin, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "December 29, 2023, 1:04:45 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -317,7 +303,6 @@
   },
   "Akron, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 4, 2024, 5:46:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -347,7 +332,6 @@
   },
   "Akron, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -367,7 +351,6 @@
   },
   "Akron, OH": {
     "reporter": "Jason Segedy",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -387,7 +370,6 @@
   },
   "Alameda County, CA": {
     "reporter": "Patrick Siegman",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -433,7 +415,6 @@
   },
   "Alameda, CA": {
     "reporter": "John Knox White",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -460,7 +441,6 @@
   },
   "Albany, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -480,7 +460,6 @@
   },
   "Albany, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": [
       "Size of Project",
       "By Right",
@@ -532,7 +511,6 @@
   },
   "Albany, OR": {
     "reporter": "Tony Jordan",
-    "updated": "May 12, 2024, 3:34:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -565,7 +543,6 @@
   },
   "Albany, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -585,7 +562,6 @@
   },
   "Albemarle, NC": {
     "reporter": "Kevin Robinson",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -605,7 +581,6 @@
   },
   "Albert Lea, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -625,7 +600,6 @@
   },
   "Alberton, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -645,7 +619,6 @@
   },
   "Albion, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 3:20:11 PM UTC",
     "requirements": ["Bike Parking", "Size of Project"],
     "citations": [
       {
@@ -665,7 +638,6 @@
   },
   "Albion, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -685,7 +657,6 @@
   },
   "Albion, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 24, 2024, 6:18:23 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -705,7 +676,6 @@
   },
   "Albuquerque, NM": {
     "reporter": "Carrie Barkhurst",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -738,7 +708,6 @@
   },
   "Aledo, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -758,7 +727,6 @@
   },
   "Alexandria, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -778,7 +746,6 @@
   },
   "Alexandria, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 7:58:31 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -808,7 +775,6 @@
   },
   "Alexandria, MN": {
     "reporter": "Michael Weber",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -828,7 +794,6 @@
   },
   "Alexandria, VA": {
     "reporter": "",
-    "updated": "May 19, 2024, 4:52:56 AM UTC",
     "requirements": ["Affordable Housing", "Frequent Transit", "By Right"],
     "citations": [
       {
@@ -888,7 +853,6 @@
   },
   "Algona, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -908,7 +872,6 @@
   },
   "Alleman, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -928,7 +891,6 @@
   },
   "Allen Park, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 3:57:16 AM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -953,7 +915,6 @@
   },
   "Allentown, PA": {
     "reporter": "Craig Beavers",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Size of Project", "By Right", "Bike Parking"],
     "citations": [
       {
@@ -978,7 +939,6 @@
   },
   "Alliance, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -998,7 +958,6 @@
   },
   "Allouez, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Bike Parking", "Other"],
     "citations": [
       {
@@ -1023,7 +982,6 @@
   },
   "Alma, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 9, 2024, 5:55:58 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -1043,7 +1001,6 @@
   },
   "Alma, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1063,7 +1020,6 @@
   },
   "Alma, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1083,7 +1039,6 @@
   },
   "Alpena Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -1108,7 +1063,6 @@
   },
   "Alpena, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right", "Size of Project", "Bike Parking", "Other"],
     "citations": [
       {
@@ -1148,7 +1102,6 @@
   },
   "Alpha, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 2:31:46 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1168,7 +1121,6 @@
   },
   "Alta, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1188,7 +1140,6 @@
   },
   "Alton, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1208,7 +1159,6 @@
   },
   "Altoona, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -1228,7 +1178,6 @@
   },
   "Altoona, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 2:14:06 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1248,7 +1197,6 @@
   },
   "Altoona, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1273,7 +1221,6 @@
   },
   "Altus, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 6:14:57 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -1293,7 +1240,6 @@
   },
   "Alva, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 6:53:09 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1313,7 +1259,6 @@
   },
   "Amanda, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 4:14:17 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1333,7 +1278,6 @@
   },
   "Amarillo, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "December 9, 2023, 1:05:11 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1353,7 +1297,6 @@
   },
   "Ambridge, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 9, 2024, 5:49:22 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1383,7 +1326,6 @@
   },
   "Ames, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1413,7 +1355,6 @@
   },
   "Amherst, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1433,7 +1374,6 @@
   },
   "Anaconda-Deer Lodge County, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1463,7 +1403,6 @@
   },
   "Anacortes, WA": {
     "reporter": "Scott Bonjukian",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1501,7 +1440,6 @@
   },
   "Anaheim, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 9:09:10 PM UTC",
     "requirements": [
       "By Right",
       "ADU",
@@ -1534,7 +1472,6 @@
   },
   "Anamosa, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1554,7 +1491,6 @@
   },
   "Anchorage, AK": {
     "reporter": "Jamin Agosti",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1581,7 +1517,6 @@
   },
   "Anchorage, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "August 4, 2024, 3:35:14 AM UTC",
     "requirements": ["By Right", "Size of Project", "Historic Preservation"],
     "citations": [
       {
@@ -1606,7 +1541,6 @@
   },
   "Anderson, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -1626,7 +1560,6 @@
   },
   "Angola, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1656,7 +1589,6 @@
   },
   "Ankeny, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1676,7 +1608,6 @@
   },
   "Ann Arbor, MI": {
     "reporter": "Brad Wu",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1714,7 +1645,6 @@
   },
   "Anna, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1734,7 +1664,6 @@
   },
   "Annandale, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1754,7 +1683,6 @@
   },
   "Annapolis, MD": {
     "reporter": "Ted J Sheils",
-    "updated": "May 11, 2024, 5:13:33 PM UTC",
     "requirements": ["Other", "Size of Project", "By Right"],
     "citations": [
       {
@@ -1810,7 +1738,6 @@
   },
   "Anne Arundel County, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 6:09:48 AM UTC",
     "requirements": ["By Right", "Frequent Transit", "Bike Parking"],
     "citations": [
       {
@@ -1830,7 +1757,6 @@
   },
   "Anoka, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1850,7 +1776,6 @@
   },
   "Antigo, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -1875,7 +1800,6 @@
   },
   "Antioch, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -1895,7 +1819,6 @@
   },
   "Appleton, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1915,7 +1838,6 @@
   },
   "Appleton, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1935,7 +1857,6 @@
   },
   "Arcadia, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 25, 2024, 4:01:43 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -1955,7 +1876,6 @@
   },
   "Arcata, CA": {
     "reporter": "Colin Fiske",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -1975,7 +1895,6 @@
   },
   "Archbold, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -1995,7 +1914,6 @@
   },
   "Arcola, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2015,7 +1933,6 @@
   },
   "Ardmore, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2035,7 +1952,6 @@
   },
   "Argyle, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2055,7 +1971,6 @@
   },
   "Arkansas City, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2075,7 +1990,6 @@
   },
   "Arlington Heights, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2095,7 +2009,6 @@
   },
   "Arlington, MA": {
     "reporter": "Vincent Baudoin",
-    "updated": "March 7, 2024, 9:16:25 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2115,7 +2028,6 @@
   },
   "Arlington, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -2145,7 +2057,6 @@
   },
   "Arlington, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 11:14:28 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -2170,7 +2081,6 @@
   },
   "Armada, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 8:21:29 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -2195,7 +2105,6 @@
   },
   "Armadale, WA": {
     "reporter": "Samuel Deetz",
-    "updated": "April 13, 2024, 5:28:49 AM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -2238,7 +2147,6 @@
   },
   "Arnolds Park, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2258,7 +2166,6 @@
   },
   "Arvada, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 25, 2024, 4:42:01 AM UTC",
     "requirements": [
       "Frequent Transit",
       "Bike Parking",
@@ -2304,7 +2211,6 @@
   },
   "Ascension Parish, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 6:11:03 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -2324,7 +2230,6 @@
   },
   "Asheville, NC": {
     "reporter": "Joe Minicozzi",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2344,7 +2249,6 @@
   },
   "Ashland, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 27, 2024, 1:51:19 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2364,7 +2268,6 @@
   },
   "Ashland, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2384,7 +2287,6 @@
   },
   "Ashland, OR": {
     "reporter": "Derek Severson",
-    "updated": "May 12, 2024, 3:14:26 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2430,7 +2332,6 @@
   },
   "Ashland, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 12:50:59 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2450,7 +2351,6 @@
   },
   "Ashtabula, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2470,7 +2370,6 @@
   },
   "Ashville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 10, 2024, 7:20:19 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2490,7 +2389,6 @@
   },
   "Ashwaubenon, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -2510,7 +2408,6 @@
   },
   "Aspen, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 7:46:15 PM UTC",
     "requirements": ["In Lieu Fees", "TDM"],
     "citations": [
       {
@@ -2555,7 +2452,6 @@
   },
   "Atchison, KS": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -2580,7 +2476,6 @@
   },
   "Atglen, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 29, 2024, 12:49:59 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2600,7 +2495,6 @@
   },
   "Athens, OH": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": [
       "By Right",
       "Other",
@@ -2631,7 +2525,6 @@
   },
   "Athens, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2651,7 +2544,6 @@
   },
   "Athens-Clarke County, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 8:51:24 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -2676,7 +2568,6 @@
   },
   "Atkinson, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2696,7 +2587,6 @@
   },
   "Atlanta, GA": {
     "reporter": "Caleb Racicot",
-    "updated": "February 20, 2024, 2:14:32 AM UTC",
     "requirements": ["By Right", "Affordable Housing", "Historic Preservation"],
     "citations": [
       {
@@ -2773,7 +2663,6 @@
   },
   "Auburn Hills, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 10:28:12 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2793,7 +2682,6 @@
   },
   "Auburn, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2813,7 +2701,6 @@
   },
   "Auburn, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2838,7 +2725,6 @@
   },
   "Auburn, ME": {
     "reporter": "",
-    "updated": "August 24, 2024, 4:06:47 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2886,7 +2772,6 @@
   },
   "Auburn, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 25, 2024, 2:27:41 AM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -2906,7 +2791,6 @@
   },
   "Auburn, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2926,7 +2810,6 @@
   },
   "Augsburg, BY": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 2:46:44 AM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -2946,7 +2829,6 @@
   },
   "Augusta Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 9:29:26 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -2966,7 +2848,6 @@
   },
   "Augusta, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 5:27:02 PM UTC",
     "requirements": ["Other", "By Right", "Bike Parking"],
     "citations": [
       {
@@ -2991,7 +2872,6 @@
   },
   "Augusta, ME": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 8:55:58 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -3011,7 +2891,6 @@
   },
   "Aurelia, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3031,7 +2910,6 @@
   },
   "Aurora, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "January 22, 2024, 9:08:13 PM UTC",
     "requirements": [
       "By Right",
       "Other",
@@ -3077,7 +2955,6 @@
   },
   "Aurora, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3097,7 +2974,6 @@
   },
   "Aurora, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3117,7 +2993,6 @@
   },
   "Aurora, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3137,7 +3012,6 @@
   },
   "Aurora, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3157,7 +3031,6 @@
   },
   "Austin, TX": {
     "reporter": "Dan Keshet",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3198,7 +3071,6 @@
   },
   "Auxvasse, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3218,7 +3090,6 @@
   },
   "Avalon, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 21, 2024, 3:51:23 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3238,7 +3109,6 @@
   },
   "Avilla, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3258,7 +3128,6 @@
   },
   "Avon Lake, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3278,7 +3147,6 @@
   },
   "Avon, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 7:53:21 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3298,7 +3166,6 @@
   },
   "Avon, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3318,7 +3185,6 @@
   },
   "Badin, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3338,7 +3204,6 @@
   },
   "Bagley, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3358,7 +3223,6 @@
   },
   "Baker, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -3378,7 +3242,6 @@
   },
   "Bakersfield, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 20, 2024, 1:06:52 AM UTC",
     "requirements": ["Frequent Transit", "Other", "Affordable Housing"],
     "citations": [
       {
@@ -3418,7 +3281,6 @@
   },
   "Baldwin, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 24, 2024, 9:56:08 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -3438,7 +3300,6 @@
   },
   "Baldwin, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3458,7 +3319,6 @@
   },
   "Ballwin, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3478,7 +3338,6 @@
   },
   "Baltic, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3498,7 +3357,6 @@
   },
   "Baltimore County, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 7:16:09 PM UTC",
     "requirements": ["Frequent Transit"],
     "citations": [
       {
@@ -3518,7 +3376,6 @@
   },
   "Baltimore, MD": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3543,7 +3400,6 @@
   },
   "Baltimore, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 4:18:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3563,7 +3419,6 @@
   },
   "Bandera, TX": {
     "reporter": "Matt Lewis",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3583,7 +3438,6 @@
   },
   "Bangor, ME": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 2:48:36 AM UTC",
     "requirements": ["By Right", "ADU", "Size of Project", "Other"],
     "citations": [
       {
@@ -3603,7 +3457,6 @@
   },
   "Baraboo, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3623,7 +3476,6 @@
   },
   "Barberton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 11, 2024, 8:12:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3643,7 +3495,6 @@
   },
   "Bargersville, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3663,7 +3514,6 @@
   },
   "Barnesville, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3683,7 +3533,6 @@
   },
   "Barneveld, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -3703,7 +3552,6 @@
   },
   "Barrington Hills, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 28, 2023, 7:27:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3723,7 +3571,6 @@
   },
   "Barrington, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 5:02:26 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3743,7 +3590,6 @@
   },
   "Barron, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3763,7 +3609,6 @@
   },
   "Bartlesville, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 4:43:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3783,7 +3628,6 @@
   },
   "Bartlett, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -3803,7 +3647,6 @@
   },
   "Basalt, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 7:27:22 PM UTC",
     "requirements": [
       "In Lieu Fees",
       "Other",
@@ -3843,7 +3686,6 @@
   },
   "Basin, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -3863,7 +3705,6 @@
   },
   "Bastrop, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 6:26:56 PM UTC",
     "requirements": ["By Right", "Car Share", "Tree Preservation", "Other"],
     "citations": [
       {
@@ -3888,7 +3729,6 @@
   },
   "Bastrop, TX": {
     "reporter": "Matt Jones",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3908,7 +3748,6 @@
   },
   "Batavia, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -3938,7 +3777,6 @@
   },
   "Batavia, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -3958,7 +3796,6 @@
   },
   "Batesville, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -3978,7 +3815,6 @@
   },
   "Batesville, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -3998,7 +3834,6 @@
   },
   "Batesville, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 2, 2024, 9:55:35 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -4018,7 +3853,6 @@
   },
   "Bath Charter Township, MI": {
     "reporter": "Nick Tafelsky",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -4045,7 +3879,6 @@
   },
   "Bath, ME": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4059,7 +3892,6 @@
   },
   "Baton Rouge, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 8:57:15 PM UTC",
     "requirements": [
       "By Right",
       "Tree Preservation",
@@ -4104,7 +3936,6 @@
   },
   "Battle Creek, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 3:29:20 PM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -4134,7 +3965,6 @@
   },
   "Baudette, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4154,7 +3984,6 @@
   },
   "Bay City, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 25, 2024, 1:54:27 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4174,7 +4003,6 @@
   },
   "Bayard, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4194,7 +4022,6 @@
   },
   "Bayfield, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -4214,7 +4041,6 @@
   },
   "Bayfield, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4234,7 +4060,6 @@
   },
   "Bear Lake, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 6:28:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4259,7 +4084,6 @@
   },
   "Beatrice, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4279,7 +4103,6 @@
   },
   "Beaumont, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 8:22:51 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -4304,7 +4127,6 @@
   },
   "Beaver Falls, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 25, 2024, 6:04:04 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4324,7 +4146,6 @@
   },
   "Beaver, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 9, 2024, 5:56:15 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4344,7 +4165,6 @@
   },
   "Beaverton, OR": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4358,7 +4178,6 @@
   },
   "Bedford Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 5, 2024, 12:29:28 AM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -4388,7 +4207,6 @@
   },
   "Bedford, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4408,7 +4226,6 @@
   },
   "Beijing, BJ": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 8:37:29 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4428,7 +4245,6 @@
   },
   "Bel Air, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 11, 2024, 3:17:57 AM UTC",
     "requirements": ["By Right", "Size of Project", "In Lieu Fees"],
     "citations": [
       {
@@ -4453,7 +4269,6 @@
   },
   "Belding, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 6:10:58 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -4473,7 +4288,6 @@
   },
   "Belfast, ME": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4498,7 +4312,6 @@
   },
   "Bella Vista, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4518,7 +4331,6 @@
   },
   "Bellaire, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4538,7 +4350,6 @@
   },
   "Bellbrook, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 5, 2024, 4:09:27 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4558,7 +4369,6 @@
   },
   "Belle Center, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 5:32:50 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -4578,7 +4388,6 @@
   },
   "Belle Fourche, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4598,7 +4407,6 @@
   },
   "Belle Plaine, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4618,7 +4426,6 @@
   },
   "Belle Plaine, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4638,7 +4445,6 @@
   },
   "Bellefontaine Neighbors, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4658,7 +4464,6 @@
   },
   "Bellefonte, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -4678,7 +4483,6 @@
   },
   "Bellefonte, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 25, 2024, 10:39:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4718,7 +4522,6 @@
   },
   "Belleville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -4738,7 +4541,6 @@
   },
   "Belleville, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4758,7 +4560,6 @@
   },
   "Belleville, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4778,7 +4579,6 @@
   },
   "Bellevue, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4798,7 +4598,6 @@
   },
   "Bellevue, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4818,7 +4617,6 @@
   },
   "Bellevue, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 21, 2024, 3:54:18 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4838,7 +4636,6 @@
   },
   "Bellevue, WA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 20, 2024, 11:52:03 PM UTC",
     "requirements": ["Frequent Transit", "By Right"],
     "citations": [
       {
@@ -4878,7 +4675,6 @@
   },
   "Bellflower, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 2:28:34 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4898,7 +4694,6 @@
   },
   "Bellingham, WA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4918,7 +4713,6 @@
   },
   "Bellwood, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -4938,7 +4732,6 @@
   },
   "Bellwood, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4958,7 +4751,6 @@
   },
   "Belmond, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -4978,7 +4770,6 @@
   },
   "Belmont, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Size of Project", "By Right", "Other"],
     "citations": [
       {
@@ -5003,7 +4794,6 @@
   },
   "Beloit, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5023,7 +4813,6 @@
   },
   "Belvidere, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -5043,7 +4832,6 @@
   },
   "Ben Avon, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 21, 2024, 3:58:09 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5063,7 +4851,6 @@
   },
   "Bend, OR": {
     "reporter": "Melanie Kebler",
-    "updated": "April 17, 2024, 5:00:05 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5096,7 +4883,6 @@
   },
   "Bennet, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5116,7 +4902,6 @@
   },
   "Bennington, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -5136,7 +4921,6 @@
   },
   "Bensenville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 28, 2023, 11:14:20 PM UTC",
     "requirements": ["Other", "Frequent Transit", "Car Share", "In Lieu Fees"],
     "citations": [
       {
@@ -5161,7 +4945,6 @@
   },
   "Benton Harbor, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 9:48:50 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -5186,7 +4969,6 @@
   },
   "Benton, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5211,7 +4993,6 @@
   },
   "Benton, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5231,7 +5012,6 @@
   },
   "Benton, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5251,7 +5031,6 @@
   },
   "Benton, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5271,7 +5050,6 @@
   },
   "Bentonville, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -5296,7 +5074,6 @@
   },
   "Benzonia, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "December 9, 2023, 1:31:30 AM UTC",
     "requirements": ["Bike Parking", "Other", "By Right"],
     "citations": [
       {
@@ -5316,7 +5093,6 @@
   },
   "Beresford, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5336,7 +5112,6 @@
   },
   "Berkeley, CA": {
     "reporter": "Tom Radulovich",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5361,7 +5136,6 @@
   },
   "Berkley, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 10:35:23 PM UTC",
     "requirements": ["Bike Parking", "Other"],
     "citations": [
       {
@@ -5386,7 +5160,6 @@
   },
   "Berlin, BE": {
     "reporter": "Samuel Deetz",
-    "updated": "March 7, 2024, 10:24:19 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5406,7 +5179,6 @@
   },
   "Berlin, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 10, 2024, 5:36:16 AM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -5426,7 +5198,6 @@
   },
   "Bernice, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 6:15:22 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5446,7 +5217,6 @@
   },
   "Berrien Springs, MI": {
     "reporter": "Andrew von Mauer",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5479,7 +5249,6 @@
   },
   "Berryville, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5499,7 +5268,6 @@
   },
   "Berthold, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -5519,7 +5287,6 @@
   },
   "Berthoud, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 11:07:12 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -5544,7 +5311,6 @@
   },
   "Bertrand Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 5, 2024, 12:38:10 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -5569,7 +5335,6 @@
   },
   "Berwick, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 11, 2024, 2:21:52 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5589,7 +5354,6 @@
   },
   "Berwyn, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["Other", "Frequent Transit", "By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -5609,7 +5373,6 @@
   },
   "Bessemer City, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -5639,7 +5402,6 @@
   },
   "Bessemer, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5659,7 +5421,6 @@
   },
   "Bethany Beach, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5679,7 +5440,6 @@
   },
   "Bethel, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -5699,7 +5459,6 @@
   },
   "Bethlehem, PA": {
     "reporter": "Megan Lysowski",
-    "updated": "January 23, 2024, 2:06:03 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5719,7 +5478,6 @@
   },
   "Beulah, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "December 9, 2023, 1:36:09 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5739,7 +5497,6 @@
   },
   "Beverly Hills, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 5:17:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5759,7 +5516,6 @@
   },
   "Bexley, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 5:20:20 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -5789,7 +5545,6 @@
   },
   "Big Lake, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 21, 2024, 3:52:12 AM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -5809,7 +5564,6 @@
   },
   "Big Rapids, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 6, 2024, 5:11:25 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -5834,7 +5588,6 @@
   },
   "Big Rock, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -5854,7 +5607,6 @@
   },
   "Big Timber, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -5874,7 +5626,6 @@
   },
   "Billings, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5894,7 +5645,6 @@
   },
   "Billings, MT": {
     "reporter": "Randy Vinson",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5927,7 +5677,6 @@
   },
   "Biloxi, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5947,7 +5696,6 @@
   },
   "Binghamton, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 2:08:00 AM UTC",
     "requirements": ["Other", "Size of Project"],
     "citations": [
       {
@@ -5977,7 +5725,6 @@
   },
   "Birchwood, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -5997,7 +5744,6 @@
   },
   "Birmingham, AL": {
     "reporter": "Daniel Christiansen",
-    "updated": "May 10, 2024, 8:14:55 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6056,7 +5802,6 @@
   },
   "Birmingham, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 19, 2024, 6:01:16 PM UTC",
     "requirements": ["Historic Preservation", "Other", "In Lieu Fees"],
     "citations": [
       {
@@ -6086,7 +5831,6 @@
   },
   "Biron, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6106,7 +5850,6 @@
   },
   "Bismarck, ND": {
     "reporter": "Kate Herzog",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6126,7 +5869,6 @@
   },
   "Bixby, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 5:33:06 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6146,7 +5888,6 @@
   },
   "Black Creek, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6166,7 +5907,6 @@
   },
   "Black Hawk County, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 2, 2024, 6:13:00 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6186,7 +5926,6 @@
   },
   "Black Hawk, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 15, 2024, 6:34:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -6206,7 +5945,6 @@
   },
   "Black River Falls, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6226,7 +5964,6 @@
   },
   "Blaine, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 20, 2024, 9:08:08 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6246,7 +5983,6 @@
   },
   "Blissfield, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 2:13:10 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6266,7 +6002,6 @@
   },
   "Bloomfield Hills, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 19, 2024, 6:05:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6286,7 +6021,6 @@
   },
   "Bloomfield, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6306,7 +6040,6 @@
   },
   "Bloomington, IL": {
     "reporter": "Noah Tang",
-    "updated": "April 13, 2024, 1:23:57 AM UTC",
     "requirements": ["By Right", "Frequent Transit", "Other"],
     "citations": [
       {
@@ -6344,7 +6077,6 @@
   },
   "Bloomington, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6369,7 +6101,6 @@
   },
   "Bloomsburg, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 11, 2024, 2:17:53 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6389,7 +6120,6 @@
   },
   "Blue Ash, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 7:00:05 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -6414,7 +6144,6 @@
   },
   "Blue Earth, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 20, 2024, 10:19:26 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6434,7 +6163,6 @@
   },
   "Blue Island, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 4:37:34 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -6467,7 +6195,6 @@
   },
   "Blue River, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 5, 2024, 3:00:29 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6487,7 +6214,6 @@
   },
   "Blue Springs, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Other", "Bike Parking"],
     "citations": [
       {
@@ -6512,7 +6238,6 @@
   },
   "Bluefield, WV": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6532,7 +6257,6 @@
   },
   "Boiling Springs, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6562,7 +6286,6 @@
   },
   "Boise, ID": {
     "reporter": "Matthew Pabich",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": [
       "By Right",
       "Tree Preservation",
@@ -6604,7 +6327,6 @@
   },
   "Bolivar, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6624,7 +6346,6 @@
   },
   "Bolivar, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 12, 2024, 3:09:03 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -6644,7 +6365,6 @@
   },
   "Bonduel, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6664,7 +6384,6 @@
   },
   "Bonn, NW": {
     "reporter": "Samuel Deetz",
-    "updated": "May 3, 2024, 3:13:17 AM UTC",
     "requirements": ["By Right", "In Lieu Fees", "Other", "Car Share"],
     "citations": [
       {
@@ -6699,7 +6418,6 @@
   },
   "Boone County, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6719,7 +6437,6 @@
   },
   "Boone, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6739,7 +6456,6 @@
   },
   "Boonsboro, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 8:31:27 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6759,7 +6475,6 @@
   },
   "Bossier City, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6779,7 +6494,6 @@
   },
   "Boston Heights, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 12, 2024, 1:26:40 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6799,7 +6513,6 @@
   },
   "Boston, MA": {
     "reporter": "",
-    "updated": "August 24, 2024, 4:15:12 AM UTC",
     "requirements": ["Affordable Housing"],
     "citations": [
       {
@@ -6850,7 +6563,6 @@
   },
   "Boulder City, NV": {
     "reporter": "Michael Mays",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6870,7 +6582,6 @@
   },
   "Boulder, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 4, 2024, 2:23:35 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6900,7 +6611,6 @@
   },
   "Bourbonnais, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -6920,7 +6630,6 @@
   },
   "Bowling Green, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6940,7 +6649,6 @@
   },
   "Bowling Green, OH": {
     "reporter": "Heather Sayler",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6960,7 +6668,6 @@
   },
   "Bowman, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -6980,7 +6687,6 @@
   },
   "Boyd, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7000,7 +6706,6 @@
   },
   "Boyertown, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 18, 2024, 5:02:52 AM UTC",
     "requirements": ["In Lieu Fees", "By Right", "Other"],
     "citations": [
       {
@@ -7025,7 +6730,6 @@
   },
   "Boyne City, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7045,7 +6749,6 @@
   },
   "Bozeman, MT": {
     "reporter": "David Fine",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7065,7 +6768,6 @@
   },
   "Braceville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 3:20:29 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7085,7 +6787,6 @@
   },
   "Bradford, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 17, 2024, 5:34:06 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7105,7 +6806,6 @@
   },
   "Brady, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7125,7 +6825,6 @@
   },
   "Braham, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7145,7 +6844,6 @@
   },
   "Brainerd, MN": {
     "reporter": "Mark Ostgarden",
-    "updated": "January 3, 2024, 6:51:29 PM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -7201,7 +6899,6 @@
   },
   "Brandenburg, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7221,7 +6918,6 @@
   },
   "Brandon, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -7241,7 +6937,6 @@
   },
   "Brandon, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7261,7 +6956,6 @@
   },
   "Brandon, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7281,7 +6975,6 @@
   },
   "Branson, MO": {
     "reporter": "Joel Hornickel",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7301,7 +6994,6 @@
   },
   "Brattleboro, VT": {
     "reporter": "Brian Bannon",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7326,7 +7018,6 @@
   },
   "Breckenridge, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 5, 2024, 3:37:42 AM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -7356,7 +7047,6 @@
   },
   "Breckenridge, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 9, 2024, 6:11:47 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -7376,7 +7066,6 @@
   },
   "Bremerhaven, HB": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 9:41:36 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -7406,7 +7095,6 @@
   },
   "Brentwood, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 21, 2024, 3:25:37 AM UTC",
     "requirements": ["Size of Project", "By Right", "Other"],
     "citations": [
       {
@@ -7426,7 +7114,6 @@
   },
   "Brevard, NC": {
     "reporter": "Aaron Bland",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -7446,7 +7133,6 @@
   },
   "Bridgeport Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 9, 2024, 10:13:27 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -7466,7 +7152,6 @@
   },
   "Bridgeport, CT": {
     "reporter": "Lynn Haig",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7486,7 +7171,6 @@
   },
   "Bridgman, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 10:18:12 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -7516,7 +7200,6 @@
   },
   "Brighton Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 9:00:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7536,7 +7219,6 @@
   },
   "Brighton, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 10:57:52 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other", "Bike Parking"],
     "citations": [
       {
@@ -7561,7 +7243,6 @@
   },
   "Brighton, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 8:46:45 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -7581,7 +7262,6 @@
   },
   "Brimfield, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7601,7 +7281,6 @@
   },
   "Bristol, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 22, 2024, 4:24:07 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -7621,7 +7300,6 @@
   },
   "Bristol, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 5:21:09 AM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -7651,7 +7329,6 @@
   },
   "Broadview, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7671,7 +7348,6 @@
   },
   "Brodhead, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "April 13, 2024, 12:37:23 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7691,7 +7367,6 @@
   },
   "Broken Arrow, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7711,7 +7386,6 @@
   },
   "Broken Bow, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7731,7 +7405,6 @@
   },
   "Bromont, QC": {
     "reporter": "Etienne Lefebvre",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -7751,7 +7424,6 @@
   },
   "Bronson, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 31, 2024, 1:42:02 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -7771,7 +7443,6 @@
   },
   "Brookfield, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7791,7 +7462,6 @@
   },
   "Brookfield, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "April 13, 2024, 12:47:15 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7811,7 +7481,6 @@
   },
   "Brookhaven, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 21, 2024, 5:45:53 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7831,7 +7500,6 @@
   },
   "Brookings, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7851,7 +7519,6 @@
   },
   "Brookline, MA": {
     "reporter": "Michael Zoorob",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -7884,7 +7551,6 @@
   },
   "Brooklyn Center, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7904,7 +7570,6 @@
   },
   "Brooklyn Park, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Frequent Transit", "Other"],
     "citations": [
       {
@@ -7924,7 +7589,6 @@
   },
   "Brooklyn, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 10:43:06 PM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -7949,7 +7613,6 @@
   },
   "Brookville, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "September 1, 2024, 2:29:36 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7969,7 +7632,6 @@
   },
   "Broomfield, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 15, 2024, 6:12:09 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -7994,7 +7656,6 @@
   },
   "Brown City, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 11, 2024, 9:11:42 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -8014,7 +7675,6 @@
   },
   "Brown Deer, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8034,7 +7694,6 @@
   },
   "Brownsburg, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8054,7 +7713,6 @@
   },
   "Brownstown Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 2:37:27 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -8087,7 +7745,6 @@
   },
   "Brownsville, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "February 12, 2024, 7:51:46 PM UTC",
     "requirements": ["By Right", "Bike Parking", "Other"],
     "citations": [
       {
@@ -8117,7 +7774,6 @@
   },
   "Brownsville, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8137,7 +7793,6 @@
   },
   "Brunswick, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 9:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8157,7 +7812,6 @@
   },
   "Brunswick, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 8:50:10 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -8177,7 +7831,6 @@
   },
   "Brunswick, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 7, 2024, 1:48:15 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8197,7 +7850,6 @@
   },
   "Bryan, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8217,7 +7869,6 @@
   },
   "Buchanan, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 10:28:25 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8237,7 +7888,6 @@
   },
   "Buckley, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 7:34:31 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8262,7 +7912,6 @@
   },
   "Bucyrus, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 30, 2024, 4:07:44 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8287,7 +7936,6 @@
   },
   "Buena Vista Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 9, 2024, 10:24:15 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -8307,7 +7955,6 @@
   },
   "Buena Vista, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 4, 2024, 8:47:26 PM UTC",
     "requirements": ["Bike Parking", "In Lieu Fees", "Other"],
     "citations": [
       {
@@ -8342,7 +7989,6 @@
   },
   "Buffalo, NY": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8362,7 +8008,6 @@
   },
   "Buhl, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8382,7 +8027,6 @@
   },
   "Burlington, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8402,7 +8046,6 @@
   },
   "Burlington, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8422,7 +8065,6 @@
   },
   "Burlington, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8442,7 +8084,6 @@
   },
   "Burlington, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8462,7 +8103,6 @@
   },
   "Burlington, VT": {
     "reporter": "Edward Erfurt",
-    "updated": "May 12, 2024, 4:12:55 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8513,7 +8153,6 @@
   },
   "Burlington, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8533,7 +8172,6 @@
   },
   "Burnsville, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Car Share", "Other"],
     "citations": [
       {
@@ -8553,7 +8191,6 @@
   },
   "Burr Ridge, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 28, 2023, 7:21:21 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8573,7 +8210,6 @@
   },
   "Butler, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8593,7 +8229,6 @@
   },
   "Butte-Silver Bow County, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -8618,7 +8253,6 @@
   },
   "Byesville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 5, 2024, 5:41:05 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8638,7 +8272,6 @@
   },
   "Byron, MN": {
     "reporter": "Orion Roen",
-    "updated": "January 21, 2024, 10:35:17 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8658,7 +8291,6 @@
   },
   "Cabot, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8678,7 +8310,6 @@
   },
   "Cache, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 7:41:20 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8698,7 +8329,6 @@
   },
   "Cadillac, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 7:23:09 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8723,7 +8353,6 @@
   },
   "Cadiz, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 5, 2024, 6:20:04 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8743,7 +8372,6 @@
   },
   "Cadott, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8763,7 +8391,6 @@
   },
   "Caledonia Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 8:34:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8783,7 +8410,6 @@
   },
   "Calgary, AB": {
     "reporter": "Bobby Siemiaszko",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8803,7 +8429,6 @@
   },
   "California, CA": {
     "reporter": "Patrick Siegman",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": [
       "Size of Project",
       "Frequent Transit",
@@ -8866,7 +8491,6 @@
   },
   "Calmar, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8886,7 +8510,6 @@
   },
   "Calumet City, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 10:08:48 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -8906,7 +8529,6 @@
   },
   "Calumet Park, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["Other", "Frequent Transit"],
     "citations": [
       {
@@ -8931,7 +8553,6 @@
   },
   "Calumet, MI": {
     "reporter": "Nani Wolf",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -8951,7 +8572,6 @@
   },
   "Calvert County, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 4:28:48 AM UTC",
     "requirements": ["Other", "Size of Project"],
     "citations": [
       {
@@ -8976,7 +8596,6 @@
   },
   "Cambridge, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -8996,7 +8615,6 @@
   },
   "Cambridge, MA": {
     "reporter": "Jessica Sheehan",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9016,7 +8634,6 @@
   },
   "Cambridge, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 10, 2024, 5:26:18 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9036,7 +8653,6 @@
   },
   "Cambridge, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9056,7 +8672,6 @@
   },
   "Cambridge, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9076,7 +8691,6 @@
   },
   "Cambridge, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 5, 2024, 5:48:15 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9096,7 +8710,6 @@
   },
   "Cambridge, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9116,7 +8729,6 @@
   },
   "Camden, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9136,7 +8748,6 @@
   },
   "Cameron, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9156,7 +8767,6 @@
   },
   "Camp Hill, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 12, 2024, 3:32:42 AM UTC",
     "requirements": ["Other", "By Right", "Bike Parking"],
     "citations": [
       {
@@ -9186,7 +8796,6 @@
   },
   "Campbell, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 10:52:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9206,7 +8815,6 @@
   },
   "Campbellsville, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9226,7 +8834,6 @@
   },
   "Campton Hills, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -9246,7 +8853,6 @@
   },
   "Camrose, AB": {
     "reporter": "Aaron Leckie",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9266,7 +8872,6 @@
   },
   "Canada": {
     "reporter": "",
-    "updated": "April 3, 2024, 5:03:38 PM UTC",
     "requirements": ["Frequent Transit"],
     "citations": [
       {
@@ -9291,7 +8896,6 @@
   },
   "Canal Winchester, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 4:03:33 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9311,7 +8915,6 @@
   },
   "Canandaigua, NY": {
     "reporter": "Eric Cooper",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9336,7 +8939,6 @@
   },
   "Cannon Falls, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9356,7 +8958,6 @@
   },
   "Canton, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 2:02:30 AM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -9381,7 +8982,6 @@
   },
   "Canton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 11:22:03 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -9401,7 +9001,6 @@
   },
   "Canton, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9421,7 +9020,6 @@
   },
   "Canyon Lake, CA": {
     "reporter": "Maya Luong",
-    "updated": "June 21, 2024, 12:45:16 AM UTC",
     "requirements": [
       "Frequent Transit",
       "ADU",
@@ -9447,7 +9045,6 @@
   },
   "Capac, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 7:03:26 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9467,7 +9064,6 @@
   },
   "Cape Canaveral, FL": {
     "reporter": "Wes Morrison",
-    "updated": "January 23, 2024, 2:17:35 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9500,7 +9096,6 @@
   },
   "Cape Coral, FL": {
     "reporter": "Samuel Deetz",
-    "updated": "February 12, 2024, 7:58:28 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9525,7 +9120,6 @@
   },
   "Cape Girardeau, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9545,7 +9139,6 @@
   },
   "Carbondale, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "July 31, 2024, 11:10:28 PM UTC",
     "requirements": ["By Right", "In Lieu Fees", "Frequent Transit"],
     "citations": [
       {
@@ -9575,7 +9168,6 @@
   },
   "Carbondale, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 24, 2024, 5:58:16 PM UTC",
     "requirements": ["Bike Parking", "By Right"],
     "citations": [
       {
@@ -9610,7 +9202,6 @@
   },
   "Carbondale, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9630,7 +9221,6 @@
   },
   "Cardiff, Wales": {
     "reporter": "Samuel Deetz",
-    "updated": "August 25, 2024, 6:14:45 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9655,7 +9245,6 @@
   },
   "Cardington, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 10, 2024, 5:47:57 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -9680,7 +9269,6 @@
   },
   "Carlisle, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9700,7 +9288,6 @@
   },
   "Carlisle, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 12, 2024, 3:44:24 AM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -9720,7 +9307,6 @@
   },
   "Carlsbad, NM": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 5:34:04 PM UTC",
     "requirements": ["Frequent Transit", "Other"],
     "citations": [
       {
@@ -9740,7 +9326,6 @@
   },
   "Carlyle, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9760,7 +9345,6 @@
   },
   "Carmel, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -9790,7 +9374,6 @@
   },
   "Carnegie, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 23, 2024, 5:31:33 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -9815,7 +9398,6 @@
   },
   "Carol Stream, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9835,7 +9417,6 @@
   },
   "Carrboro, NC": {
     "reporter": "Patrick McDonough",
-    "updated": "August 24, 2024, 4:35:04 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9868,7 +9449,6 @@
   },
   "Carrington, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9888,7 +9468,6 @@
   },
   "Carroll, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9908,7 +9487,6 @@
   },
   "Carroll, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 4:28:23 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9928,7 +9506,6 @@
   },
   "Carrollton Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 5, 2024, 12:50:11 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -9948,7 +9525,6 @@
   },
   "Carrollton, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9968,7 +9544,6 @@
   },
   "Carrollton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 29, 2024, 3:44:16 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -9988,7 +9563,6 @@
   },
   "Carrollton, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 9:28:53 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -10013,7 +9587,6 @@
   },
   "Carson City, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 11:29:48 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -10033,7 +9606,6 @@
   },
   "Carterville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10053,7 +9625,6 @@
   },
   "Carthage, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10073,7 +9644,6 @@
   },
   "Caruthersville, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10093,7 +9663,6 @@
   },
   "Carver, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10118,7 +9687,6 @@
   },
   "Cary, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "February 13, 2024, 12:02:34 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10143,7 +9711,6 @@
   },
   "Casa Grande, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10163,7 +9730,6 @@
   },
   "Casco Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 5, 2024, 12:57:48 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10183,7 +9749,6 @@
   },
   "Casey, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10203,7 +9768,6 @@
   },
   "Cashton, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10223,7 +9787,6 @@
   },
   "Casper, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10243,7 +9806,6 @@
   },
   "Cass City, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 11, 2024, 8:02:24 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10263,7 +9825,6 @@
   },
   "Cassadaga, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -10283,7 +9844,6 @@
   },
   "Cassopolis, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 30, 2024, 4:53:51 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10303,7 +9863,6 @@
   },
   "Cassville, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10323,7 +9882,6 @@
   },
   "Castle Pines, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 4:38:00 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10343,7 +9901,6 @@
   },
   "Castle Rock, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 4:48:11 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -10368,7 +9925,6 @@
   },
   "Castle Shannon, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 21, 2024, 9:07:19 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10388,7 +9944,6 @@
   },
   "Catawissa, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 11, 2024, 2:26:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10408,7 +9963,6 @@
   },
   "Catoosa, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 1:32:57 AM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -10428,7 +9982,6 @@
   },
   "Cayce, SC": {
     "reporter": "Carroll Williamson",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10448,7 +10001,6 @@
   },
   "Cañon City, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 7, 2024, 5:05:20 PM UTC",
     "requirements": [
       "By Right",
       "Historic Preservation",
@@ -10501,7 +10053,6 @@
   },
   "Cecil, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10521,7 +10072,6 @@
   },
   "Cedar Creek Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 5, 2024, 1:03:29 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10541,7 +10091,6 @@
   },
   "Cedar Falls, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10561,7 +10110,6 @@
   },
   "Cedar Rapids, IA": {
     "reporter": "Seth Gunnerson",
-    "updated": "March 27, 2024, 6:57:45 PM UTC",
     "requirements": ["By Right", "Frequent Transit", "Other"],
     "citations": [
       {
@@ -10596,7 +10144,6 @@
   },
   "Cedar Springs, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 7:24:24 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -10621,7 +10168,6 @@
   },
   "Cedarburg, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10641,7 +10187,6 @@
   },
   "Celina, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 17, 2024, 5:48:15 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10661,7 +10206,6 @@
   },
   "Centennial, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 6, 2024, 4:51:46 PM UTC",
     "requirements": ["Bike Parking", "Car Share", "Other", "TDM"],
     "citations": [
       {
@@ -10681,7 +10225,6 @@
   },
   "Center Line, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 7:24:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10701,7 +10244,6 @@
   },
   "Center, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 6:36:53 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10721,7 +10263,6 @@
   },
   "Centerburg, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 12:37:34 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10741,7 +10282,6 @@
   },
   "Centerville, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10761,7 +10301,6 @@
   },
   "Centerville, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -10781,7 +10320,6 @@
   },
   "Centerville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -10801,7 +10339,6 @@
   },
   "Central City, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 17, 2024, 5:26:04 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10826,7 +10363,6 @@
   },
   "Central Falls, RI": {
     "reporter": "Cedric Ye",
-    "updated": "July 17, 2024, 3:11:17 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10846,7 +10382,6 @@
   },
   "Central Point, OR": {
     "reporter": "Tony Jordan",
-    "updated": "May 12, 2024, 3:21:54 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10879,7 +10414,6 @@
   },
   "Central, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 4, 2024, 10:33:34 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -10899,7 +10433,6 @@
   },
   "Centralia, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 22, 2024, 1:17:38 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10919,7 +10452,6 @@
   },
   "Centralia, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10944,7 +10476,6 @@
   },
   "Centre Hall, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 25, 2024, 10:52:30 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10964,7 +10495,6 @@
   },
   "Cerro Gordo, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 26, 2024, 6:55:08 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -10984,7 +10514,6 @@
   },
   "Chadron, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11004,7 +10533,6 @@
   },
   "Chaffee, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11024,7 +10552,6 @@
   },
   "Chagrin Falls, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -11044,7 +10571,6 @@
   },
   "Chalfont, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 21, 2024, 9:29:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11064,7 +10590,6 @@
   },
   "Chambersburg, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 26, 2024, 12:01:08 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11089,7 +10614,6 @@
   },
   "Champaign County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11109,7 +10633,6 @@
   },
   "Champaign, IL": {
     "reporter": "Ben LeRoy",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11134,7 +10657,6 @@
   },
   "Chandler, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 5:03:27 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -11159,7 +10681,6 @@
   },
   "Chanute, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11179,7 +10700,6 @@
   },
   "Chapel Hill, NC": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right", "Frequent Transit", "In Lieu Fees", "TDM"],
     "citations": [
       {
@@ -11219,7 +10739,6 @@
   },
   "Chardon, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 11:06:58 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11239,7 +10758,6 @@
   },
   "Charles City, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11259,7 +10777,6 @@
   },
   "Charles County, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 5:22:33 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -11289,7 +10806,6 @@
   },
   "Charleston, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11309,7 +10825,6 @@
   },
   "Charleston, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11329,7 +10844,6 @@
   },
   "Charleston, SC": {
     "reporter": "Jim Hemphill",
-    "updated": "January 23, 2024, 2:47:29 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11354,7 +10868,6 @@
   },
   "Charleston, WV": {
     "reporter": "John Butterworth",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11389,7 +10902,6 @@
   },
   "Charlestown, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 7:44:47 PM UTC",
     "requirements": ["Bike Parking", "By Right"],
     "citations": [
       {
@@ -11414,7 +10926,6 @@
   },
   "Charlevoix, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11444,7 +10955,6 @@
   },
   "Charlotte, NC": {
     "reporter": "Alan Goodwin",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -11464,7 +10974,6 @@
   },
   "Charlottesville, VA": {
     "reporter": "Danny Yoder",
-    "updated": "January 23, 2024, 3:42:28 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11497,7 +11006,6 @@
   },
   "Chaska, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -11517,7 +11025,6 @@
   },
   "Chatfield, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11537,7 +11044,6 @@
   },
   "Chatham, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -11557,7 +11063,6 @@
   },
   "Chattahoochee Hills, GA": {
     "reporter": "Thomas Reed",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11577,7 +11082,6 @@
   },
   "Chattanooga, TN": {
     "reporter": "Jonathan Hunter",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11610,7 +11114,6 @@
   },
   "Cheboygan, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -11630,7 +11133,6 @@
   },
   "Chelsea, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 8:11:03 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -11655,7 +11157,6 @@
   },
   "Cherokee, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11675,7 +11176,6 @@
   },
   "Cherryvale, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11695,7 +11195,6 @@
   },
   "Cherryville, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11715,7 +11214,6 @@
   },
   "Chesapeake, VA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 9:44:35 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -11735,7 +11233,6 @@
   },
   "Chester, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 21, 2024, 4:40:24 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -11760,7 +11257,6 @@
   },
   "Chester, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11780,7 +11276,6 @@
   },
   "Chesterfield Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 8:38:12 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -11800,7 +11295,6 @@
   },
   "Chesterfield, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11820,7 +11314,6 @@
   },
   "Chesterton, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11840,7 +11333,6 @@
   },
   "Chesterville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 10, 2024, 5:49:21 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -11865,7 +11357,6 @@
   },
   "Cheyenne, WY": {
     "reporter": "Seth Lloyd",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11885,7 +11376,6 @@
   },
   "Chicago Heights, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11905,7 +11395,6 @@
   },
   "Chicago Ridge, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 28, 2023, 7:53:26 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11925,7 +11414,6 @@
   },
   "Chicago, IL": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -11955,7 +11443,6 @@
   },
   "Chico, CA": {
     "reporter": "Patrick Siegman",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -11990,7 +11477,6 @@
   },
   "Chillicothe, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -12010,7 +11496,6 @@
   },
   "Chilton, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12030,7 +11515,6 @@
   },
   "Chino Valley, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12050,7 +11534,6 @@
   },
   "Chippewa Falls, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12070,7 +11553,6 @@
   },
   "Choteau, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12090,7 +11572,6 @@
   },
   "Chouteau, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 3:48:48 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -12110,7 +11591,6 @@
   },
   "Christopher, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12130,7 +11610,6 @@
   },
   "Chula Vista, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 11:31:20 PM UTC",
     "requirements": ["ADU"],
     "citations": [
       {
@@ -12150,7 +11629,6 @@
   },
   "Cincinnati, OH": {
     "reporter": "Giovanni A Rocco",
-    "updated": "April 4, 2024, 1:41:22 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12216,7 +11694,6 @@
   },
   "Circleville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 10, 2024, 7:16:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12236,7 +11713,6 @@
   },
   "Clairton, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 12, 2024, 6:49:20 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12256,7 +11732,6 @@
   },
   "Claremont, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12276,7 +11751,6 @@
   },
   "Claremore, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 1:47:08 AM UTC",
     "requirements": ["ADU", "By Right"],
     "citations": [
       {
@@ -12301,7 +11775,6 @@
   },
   "Clarendon Hills, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Bike Parking", "In Lieu Fees"],
     "citations": [
       {
@@ -12326,7 +11799,6 @@
   },
   "Clarion, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12346,7 +11818,6 @@
   },
   "Clarion, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 31, 2024, 12:36:32 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12366,7 +11837,6 @@
   },
   "Clark County, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12386,7 +11856,6 @@
   },
   "Clark, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12406,7 +11875,6 @@
   },
   "Clarkston, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 19, 2024, 7:00:32 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -12431,7 +11899,6 @@
   },
   "Clarksville, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12451,7 +11918,6 @@
   },
   "Clarksville, IN": {
     "reporter": "Neal Turpin",
-    "updated": "December 24, 2023, 6:27:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12471,7 +11937,6 @@
   },
   "Clarksville, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12491,7 +11956,6 @@
   },
   "Clawson, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 19, 2024, 7:08:54 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -12516,7 +11980,6 @@
   },
   "Clayton, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12536,7 +11999,6 @@
   },
   "Clayton, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -12566,7 +12028,6 @@
   },
   "Clayton, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12586,7 +12047,6 @@
   },
   "Clear Lake, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right", "Other", "Historic Preservation"],
     "citations": [
       {
@@ -12621,7 +12081,6 @@
   },
   "Clear Lake, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12641,7 +12100,6 @@
   },
   "Clearwater, FL": {
     "reporter": "Lauren Matzke",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12666,7 +12124,6 @@
   },
   "Clearwater, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12686,7 +12143,6 @@
   },
   "Clearwater, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -12706,7 +12162,6 @@
   },
   "Cleburne, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 8:15:18 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12726,7 +12181,6 @@
   },
   "Clemson, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12746,7 +12200,6 @@
   },
   "Cleveland Heights, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["Car Share", "Other"],
     "citations": [
       {
@@ -12776,7 +12229,6 @@
   },
   "Cleveland, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -12796,7 +12248,6 @@
   },
   "Cleveland, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12816,7 +12267,6 @@
   },
   "Cleveland, OH": {
     "reporter": "Matt Moss",
-    "updated": "April 13, 2024, 1:06:37 AM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -12849,7 +12299,6 @@
   },
   "Clever, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12869,7 +12318,6 @@
   },
   "Clinton , IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12889,7 +12337,6 @@
   },
   "Clinton Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 8:45:25 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -12909,7 +12356,6 @@
   },
   "Clinton County, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12929,7 +12375,6 @@
   },
   "Clinton, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 12:39:59 AM UTC",
     "requirements": ["In Lieu Fees", "By Right"],
     "citations": [
       {
@@ -12959,7 +12404,6 @@
   },
   "Clinton, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 2:40:34 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12979,7 +12423,6 @@
   },
   "Clinton, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -12999,7 +12442,6 @@
   },
   "Clinton, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13019,7 +12461,6 @@
   },
   "Clintonville, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13039,7 +12480,6 @@
   },
   "Clio, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 8:06:52 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13059,7 +12499,6 @@
   },
   "Cloquet, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 21, 2024, 3:34:21 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13089,7 +12528,6 @@
   },
   "Cloverdale, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13109,7 +12547,6 @@
   },
   "Cloverport, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13129,7 +12566,6 @@
   },
   "Clovis, NM": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13149,7 +12585,6 @@
   },
   "Clyman, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13169,7 +12604,6 @@
   },
   "Coal City, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 12:26:52 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13194,7 +12628,6 @@
   },
   "Coatesville, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 29, 2024, 12:29:14 AM UTC",
     "requirements": ["In Lieu Fees", "By Right", "Other"],
     "citations": [
       {
@@ -13224,7 +12657,6 @@
   },
   "Cody, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -13244,7 +12676,6 @@
   },
   "Coffeyville, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13264,7 +12695,6 @@
   },
   "Cohasset, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13284,7 +12714,6 @@
   },
   "Cokato, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13304,7 +12733,6 @@
   },
   "Colby, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13324,7 +12752,6 @@
   },
   "Cold Spring, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees", "Other"],
     "citations": [
       {
@@ -13344,7 +12771,6 @@
   },
   "Colfax, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13364,7 +12790,6 @@
   },
   "College Station, TX": {
     "reporter": "Bobby Siemiaszko",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -13384,7 +12809,6 @@
   },
   "Collierville, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13404,7 +12828,6 @@
   },
   "Collins, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13424,7 +12847,6 @@
   },
   "Collinsville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 1:54:58 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -13444,7 +12866,6 @@
   },
   "Collinsville, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 1:56:57 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13464,7 +12885,6 @@
   },
   "Colman, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13484,7 +12904,6 @@
   },
   "Coloma, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 10:34:55 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13504,7 +12923,6 @@
   },
   "Coloma, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13524,7 +12942,6 @@
   },
   "Colona, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13544,7 +12961,6 @@
   },
   "Colorado City, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "February 16, 2024, 1:02:04 AM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -13569,7 +12985,6 @@
   },
   "Colorado Springs, CO": {
     "reporter": "Cullom Radvillas",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -13609,7 +13024,6 @@
   },
   "Colorado, CO": {
     "reporter": "Tony Jordan",
-    "updated": "May 15, 2024, 10:18:28 PM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -13647,7 +13061,6 @@
   },
   "Colton, CA": {
     "reporter": "Bobby Siemiaszko",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13667,7 +13080,6 @@
   },
   "Colton, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13687,7 +13099,6 @@
   },
   "Columbia City, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13707,7 +13118,6 @@
   },
   "Columbia Falls, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -13727,7 +13137,6 @@
   },
   "Columbia Heights, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13747,7 +13156,6 @@
   },
   "Columbia, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -13767,7 +13175,6 @@
   },
   "Columbia, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 12:53:45 AM UTC",
     "requirements": [
       "By Right",
       "Bike Parking",
@@ -13813,7 +13220,6 @@
   },
   "Columbus, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 5:31:01 AM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -13843,7 +13249,6 @@
   },
   "Columbus, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -13868,7 +13273,6 @@
   },
   "Columbus, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13888,7 +13292,6 @@
   },
   "Columbus, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -13908,7 +13311,6 @@
   },
   "Columbus, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13928,7 +13330,6 @@
   },
   "Columbus, OH": {
     "reporter": "Josh Lapp",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13953,7 +13354,6 @@
   },
   "Colville, WA": {
     "reporter": "RJ Keetch",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -13973,7 +13373,6 @@
   },
   "Colwich, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -13993,7 +13392,6 @@
   },
   "Combined Locks, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14013,7 +13411,6 @@
   },
   "Commerce Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 9:47:10 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14033,7 +13430,6 @@
   },
   "Commerce City, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 5, 2024, 4:06:24 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14053,7 +13449,6 @@
   },
   "Comstock Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 4:20:28 PM UTC",
     "requirements": ["Other", "Size of Project"],
     "citations": [
       {
@@ -14073,7 +13468,6 @@
   },
   "Concord, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 11:01:39 PM UTC",
     "requirements": ["Frequent Transit", "In Lieu Fees", "ADU"],
     "citations": [
       {
@@ -14108,7 +13502,6 @@
   },
   "Concord, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14128,7 +13521,6 @@
   },
   "Concord, NH": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 2:32:48 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14148,7 +13540,6 @@
   },
   "Concordia, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14168,7 +13559,6 @@
   },
   "Concordia, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14188,7 +13578,6 @@
   },
   "Connecticut, CT": {
     "reporter": "Patrick Siegman",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14215,7 +13604,6 @@
   },
   "Connellsville, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 25, 2024, 6:55:42 AM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -14235,7 +13623,6 @@
   },
   "Connersville, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -14255,7 +13642,6 @@
   },
   "Constantine, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 31, 2024, 1:34:21 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14275,7 +13661,6 @@
   },
   "Conway, AR": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14300,7 +13685,6 @@
   },
   "Coon Valley, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14320,7 +13704,6 @@
   },
   "Cooperstown, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14340,7 +13723,6 @@
   },
   "Coopersville, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 9:07:31 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -14360,7 +13742,6 @@
   },
   "Coos Bay, OR": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 9:14:18 PM UTC",
     "requirements": ["By Right", "ADU"],
     "citations": [
       {
@@ -14390,7 +13771,6 @@
   },
   "Copemish, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 6:34:14 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14410,7 +13790,6 @@
   },
   "Coraopolis, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 23, 2024, 1:08:09 AM UTC",
     "requirements": ["Other", "Bike Parking"],
     "citations": [
       {
@@ -14440,7 +13819,6 @@
   },
   "Corinth, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 12:59:49 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14460,7 +13838,6 @@
   },
   "Cork, County Cork": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 7:44:13 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14498,7 +13875,6 @@
   },
   "Cornelius, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -14518,7 +13894,6 @@
   },
   "Corning, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14538,7 +13913,6 @@
   },
   "Corona, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 20, 2024, 9:13:14 PM UTC",
     "requirements": [
       "ADU",
       "In Lieu Fees",
@@ -14575,7 +13949,6 @@
   },
   "Corpus Christi, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 11:36:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14595,7 +13968,6 @@
   },
   "Cortez, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -14615,7 +13987,6 @@
   },
   "Cortland, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 12, 2024, 2:06:27 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -14635,7 +14006,6 @@
   },
   "Corunna, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 13, 2024, 5:32:51 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -14660,7 +14030,6 @@
   },
   "Corvallis, OR": {
     "reporter": "Evan Manvel",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14734,7 +14103,6 @@
   },
   "Corwin, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -14754,7 +14122,6 @@
   },
   "Coshocton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 29, 2024, 5:14:18 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14774,7 +14141,6 @@
   },
   "Cottage Grove, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14794,7 +14160,6 @@
   },
   "Cottbus, BB": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 7:13:21 PM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -14814,7 +14179,6 @@
   },
   "Council Bluffs, IA": {
     "reporter": "Brandon Siracuse",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14834,7 +14198,6 @@
   },
   "Country Club Hills, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14854,7 +14217,6 @@
   },
   "Countryside, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14874,7 +14236,6 @@
   },
   "Covington, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": [
       "By Right",
       "Bike Parking",
@@ -14942,7 +14303,6 @@
   },
   "Covington, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14962,7 +14322,6 @@
   },
   "Covington, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -14982,7 +14341,6 @@
   },
   "Cowley, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15002,7 +14360,6 @@
   },
   "Cozad, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15022,7 +14379,6 @@
   },
   "Craig, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15042,7 +14398,6 @@
   },
   "Cramerton, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15062,7 +14417,6 @@
   },
   "Creede, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 6:16:55 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -15082,7 +14436,6 @@
   },
   "Creighton, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15102,7 +14455,6 @@
   },
   "Crescent Springs, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15122,7 +14474,6 @@
   },
   "Cresco, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15142,7 +14493,6 @@
   },
   "Crested Butte, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 4, 2024, 7:35:04 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -15162,7 +14512,6 @@
   },
   "Creston, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15182,7 +14531,6 @@
   },
   "Creston, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Other", "In Lieu Fees"],
     "citations": [
       {
@@ -15207,7 +14555,6 @@
   },
   "Crestview Hills, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15227,7 +14574,6 @@
   },
   "Crestwood, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["Bike Parking", "Other", "Frequent Transit", "TDM"],
     "citations": [
       {
@@ -15262,7 +14608,6 @@
   },
   "Crete, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "May 19, 2024, 4:37:00 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15282,7 +14627,6 @@
   },
   "Cripple Creek, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 3:21:26 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15307,7 +14651,6 @@
   },
   "Crofton, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15327,7 +14670,6 @@
   },
   "Crooks, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15347,7 +14689,6 @@
   },
   "Crosby, MN": {
     "reporter": "Matt Steele",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15367,7 +14708,6 @@
   },
   "Cross Plains, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15392,7 +14732,6 @@
   },
   "Crowley, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 5, 2024, 12:48:15 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15412,7 +14751,6 @@
   },
   "Crown Point, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15432,7 +14770,6 @@
   },
   "Crystal Lake, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -15457,7 +14794,6 @@
   },
   "Crystal, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15477,7 +14813,6 @@
   },
   "Culver City, CA": {
     "reporter": "Tony Jordan",
-    "updated": "January 1, 2024, 10:04:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15510,7 +14845,6 @@
   },
   "Cumberland, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15530,7 +14864,6 @@
   },
   "Cumberland, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 5:06:06 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15550,7 +14883,6 @@
   },
   "Cumberland, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15570,7 +14902,6 @@
   },
   "Cunningham, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15590,7 +14921,6 @@
   },
   "Curtiss, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15610,7 +14940,6 @@
   },
   "Cutler Bay, FL": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15648,7 +14977,6 @@
   },
   "Cuyahoga Falls, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 11, 2024, 8:53:45 PM UTC",
     "requirements": ["By Right", "Bike Parking", "Other"],
     "citations": [
       {
@@ -15673,7 +15001,6 @@
   },
   "Dagsboro, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -15693,7 +15020,6 @@
   },
   "Daleville, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -15713,7 +15039,6 @@
   },
   "Dallas Center, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15733,7 +15058,6 @@
   },
   "Dallas, TX": {
     "reporter": "",
-    "updated": "February 20, 2024, 10:27:04 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -15771,7 +15095,6 @@
   },
   "Danby, NY": {
     "reporter": "David West",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15791,7 +15114,6 @@
   },
   "Dane, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15811,7 +15133,6 @@
   },
   "Dansville, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15831,7 +15152,6 @@
   },
   "Danville, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 3:35:41 AM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -15856,7 +15176,6 @@
   },
   "Danville, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15876,7 +15195,6 @@
   },
   "Danville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 23, 2024, 4:03:13 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15901,7 +15219,6 @@
   },
   "Danville, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -15926,7 +15243,6 @@
   },
   "Danville, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15951,7 +15267,6 @@
   },
   "Danville, VA": {
     "reporter": "Michael Kwan",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -15971,7 +15286,6 @@
   },
   "Darby, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 21, 2024, 6:07:48 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -15991,7 +15305,6 @@
   },
   "Dardanelle, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16011,7 +15324,6 @@
   },
   "Darien, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16031,7 +15343,6 @@
   },
   "Dassel, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16051,7 +15362,6 @@
   },
   "Davenport, IA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16071,7 +15381,6 @@
   },
   "David City, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16091,7 +15400,6 @@
   },
   "Davidson, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -16116,7 +15424,6 @@
   },
   "Davis, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16136,7 +15443,6 @@
   },
   "Davison, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 8:15:05 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -16161,7 +15467,6 @@
   },
   "Dayton, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16181,7 +15486,6 @@
   },
   "Dayton, OH": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16206,7 +15510,6 @@
   },
   "De Pere, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16226,7 +15529,6 @@
   },
   "De Soto, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16246,7 +15548,6 @@
   },
   "De Soto, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16266,7 +15567,6 @@
   },
   "De Soto, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16286,7 +15586,6 @@
   },
   "De Soto, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16306,7 +15605,6 @@
   },
   "DeForest, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 27, 2024, 6:13:23 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16331,7 +15629,6 @@
   },
   "DeKalb, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16356,7 +15653,6 @@
   },
   "DeMotte, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16376,7 +15672,6 @@
   },
   "DeRidder, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 5, 2024, 7:18:05 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16396,7 +15691,6 @@
   },
   "DeTour Village, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 1:32:45 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -16416,7 +15710,6 @@
   },
   "DeWitt Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 13, 2024, 8:36:10 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -16436,7 +15729,6 @@
   },
   "DeWitt County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16456,7 +15748,6 @@
   },
   "DeWitt, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 13, 2024, 7:53:00 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16476,7 +15767,6 @@
   },
   "Deadwood, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16501,7 +15791,6 @@
   },
   "Dearborn Heights, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 4:10:52 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16521,7 +15810,6 @@
   },
   "Dearborn, MI": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -16541,7 +15829,6 @@
   },
   "Decatur, AL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16561,7 +15848,6 @@
   },
   "Decatur, GA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -16581,7 +15867,6 @@
   },
   "Decatur, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16601,7 +15886,6 @@
   },
   "Decatur, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -16626,7 +15910,6 @@
   },
   "Decatur, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -16651,7 +15934,6 @@
   },
   "Decatur, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16671,7 +15953,6 @@
   },
   "Decorah, IA": {
     "reporter": "Joel Zook",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16691,7 +15972,6 @@
   },
   "Deer Lodge, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16711,7 +15991,6 @@
   },
   "Defiance, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 17, 2024, 6:32:01 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16736,7 +16015,6 @@
   },
   "Del Norte, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 6:40:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16756,7 +16034,6 @@
   },
   "Delano, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16776,7 +16053,6 @@
   },
   "Delavan, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16796,7 +16072,6 @@
   },
   "Delaware, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 30, 2024, 8:28:10 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16816,7 +16091,6 @@
   },
   "Delhi, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16836,7 +16110,6 @@
   },
   "Delhi, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 5, 2024, 9:11:05 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16856,7 +16129,6 @@
   },
   "Dell Rapids, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16876,7 +16148,6 @@
   },
   "Delmar, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 10, 2024, 4:35:22 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16896,7 +16167,6 @@
   },
   "Delta Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 6:41:10 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16916,7 +16186,6 @@
   },
   "Delta, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 5:39:31 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -16941,7 +16210,6 @@
   },
   "Denison, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -16961,7 +16229,6 @@
   },
   "Denmark, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -16986,7 +16253,6 @@
   },
   "Dennis, MA": {
     "reporter": "Daniel Fortier",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17006,7 +16272,6 @@
   },
   "Denton, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 10, 2024, 6:53:40 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -17026,7 +16291,6 @@
   },
   "Denton, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "February 15, 2024, 7:27:00 PM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -17073,7 +16337,6 @@
   },
   "Denver, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 6, 2024, 2:03:01 AM UTC",
     "requirements": [
       "Size of Project",
       "Frequent Transit",
@@ -17151,7 +16414,6 @@
   },
   "Derby, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17176,7 +16438,6 @@
   },
   "Des Moines, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right", "Car Share", "Bike Parking", "Other"],
     "citations": [
       {
@@ -17206,7 +16467,6 @@
   },
   "Des Plaines, IL": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["Frequent Transit", "Planned Frequent Transit"],
     "citations": [
       {
@@ -17226,7 +16486,6 @@
   },
   "Deshler, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 19, 2024, 5:54:55 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -17246,7 +16505,6 @@
   },
   "Detroit Lakes, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -17266,7 +16524,6 @@
   },
   "Detroit, MI": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17286,7 +16543,6 @@
   },
   "Dewey Beach, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -17306,7 +16562,6 @@
   },
   "Dexter, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17326,7 +16581,6 @@
   },
   "Dexter, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 8:20:04 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -17356,7 +16610,6 @@
   },
   "Dexter, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17376,7 +16629,6 @@
   },
   "Diamondhead, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 7:04:39 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -17401,7 +16653,6 @@
   },
   "Dickinson, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17421,7 +16672,6 @@
   },
   "Dillon, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 5, 2024, 3:46:01 AM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -17441,7 +16691,6 @@
   },
   "Dixon, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17461,7 +16710,6 @@
   },
   "Dodge City, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17481,7 +16729,6 @@
   },
   "Dodge County, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 8:52:13 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -17501,7 +16748,6 @@
   },
   "Dodgeville, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17521,7 +16767,6 @@
   },
   "Dolores, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -17541,7 +16786,6 @@
   },
   "Donnelly, ID": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17561,7 +16805,6 @@
   },
   "Door County, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 8:49:34 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -17586,7 +16829,6 @@
   },
   "Dorchester, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17606,7 +16848,6 @@
   },
   "Dormont, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 23, 2024, 2:10:50 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -17626,7 +16867,6 @@
   },
   "Dothan, AL": {
     "reporter": "Preston Cosmos",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17651,7 +16891,6 @@
   },
   "Douglas, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 9:32:29 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -17671,7 +16910,6 @@
   },
   "Douglas, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 5:15:23 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17691,7 +16929,6 @@
   },
   "Douglas, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17711,7 +16948,6 @@
   },
   "Douglass Hills, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "August 4, 2024, 3:28:35 AM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -17747,7 +16983,6 @@
   },
   "Dover, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17767,7 +17002,6 @@
   },
   "Dover, NH": {
     "reporter": "Christopher Parker",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -17787,7 +17021,6 @@
   },
   "Dover, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 12, 2024, 2:46:19 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17807,7 +17040,6 @@
   },
   "Downers Grove, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Other", "Car Share"],
     "citations": [
       {
@@ -17837,7 +17069,6 @@
   },
   "Downingtown, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 30, 2024, 6:44:08 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -17857,7 +17088,6 @@
   },
   "Doylestown, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 22, 2024, 4:34:02 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -17877,7 +17107,6 @@
   },
   "Dresden, SN": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 6:49:50 PM UTC",
     "requirements": [
       "Frequent Transit",
       "TDM",
@@ -17913,7 +17142,6 @@
   },
   "Dry Ridge, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17933,7 +17161,6 @@
   },
   "Dryden, ON": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -17953,7 +17180,6 @@
   },
   "Du Quoin, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 1:20:46 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17973,7 +17199,6 @@
   },
   "DuPage County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -17993,7 +17218,6 @@
   },
   "Dublin, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 31, 2024, 7:54:34 PM UTC",
     "requirements": ["Frequent Transit", "Car Share", "TDM", "Other"],
     "citations": [
       {
@@ -18023,7 +17247,6 @@
   },
   "Dublin, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 22, 2024, 4:38:46 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -18043,7 +17266,6 @@
   },
   "Dubuque, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 8:16:06 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18063,7 +17285,6 @@
   },
   "Duluth, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18088,7 +17309,6 @@
   },
   "Duluth, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 22, 2024, 12:15:58 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18149,7 +17369,6 @@
   },
   "Duncan, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18169,7 +17388,6 @@
   },
   "Duncan, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18189,7 +17407,6 @@
   },
   "Dundee, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 4:48:25 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18214,7 +17431,6 @@
   },
   "Dunkirk, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -18234,7 +17450,6 @@
   },
   "Dunwoody, GA": {
     "reporter": "Caleb Racicot",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18254,7 +17469,6 @@
   },
   "Durand, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 13, 2024, 5:39:41 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -18279,7 +17493,6 @@
   },
   "Durand, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18299,7 +17512,6 @@
   },
   "Durango, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 10:11:17 PM UTC",
     "requirements": [
       "Size of Project",
       "In Lieu Fees",
@@ -18336,7 +17548,6 @@
   },
   "Durant, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18356,7 +17567,6 @@
   },
   "Durham County, NC": {
     "reporter": "Tony Jordan",
-    "updated": "January 23, 2024, 4:11:14 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18376,7 +17586,6 @@
   },
   "Durham, NC": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18409,7 +17618,6 @@
   },
   "Dyersburg, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18429,7 +17637,6 @@
   },
   "Dyersville, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18449,7 +17656,6 @@
   },
   "Dysart, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18469,7 +17675,6 @@
   },
   "Eagan, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 20, 2024, 9:54:18 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -18489,7 +17694,6 @@
   },
   "Eagle Grove, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18509,7 +17713,6 @@
   },
   "Eagle, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 8:10:52 PM UTC",
     "requirements": [
       "In Lieu Fees",
       "Other",
@@ -18551,7 +17754,6 @@
   },
   "Eagle, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18571,7 +17773,6 @@
   },
   "Early, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18591,7 +17792,6 @@
   },
   "East Alton, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 22, 2024, 7:24:23 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18611,7 +17811,6 @@
   },
   "East Dundee, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Size of Project", "In Lieu Fees"],
     "citations": [
       {
@@ -18631,7 +17830,6 @@
   },
   "East Grand Forks, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees", "Bike Parking", "Other"],
     "citations": [
       {
@@ -18651,7 +17849,6 @@
   },
   "East Grand Rapids, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 7:32:24 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18671,7 +17868,6 @@
   },
   "East Greenwich, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 6:03:51 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18696,7 +17892,6 @@
   },
   "East Helena, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18716,7 +17911,6 @@
   },
   "East Lansdowne, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 23, 2024, 5:10:53 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -18736,7 +17930,6 @@
   },
   "East Lansing, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 13, 2024, 8:04:06 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18766,7 +17959,6 @@
   },
   "East Liverpool, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 29, 2024, 4:56:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18786,7 +17978,6 @@
   },
   "East Moline, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18806,7 +17997,6 @@
   },
   "East Palestine, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 29, 2024, 5:00:59 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18826,7 +18016,6 @@
   },
   "East Peoria, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18846,7 +18035,6 @@
   },
   "East Pittsburgh, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 23, 2024, 2:42:45 AM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -18871,7 +18059,6 @@
   },
   "East Providence, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 4:39:54 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -18891,7 +18078,6 @@
   },
   "East Rochester, NY": {
     "reporter": "Eric Cooper",
-    "updated": "May 27, 2024, 11:17:00 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18911,7 +18097,6 @@
   },
   "East St. Louis, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18931,7 +18116,6 @@
   },
   "East Tawas, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 24, 2024, 5:08:12 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18951,7 +18135,6 @@
   },
   "East Troy, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -18976,7 +18159,6 @@
   },
   "Easton, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 10, 2024, 7:33:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19001,7 +18183,6 @@
   },
   "Eastpointe, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 7:34:56 PM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -19039,7 +18220,6 @@
   },
   "Eaton Rapids, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 6:23:59 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19059,7 +18239,6 @@
   },
   "Eau Claire, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["Bike Parking", "Other", "Frequent Transit"],
     "citations": [
       {
@@ -19084,7 +18263,6 @@
   },
   "Ebensburg, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 25, 2024, 4:26:17 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19109,7 +18287,6 @@
   },
   "Ecorse, MI": {
     "reporter": "Nani Wolf",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -19129,7 +18306,6 @@
   },
   "Eden Prairie, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19164,7 +18340,6 @@
   },
   "Eden Valley, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19184,7 +18359,6 @@
   },
   "Edgerton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19204,7 +18378,6 @@
   },
   "Edgerton, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19224,7 +18397,6 @@
   },
   "Edgewood, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 23, 2024, 2:58:55 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19244,7 +18416,6 @@
   },
   "Edina, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Frequent Transit", "Car Share", "Bike Parking"],
     "citations": [
       {
@@ -19279,7 +18450,6 @@
   },
   "Edinboro, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19299,7 +18469,6 @@
   },
   "Edison, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 10, 2024, 5:50:39 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -19319,7 +18488,6 @@
   },
   "Edisto Beach, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19339,7 +18507,6 @@
   },
   "Edmond, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 16, 2024, 8:07:31 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19359,7 +18526,6 @@
   },
   "Edmonton, AB": {
     "reporter": "Karl Parkinson",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19386,7 +18552,6 @@
   },
   "Edwardsville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -19406,7 +18571,6 @@
   },
   "Effingham, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19426,7 +18590,6 @@
   },
   "Egg Harbor, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["In Lieu Fees", "Other"],
     "citations": [
       {
@@ -19456,7 +18619,6 @@
   },
   "El Dorado, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19476,7 +18638,6 @@
   },
   "El Paso, TX": {
     "reporter": "Alex Hoffman",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19496,7 +18657,6 @@
   },
   "El Reno, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19516,7 +18676,6 @@
   },
   "Elberta, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "December 9, 2023, 1:44:04 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19536,7 +18695,6 @@
   },
   "Elburn, IL": {
     "reporter": "Jake Seid",
-    "updated": "July 25, 2024, 7:49:15 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19571,7 +18729,6 @@
   },
   "Eldora, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19591,7 +18748,6 @@
   },
   "Elgin, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -19616,7 +18772,6 @@
   },
   "Elgin, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19636,7 +18791,6 @@
   },
   "Elgin, OR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -19656,7 +18810,6 @@
   },
   "Elgin, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19681,7 +18834,6 @@
   },
   "Elizabeth, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 4:12:29 AM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -19701,7 +18853,6 @@
   },
   "Elizabeth, NJ": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 12:07:17 AM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -19721,7 +18872,6 @@
   },
   "Elizabethtown, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -19741,7 +18891,6 @@
   },
   "Elk Grove, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 13, 2024, 4:51:42 PM UTC",
     "requirements": [
       "ADU",
       "Frequent Transit",
@@ -19773,7 +18922,6 @@
   },
   "Elk Point, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19793,7 +18941,6 @@
   },
   "Elk Rapids, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19818,7 +18965,6 @@
   },
   "Elk River, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 21, 2024, 9:05:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19838,7 +18984,6 @@
   },
   "Elkader, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19863,7 +19008,6 @@
   },
   "Elkhart, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other", "Bike Parking"],
     "citations": [
       {
@@ -19893,7 +19037,6 @@
   },
   "Elkhorn, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -19913,7 +19056,6 @@
   },
   "Elkins, WV": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19933,7 +19075,6 @@
   },
   "Elko, NV": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 8:42:24 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -19953,7 +19094,6 @@
   },
   "Elkton, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 10, 2024, 11:23:54 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -19973,7 +19113,6 @@
   },
   "Elkton, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 11, 2024, 8:45:12 PM UTC",
     "requirements": ["Size of Project", "Other", "Bike Parking"],
     "citations": [
       {
@@ -19993,7 +19132,6 @@
   },
   "Ellendale, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20013,7 +19151,6 @@
   },
   "Ellinwood, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20033,7 +19170,6 @@
   },
   "Elliot Lake, ON": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20053,7 +19189,6 @@
   },
   "Ellisville, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -20078,7 +19213,6 @@
   },
   "Ellsworth, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20098,7 +19232,6 @@
   },
   "Ellsworth, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -20123,7 +19256,6 @@
   },
   "Ellwood City, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20143,7 +19275,6 @@
   },
   "Elmhurst, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20163,7 +19294,6 @@
   },
   "Elmira, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "January 23, 2024, 4:33:36 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20183,7 +19313,6 @@
   },
   "Elmore, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20203,7 +19332,6 @@
   },
   "Elmwood, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20223,7 +19351,6 @@
   },
   "Eloy, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 5:16:04 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -20248,7 +19375,6 @@
   },
   "Elsie, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 13, 2024, 8:20:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20268,7 +19394,6 @@
   },
   "Elsmere, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Bike Parking", "Other", "Car Share"],
     "citations": [
       {
@@ -20288,7 +19413,6 @@
   },
   "Elverson, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 30, 2024, 7:05:35 PM UTC",
     "requirements": ["In Lieu Fees", "Other"],
     "citations": [
       {
@@ -20323,7 +19447,6 @@
   },
   "Elwood, UT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20343,7 +19466,6 @@
   },
   "Ely, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20363,7 +19485,6 @@
   },
   "Elyria, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20383,7 +19504,6 @@
   },
   "Emeryville, CA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20408,7 +19528,6 @@
   },
   "Emily, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "December 29, 2023, 12:51:49 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -20428,7 +19547,6 @@
   },
   "Emmitsburg, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 9:09:07 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -20453,7 +19571,6 @@
   },
   "Emporia, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20473,7 +19590,6 @@
   },
   "Englewood, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 6, 2024, 6:28:34 PM UTC",
     "requirements": ["By Right", "Frequent Transit", "Other"],
     "citations": [
       {
@@ -20503,7 +19619,6 @@
   },
   "Enid, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 13, 2024, 6:43:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20523,7 +19638,6 @@
   },
   "Ennis, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20543,7 +19657,6 @@
   },
   "Enterprise, AL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 7:19:51 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20563,7 +19676,6 @@
   },
   "Epworth, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20583,7 +19695,6 @@
   },
   "Erie, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 9:34:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20603,7 +19714,6 @@
   },
   "Erie, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20623,7 +19733,6 @@
   },
   "Erie, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20643,7 +19752,6 @@
   },
   "Erlanger, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Other", "Bike Parking", "Car Share"],
     "citations": [
       {
@@ -20663,7 +19771,6 @@
   },
   "Escanaba, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20683,7 +19790,6 @@
   },
   "Escondido, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 20, 2024, 8:57:28 PM UTC",
     "requirements": ["By Right", "ADU"],
     "citations": [
       {
@@ -20703,7 +19809,6 @@
   },
   "Estes Park, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 11:17:16 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20723,7 +19828,6 @@
   },
   "Estherville, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20743,7 +19847,6 @@
   },
   "Etna, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 23, 2024, 3:48:30 AM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -20763,7 +19866,6 @@
   },
   "Eugene, OR": {
     "reporter": "Will Dowdy",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20814,7 +19916,6 @@
   },
   "Eunice, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 5, 2024, 12:51:49 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20834,7 +19935,6 @@
   },
   "Eupora, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 2, 2024, 9:18:19 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20854,7 +19954,6 @@
   },
   "Eureka Springs, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20874,7 +19973,6 @@
   },
   "Eureka, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 6:42:58 AM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -20924,7 +20022,6 @@
   },
   "Evanston, IL": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -20944,7 +20041,6 @@
   },
   "Evanston, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -20969,7 +20065,6 @@
   },
   "Evansville, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other", "Bike Parking"],
     "citations": [
       {
@@ -21004,7 +20099,6 @@
   },
   "Evart, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 24, 2024, 9:45:51 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -21029,7 +20123,6 @@
   },
   "Evergreen Park, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 28, 2023, 7:44:06 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21049,7 +20142,6 @@
   },
   "Everly, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21069,7 +20161,6 @@
   },
   "Excelsior Springs, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21094,7 +20185,6 @@
   },
   "Excelsior, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -21119,7 +20209,6 @@
   },
   "Eyota, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21139,7 +20228,6 @@
   },
   "Fair Grove, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21159,7 +20247,6 @@
   },
   "Fairborn, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 5, 2024, 4:31:07 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -21184,7 +20271,6 @@
   },
   "Fairbury, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21204,7 +20290,6 @@
   },
   "Fairfax County, VA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 24, 2024, 4:26:08 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21257,7 +20342,6 @@
   },
   "Fairfax, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21277,7 +20361,6 @@
   },
   "Fairfield, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21297,7 +20380,6 @@
   },
   "Fairwater, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21317,7 +20399,6 @@
   },
   "Falcon Heights, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21337,7 +20418,6 @@
   },
   "Falconer, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21357,7 +20437,6 @@
   },
   "Falls City, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21377,7 +20456,6 @@
   },
   "Fallston, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 24, 2024, 9:42:10 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -21397,7 +20475,6 @@
   },
   "Fargo, ND": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21417,7 +20494,6 @@
   },
   "Faribault, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21437,7 +20513,6 @@
   },
   "Farley, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21457,7 +20532,6 @@
   },
   "Farmerville, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 5, 2024, 10:08:53 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21477,7 +20551,6 @@
   },
   "Farmington, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 19, 2024, 7:15:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21497,7 +20570,6 @@
   },
   "Farmington, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21517,7 +20589,6 @@
   },
   "Farmington, NM": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21537,7 +20608,6 @@
   },
   "Fayetteville, AR": {
     "reporter": "Bobby Siemiaszko",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right", "Bike Parking", "Frequent Transit", "Other"],
     "citations": [
       {
@@ -21570,7 +20640,6 @@
   },
   "Fayetteville, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 5:55:14 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -21600,7 +20669,6 @@
   },
   "Federalsburg, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 10, 2024, 6:56:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21620,7 +20688,6 @@
   },
   "Fenton, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 8:24:14 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -21645,7 +20712,6 @@
   },
   "Fergus Falls, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21665,7 +20731,6 @@
   },
   "Ferguson Township, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 25, 2024, 8:54:30 PM UTC",
     "requirements": ["Other", "Bike Parking"],
     "citations": [
       {
@@ -21685,7 +20750,6 @@
   },
   "Ferguson, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -21705,7 +20769,6 @@
   },
   "Fernandina Beach, FL": {
     "reporter": "Maggie Kochman",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21725,7 +20788,6 @@
   },
   "Ferndale, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 19, 2024, 10:49:13 PM UTC",
     "requirements": ["In Lieu Fees", "Other"],
     "citations": [
       {
@@ -21755,7 +20817,6 @@
   },
   "Ferndale, WA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21780,7 +20841,6 @@
   },
   "Ferrysburg, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 9:14:06 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -21805,7 +20865,6 @@
   },
   "Findlay, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 5, 2024, 5:51:31 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21830,7 +20889,6 @@
   },
   "Firestone, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 9:29:32 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21850,7 +20908,6 @@
   },
   "Firth, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21870,7 +20927,6 @@
   },
   "Fishers, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21890,7 +20946,6 @@
   },
   "Fitchburg, WI": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -21910,7 +20965,6 @@
   },
   "Flagstaff, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "January 23, 2024, 4:29:51 AM UTC",
     "requirements": ["Size of Project"],
     "citations": [
       {
@@ -21930,7 +20984,6 @@
   },
   "Flandreau, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -21950,7 +21003,6 @@
   },
   "Flemington, NJ": {
     "reporter": "Brian Budney",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -21970,7 +21022,6 @@
   },
   "Flensburg, SH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 2, 2024, 7:37:48 PM UTC",
     "requirements": [
       "Historic Preservation",
       "Car Share",
@@ -22012,7 +21063,6 @@
   },
   "Flint Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 9:15:20 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -22032,7 +21082,6 @@
   },
   "Flint, MI": {
     "reporter": "Joel Arnold",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -22052,7 +21101,6 @@
   },
   "Flora, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22072,7 +21120,6 @@
   },
   "Florence, AL": {
     "reporter": "Melissa Bailey",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22092,7 +21139,6 @@
   },
   "Florence, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 12:58:00 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22112,7 +21158,6 @@
   },
   "Florida, FL": {
     "reporter": "",
-    "updated": "May 16, 2024, 9:47:24 PM UTC",
     "requirements": ["Other", "Frequent Transit"],
     "citations": [
       {
@@ -22137,7 +21182,6 @@
   },
   "Florissant, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22157,7 +21201,6 @@
   },
   "Flushing, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 8:29:21 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -22177,7 +21220,6 @@
   },
   "Folcroft, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 23, 2024, 5:25:08 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -22197,7 +21239,6 @@
   },
   "Foley, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22217,7 +21258,6 @@
   },
   "Fond du Lac, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22237,7 +21277,6 @@
   },
   "Fontana, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 8:10:59 PM UTC",
     "requirements": [
       "Other",
       "Frequent Transit",
@@ -22263,7 +21302,6 @@
   },
   "Fontana-on-Geneva Lake, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22283,7 +21321,6 @@
   },
   "Ford City, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 11:30:45 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -22308,7 +21345,6 @@
   },
   "Ford Heights, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 28, 2023, 7:23:24 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -22333,7 +21369,6 @@
   },
   "Forest Hills, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 23, 2024, 4:31:39 AM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -22353,7 +21388,6 @@
   },
   "Forest Lake, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22373,7 +21407,6 @@
   },
   "Forest Park, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22393,7 +21426,6 @@
   },
   "Forest View, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 29, 2023, 1:33:09 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22413,7 +21445,6 @@
   },
   "Forman, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22433,7 +21464,6 @@
   },
   "Forrest City, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22453,7 +21483,6 @@
   },
   "Forsyth, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22473,7 +21502,6 @@
   },
   "Fort Atkinson, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22503,7 +21531,6 @@
   },
   "Fort Calhoun, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22523,7 +21550,6 @@
   },
   "Fort Collins, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 11:59:02 PM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -22570,7 +21596,6 @@
   },
   "Fort Dodge, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22590,7 +21615,6 @@
   },
   "Fort Lauderdale, FL": {
     "reporter": "Maggie Kochman",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["Other", "Size of Project"],
     "citations": [
       {
@@ -22610,7 +21634,6 @@
   },
   "Fort Lupton, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 10:22:36 PM UTC",
     "requirements": ["By Right", "Size of Project", "Bike Parking", "Other"],
     "citations": [
       {
@@ -22635,7 +21658,6 @@
   },
   "Fort Madison, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22655,7 +21677,6 @@
   },
   "Fort Mill, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -22680,7 +21701,6 @@
   },
   "Fort Mitchell, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Bike Parking", "Other"],
     "citations": [
       {
@@ -22700,7 +21720,6 @@
   },
   "Fort Morgan, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 4, 2024, 6:37:36 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -22720,7 +21739,6 @@
   },
   "Fort Myers, FL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 23, 2024, 4:46:55 AM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -22745,7 +21763,6 @@
   },
   "Fort Recovery, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 17, 2024, 5:56:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22765,7 +21782,6 @@
   },
   "Fort Smith, AR": {
     "reporter": "Abdul Ghous",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22790,7 +21806,6 @@
   },
   "Fort Stockton, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "December 9, 2023, 1:14:25 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22810,7 +21825,6 @@
   },
   "Fort Wayne, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other", "Bike Parking", "Frequent Transit"],
     "citations": [
       {
@@ -22840,7 +21854,6 @@
   },
   "Fort Worth, TX": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Historic Preservation"],
     "citations": [
       {
@@ -22854,7 +21867,6 @@
   },
   "Fort Wright, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22874,7 +21886,6 @@
   },
   "Fostoria, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 1:20:21 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -22894,7 +21905,6 @@
   },
   "Fountain Inn, SC": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22914,7 +21924,6 @@
   },
   "Fowlerville, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 8:51:50 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -22934,7 +21943,6 @@
   },
   "Fox Crossing, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22954,7 +21962,6 @@
   },
   "Fox Lake, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22974,7 +21981,6 @@
   },
   "Fox Lake, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -22994,7 +22000,6 @@
   },
   "Fox River Grove, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 3:09:23 AM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -23019,7 +22024,6 @@
   },
   "Framingham, MA": {
     "reporter": "Sam Scoppettone",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23039,7 +22043,6 @@
   },
   "Frankenmuth, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 9, 2024, 6:21:41 PM UTC",
     "requirements": ["Size of Project", "Tree Preservation", "Other"],
     "citations": [
       {
@@ -23059,7 +22062,6 @@
   },
   "Frankfort, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -23079,7 +22081,6 @@
   },
   "Frankfort, KY": {
     "reporter": "Brent Sweger",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Bike Parking", "Other"],
     "citations": [
       {
@@ -23099,7 +22100,6 @@
   },
   "Frankfurt, HE": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 6:13:05 PM UTC",
     "requirements": ["By Right", "Frequent Transit", "In Lieu Fees"],
     "citations": [
       {
@@ -23142,7 +22142,6 @@
   },
   "Franklin Park, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 28, 2023, 7:59:33 PM UTC",
     "requirements": ["Frequent Transit", "Other", "In Lieu Fees", "By Right"],
     "citations": [
       {
@@ -23167,7 +22166,6 @@
   },
   "Franklin, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23187,7 +22185,6 @@
   },
   "Franklin, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 6:34:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23207,7 +22204,6 @@
   },
   "Franklin, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23227,7 +22223,6 @@
   },
   "Frazee, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23247,7 +22242,6 @@
   },
   "Frazeysburg, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 10, 2024, 6:00:00 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23267,7 +22261,6 @@
   },
   "Frederic, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23287,7 +22280,6 @@
   },
   "Frederica, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -23307,7 +22299,6 @@
   },
   "Frederick, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 9:02:40 PM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -23347,7 +22338,6 @@
   },
   "Fredericktown, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 12:46:34 AM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -23367,7 +22357,6 @@
   },
   "Fredonia, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23387,7 +22376,6 @@
   },
   "Fredonia, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -23407,7 +22395,6 @@
   },
   "Fredonia, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23427,7 +22414,6 @@
   },
   "Freeport, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -23454,7 +22440,6 @@
   },
   "Freeport, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 6:05:32 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23479,7 +22464,6 @@
   },
   "Fremantle, WA": {
     "reporter": "Samuel Deetz",
-    "updated": "April 13, 2024, 4:54:28 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23499,7 +22483,6 @@
   },
   "Fremont, CA": {
     "reporter": "Tom Radulovich",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23529,7 +22512,6 @@
   },
   "Fremont, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 6, 2024, 5:46:58 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -23559,7 +22541,6 @@
   },
   "Fremont, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23579,7 +22560,6 @@
   },
   "Fremont, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23599,7 +22579,6 @@
   },
   "Frenchtown Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 3:46:06 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -23619,7 +22598,6 @@
   },
   "Frenchtown, NJ": {
     "reporter": "Jef Buehler",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23639,7 +22617,6 @@
   },
   "Fresno, CA": {
     "reporter": "Tom Manson",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23659,7 +22636,6 @@
   },
   "Fridley, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23679,7 +22655,6 @@
   },
   "Friesland, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23699,7 +22674,6 @@
   },
   "Frisco, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 5, 2024, 4:25:07 AM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -23734,7 +22708,6 @@
   },
   "Frisco, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 6:30:03 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23754,7 +22727,6 @@
   },
   "Frostburg, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -23774,7 +22746,6 @@
   },
   "Fruita, CO": {
     "reporter": "Tony Jordan",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23794,7 +22765,6 @@
   },
   "Fullerton, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 20, 2024, 8:51:58 PM UTC",
     "requirements": ["ADU", "By Right"],
     "citations": [
       {
@@ -23819,7 +22789,6 @@
   },
   "Fullerton, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23839,7 +22808,6 @@
   },
   "Fulton, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23859,7 +22827,6 @@
   },
   "Gadsden, AL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 10:29:10 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23879,7 +22846,6 @@
   },
   "Gaines Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 8:44:24 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23899,7 +22865,6 @@
   },
   "Gaines, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 8:55:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23919,7 +22884,6 @@
   },
   "Gainesville, FL": {
     "reporter": "Tony Jordan",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -23944,7 +22908,6 @@
   },
   "Gaithersburg, MD": {
     "reporter": "Chris Berger",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Historic Preservation"],
     "citations": [
       {
@@ -23964,7 +22927,6 @@
   },
   "Galena, IL": {
     "reporter": "Jake Schreiner",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -23984,7 +22946,6 @@
   },
   "Galena, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24004,7 +22965,6 @@
   },
   "Galesburg, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24024,7 +22984,6 @@
   },
   "Galesburg, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -24044,7 +23003,6 @@
   },
   "Galion, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 30, 2024, 4:25:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24064,7 +23022,6 @@
   },
   "Gallipolis, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 7:41:59 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24084,7 +23041,6 @@
   },
   "Galva, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24104,7 +23060,6 @@
   },
   "Gambier, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 12:59:41 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24124,7 +23079,6 @@
   },
   "Garden City, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 12:50:43 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24144,7 +23098,6 @@
   },
   "Garden Grove, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 20, 2024, 9:32:08 PM UTC",
     "requirements": [
       "ADU",
       "Historic Preservation",
@@ -24170,7 +23123,6 @@
   },
   "Garden Plain, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24190,7 +23142,6 @@
   },
   "Gardner, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project", "Bike Parking", "Other"],
     "citations": [
       {
@@ -24210,7 +23161,6 @@
   },
   "Garfield Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "December 9, 2023, 2:04:03 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24230,7 +23180,6 @@
   },
   "Garland, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 9:36:39 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -24250,7 +23199,6 @@
   },
   "Garnavillo, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24270,7 +23218,6 @@
   },
   "Garrett, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24290,7 +23237,6 @@
   },
   "Garrettsville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 11, 2024, 4:23:32 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -24310,7 +23256,6 @@
   },
   "Gary, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -24340,7 +23285,6 @@
   },
   "Gas City, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24360,7 +23304,6 @@
   },
   "Gastonia, NC": {
     "reporter": "Brian Burnham",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24380,7 +23323,6 @@
   },
   "Gaylord, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24400,7 +23342,6 @@
   },
   "Gays Mills, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24430,7 +23371,6 @@
   },
   "Gem Lake, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24450,7 +23390,6 @@
   },
   "Geneva, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["In Lieu Fees", "By Right"],
     "citations": [
       {
@@ -24475,7 +23414,6 @@
   },
   "Geneva, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -24495,7 +23433,6 @@
   },
   "Genoa Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 9:07:36 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -24520,7 +23457,6 @@
   },
   "Genoa City, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -24540,7 +23476,6 @@
   },
   "Genoa, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "In Lieu Fees", "Other"],
     "citations": [
       {
@@ -24565,7 +23500,6 @@
   },
   "Genoa, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24585,7 +23519,6 @@
   },
   "Genoa, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24605,7 +23538,6 @@
   },
   "George, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24625,7 +23557,6 @@
   },
   "Georgetown Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 9:59:24 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24645,7 +23576,6 @@
   },
   "Georgetown, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 1, 2024, 4:29:18 AM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -24665,7 +23595,6 @@
   },
   "Gerald, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24685,7 +23614,6 @@
   },
   "Gering, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project", "Bike Parking", "Other"],
     "citations": [
       {
@@ -24710,7 +23638,6 @@
   },
   "Germantown, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -24735,7 +23662,6 @@
   },
   "Gettysburg, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 12, 2024, 5:03:13 PM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -24771,7 +23697,6 @@
   },
   "Gibsonburg, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24791,7 +23716,6 @@
   },
   "Gilbert, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 7:12:04 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -24811,7 +23735,6 @@
   },
   "Gillette, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24831,7 +23754,6 @@
   },
   "Gilman, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24851,7 +23773,6 @@
   },
   "Gladwin, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 24, 2024, 9:16:23 PM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -24876,7 +23797,6 @@
   },
   "Glasford, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "February 25, 2024, 3:46:59 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24896,7 +23816,6 @@
   },
   "Glen Carbon, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 22, 2024, 7:27:55 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -24916,7 +23835,6 @@
   },
   "Glen Ellyn, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24936,7 +23854,6 @@
   },
   "Glencoe, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24961,7 +23878,6 @@
   },
   "Glencoe, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 21, 2024, 5:29:34 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -24981,7 +23897,6 @@
   },
   "Glendale, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 7:02:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25001,7 +23916,6 @@
   },
   "Glendale, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 12, 2024, 11:02:35 PM UTC",
     "requirements": [
       "ADU",
       "Frequent Transit",
@@ -25038,7 +23952,6 @@
   },
   "Glendale, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 6, 2024, 6:33:42 PM UTC",
     "requirements": ["TDM"],
     "citations": [
       {
@@ -25058,7 +23971,6 @@
   },
   "Glendale, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -25078,7 +23990,6 @@
   },
   "Glendive, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25098,7 +24009,6 @@
   },
   "Glenfield, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 1:14:46 AM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -25118,7 +24028,6 @@
   },
   "Glenrock, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25138,7 +24047,6 @@
   },
   "Glenview, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25158,7 +24066,6 @@
   },
   "Glenwood Springs, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["In Lieu Fees", "Size of Project", "By Right"],
     "citations": [
       {
@@ -25183,7 +24090,6 @@
   },
   "Glenwood, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25203,7 +24109,6 @@
   },
   "Glenwood, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -25228,7 +24133,6 @@
   },
   "Glidden, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25248,7 +24152,6 @@
   },
   "Goddard, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25268,7 +24171,6 @@
   },
   "Goehner, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25288,7 +24190,6 @@
   },
   "Gold Hill, OR": {
     "reporter": "Samuel Deetz",
-    "updated": "December 24, 2023, 7:01:23 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25308,7 +24209,6 @@
   },
   "Golden Valley, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 21, 2024, 9:55:45 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -25333,7 +24233,6 @@
   },
   "Golden, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 7, 2024, 3:16:43 AM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -25363,7 +24262,6 @@
   },
   "Golf, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "February 15, 2024, 11:20:59 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25383,7 +24281,6 @@
   },
   "Gonzales, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 26, 2024, 3:09:05 AM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -25414,7 +24311,6 @@
   },
   "Good Thunder, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -25434,7 +24330,6 @@
   },
   "Goodfield, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 16, 2024, 6:48:04 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25459,7 +24354,6 @@
   },
   "Goodhue, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25479,7 +24373,6 @@
   },
   "Goodland, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25499,7 +24392,6 @@
   },
   "Goodrich, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 8:59:39 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -25519,7 +24411,6 @@
   },
   "Gothenburg, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25539,7 +24430,6 @@
   },
   "Gowrie, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25559,7 +24449,6 @@
   },
   "Grafton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25579,7 +24468,6 @@
   },
   "Grafton, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -25604,7 +24492,6 @@
   },
   "Graham, NC": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25639,7 +24526,6 @@
   },
   "Grain Valley, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25659,7 +24545,6 @@
   },
   "Gramercy, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 26, 2024, 2:16:19 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25679,7 +24564,6 @@
   },
   "Granby, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 5, 2024, 5:52:01 AM UTC",
     "requirements": ["In Lieu Fees", "Other", "By Right"],
     "citations": [
       {
@@ -25719,7 +24603,6 @@
   },
   "Grand Blanc Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 9:22:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25739,7 +24622,6 @@
   },
   "Grand Forks, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees", "Bike Parking", "Other"],
     "citations": [
       {
@@ -25759,7 +24641,6 @@
   },
   "Grand Haven Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 10:06:44 PM UTC",
     "requirements": ["ADU", "By Right"],
     "citations": [
       {
@@ -25784,7 +24665,6 @@
   },
   "Grand Haven, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 9:24:04 PM UTC",
     "requirements": ["Other", "Bike Parking"],
     "citations": [
       {
@@ -25814,7 +24694,6 @@
   },
   "Grand Island, NE": {
     "reporter": "Chad Nabity",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25834,7 +24713,6 @@
   },
   "Grand Junction, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 9:47:05 PM UTC",
     "requirements": ["By Right", "Bike Parking", "Other", "Frequent Transit"],
     "citations": [
       {
@@ -25869,7 +24747,6 @@
   },
   "Grand Lake, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 15, 2024, 4:33:45 AM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -25889,7 +24766,6 @@
   },
   "Grand Ledge, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 13, 2024, 8:10:49 PM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -25914,7 +24790,6 @@
   },
   "Grand Marais, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -25934,7 +24809,6 @@
   },
   "Grand Prairie, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "February 14, 2024, 6:48:26 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -25959,7 +24833,6 @@
   },
   "Grand Rapids, MI": {
     "reporter": "Suzanne Schulz",
-    "updated": "April 26, 2024, 9:47:24 PM UTC",
     "requirements": [
       "Frequent Transit",
       "In Lieu Fees",
@@ -26013,7 +24886,6 @@
   },
   "Grand Rapids, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26033,7 +24905,6 @@
   },
   "Grand Rapids, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 1:43:44 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26053,7 +24924,6 @@
   },
   "Grandview, MO": {
     "reporter": "Dave McCumber",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26073,7 +24943,6 @@
   },
   "Grandville, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 7:44:07 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -26098,7 +24967,6 @@
   },
   "Granger, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26118,7 +24986,6 @@
   },
   "Granite Falls, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26138,7 +25005,6 @@
   },
   "Granite Quarry, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -26158,7 +25024,6 @@
   },
   "Grant, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 6, 2024, 5:56:48 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -26178,7 +25043,6 @@
   },
   "Grants Pass, OR": {
     "reporter": "Bradley Clark",
-    "updated": "May 28, 2024, 12:56:00 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26211,7 +25075,6 @@
   },
   "Grantsville, UT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -26231,7 +25094,6 @@
   },
   "Granville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 5:33:46 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26251,7 +25113,6 @@
   },
   "Grass Lake Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 10:23:17 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -26271,7 +25132,6 @@
   },
   "Grass Lake, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 10:52:03 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -26291,7 +25151,6 @@
   },
   "Grayling Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 7:11:07 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26311,7 +25170,6 @@
   },
   "Grayling, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 7:03:56 PM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -26336,7 +25194,6 @@
   },
   "Graymoor-Devondale, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "August 4, 2024, 3:23:03 AM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -26372,7 +25229,6 @@
   },
   "Grayslake, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26392,7 +25248,6 @@
   },
   "Grayson, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26417,7 +25272,6 @@
   },
   "Great Falls, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26442,7 +25296,6 @@
   },
   "Greeley, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 11:13:03 PM UTC",
     "requirements": ["By Right", "Bike Parking", "Other", "Size of Project"],
     "citations": [
       {
@@ -26467,7 +25320,6 @@
   },
   "Green Bay, WI": {
     "reporter": "Brian Johnson",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26487,7 +25339,6 @@
   },
   "Green Forest, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26507,7 +25358,6 @@
   },
   "Green Mountain Falls, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 3:52:19 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26527,7 +25377,6 @@
   },
   "Green River, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26547,7 +25396,6 @@
   },
   "Green Springs, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26567,7 +25415,6 @@
   },
   "Greencastle, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 26, 2024, 12:08:16 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26587,7 +25434,6 @@
   },
   "Greendale, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -26607,7 +25453,6 @@
   },
   "Greendale, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -26632,7 +25477,6 @@
   },
   "Greenfield, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -26657,7 +25501,6 @@
   },
   "Greenfield, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 5:32:52 PM UTC",
     "requirements": ["Other", "In Lieu Fees", "By Right"],
     "citations": [
       {
@@ -26692,7 +25535,6 @@
   },
   "Greensboro, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 1:47:37 AM UTC",
     "requirements": [
       "By Right",
       "Historic Preservation",
@@ -26737,7 +25579,6 @@
   },
   "Greensburg, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26757,7 +25598,6 @@
   },
   "Greensburg, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26777,7 +25617,6 @@
   },
   "Greensburg, PA": {
     "reporter": "Brian Lawrence",
-    "updated": "January 1, 2024, 9:53:28 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26810,7 +25649,6 @@
   },
   "Greenville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 4:14:20 AM UTC",
     "requirements": ["By Right", "Other", "In Lieu Fees"],
     "citations": [
       {
@@ -26855,7 +25693,6 @@
   },
   "Greenville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 16, 2024, 10:32:08 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26875,7 +25712,6 @@
   },
   "Greenville, SC": {
     "reporter": "Erika Hollis",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Historic Preservation"],
     "citations": [
       {
@@ -26895,7 +25731,6 @@
   },
   "Greenwood, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": [
       "Bike Parking",
       "Frequent Transit",
@@ -26920,7 +25755,6 @@
   },
   "Greenwood, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26940,7 +25774,6 @@
   },
   "Grenada, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -26960,7 +25793,6 @@
   },
   "Gretna, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 26, 2024, 1:20:35 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -26980,7 +25812,6 @@
   },
   "Gridley, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27000,7 +25831,6 @@
   },
   "Grimes, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 31, 2024, 8:19:07 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -27025,7 +25855,6 @@
   },
   "Grinnell, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27045,7 +25874,6 @@
   },
   "Griswold, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27065,7 +25893,6 @@
   },
   "Grosse Pointe, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 5:00:20 PM UTC",
     "requirements": ["In Lieu Fees", "Other"],
     "citations": [
       {
@@ -27090,7 +25917,6 @@
   },
   "Groton, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27110,7 +25936,6 @@
   },
   "Grove City, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27130,7 +25955,6 @@
   },
   "Grundy Center, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27150,7 +25974,6 @@
   },
   "Gulfport, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 6:43:16 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27170,7 +25993,6 @@
   },
   "Gunnison, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 4, 2024, 7:19:58 PM UTC",
     "requirements": ["By Right", "ADU"],
     "citations": [
       {
@@ -27195,7 +26017,6 @@
   },
   "Gurnee, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Size of Project"],
     "citations": [
       {
@@ -27215,7 +26036,6 @@
   },
   "Guthrie Center, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27235,7 +26055,6 @@
   },
   "Guthrie, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Historic Preservation"],
     "citations": [
       {
@@ -27255,7 +26074,6 @@
   },
   "Guthrie, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 16, 2024, 6:56:20 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -27275,7 +26093,6 @@
   },
   "Guttenberg, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27295,7 +26112,6 @@
   },
   "Hagerstown, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 7:53:57 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -27315,7 +26131,6 @@
   },
   "Hainesville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27335,7 +26150,6 @@
   },
   "Halifax, NS": {
     "reporter": "Sean Gillis",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27349,7 +26163,6 @@
   },
   "Halifax, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 19, 2024, 4:27:50 AM UTC",
     "requirements": ["Other", "Size of Project", "By Right"],
     "citations": [
       {
@@ -27379,7 +26192,6 @@
   },
   "Hallsville, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27399,7 +26211,6 @@
   },
   "Hamilton, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -27419,7 +26230,6 @@
   },
   "Hamilton, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -27449,7 +26259,6 @@
   },
   "Hamilton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Other", "Bike Parking", "Historic Preservation"],
     "citations": [
       {
@@ -27474,7 +26283,6 @@
   },
   "Hammond, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27499,7 +26307,6 @@
   },
   "Hammond, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 28, 2024, 3:41:51 AM UTC",
     "requirements": ["By Right", "Bike Parking", "Frequent Transit", "Other"],
     "citations": [
       {
@@ -27529,7 +26336,6 @@
   },
   "Hampden, ME": {
     "reporter": "Clifton Iler",
-    "updated": "March 14, 2024, 5:50:04 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27554,7 +26360,6 @@
   },
   "Hampshire, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Size of Project", "In Lieu Fees"],
     "citations": [
       {
@@ -27574,7 +26379,6 @@
   },
   "Hampton, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -27594,7 +26398,6 @@
   },
   "Hampton, VA": {
     "reporter": "Samuel Deetz",
-    "updated": "May 13, 2024, 5:52:28 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -27642,7 +26445,6 @@
   },
   "Hamtramck, MI": {
     "reporter": "Nani Wolf",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -27662,7 +26464,6 @@
   },
   "Hancock, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27682,7 +26483,6 @@
   },
   "Hannibal, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 3:43:02 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27702,7 +26502,6 @@
   },
   "Hanover Park, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -27722,7 +26521,6 @@
   },
   "Harford County, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 4:56:23 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27742,7 +26540,6 @@
   },
   "Haring Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 8:50:36 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -27767,7 +26564,6 @@
   },
   "Harmony, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 24, 2024, 9:30:44 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -27787,7 +26583,6 @@
   },
   "Harrington, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -27817,7 +26612,6 @@
   },
   "Harrisburg, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -27852,7 +26646,6 @@
   },
   "Harrisburg, PA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27872,7 +26665,6 @@
   },
   "Harrison Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 8:56:45 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -27902,7 +26694,6 @@
   },
   "Harrison, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -27922,7 +26713,6 @@
   },
   "Harrison, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 24, 2024, 9:32:58 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -27947,7 +26737,6 @@
   },
   "Harrison, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27967,7 +26756,6 @@
   },
   "Harrisonburg, VA": {
     "reporter": "Austin Sachs",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -27987,7 +26775,6 @@
   },
   "Harrisonville, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28007,7 +26794,6 @@
   },
   "Harristown, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28027,7 +26813,6 @@
   },
   "Harrisville, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 7:21:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28052,7 +26837,6 @@
   },
   "Hart, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 6, 2024, 6:22:32 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28077,7 +26861,6 @@
   },
   "Hartford, CT": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28097,7 +26880,6 @@
   },
   "Hartford, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28117,7 +26899,6 @@
   },
   "Hartford, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 9:09:01 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -28137,7 +26918,6 @@
   },
   "Hartford, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28157,7 +26937,6 @@
   },
   "Hartland, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -28177,7 +26956,6 @@
   },
   "Hartley, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28197,7 +26975,6 @@
   },
   "Harvard, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Bike Parking", "By Right"],
     "citations": [
       {
@@ -28222,7 +26999,6 @@
   },
   "Harvey, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": [
       "Tree Preservation",
       "Bike Parking",
@@ -28247,7 +27023,6 @@
   },
   "Harveysburg, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28267,7 +27042,6 @@
   },
   "Harwood Heights, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -28292,7 +27066,6 @@
   },
   "Haskell, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -28312,7 +27085,6 @@
   },
   "Hastings, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28332,7 +27104,6 @@
   },
   "Hastings, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28352,7 +27123,6 @@
   },
   "Hattiesburg, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 11:03:40 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -28372,7 +27142,6 @@
   },
   "Haubstadt, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28392,7 +27161,6 @@
   },
   "Havana, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 2:12:00 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28412,7 +27180,6 @@
   },
   "Hawarden, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28432,7 +27199,6 @@
   },
   "Hawley, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28452,7 +27218,6 @@
   },
   "Hays, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28472,7 +27237,6 @@
   },
   "Haysville, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 1:16:08 AM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -28492,7 +27256,6 @@
   },
   "Hayward, CA": {
     "reporter": "Patrick Siegman",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28525,7 +27288,6 @@
   },
   "Hayward, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28545,7 +27307,6 @@
   },
   "Hazel Park, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 19, 2024, 10:55:11 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28565,7 +27326,6 @@
   },
   "Hazen, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28585,7 +27345,6 @@
   },
   "Healdsburg, CA": {
     "reporter": "Tony Jordan",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -28605,7 +27364,6 @@
   },
   "Hebron, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -28625,7 +27383,6 @@
   },
   "Heidelberg, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 3:02:03 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -28650,7 +27407,6 @@
   },
   "Helena, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28670,7 +27426,6 @@
   },
   "Henderson County, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28690,7 +27445,6 @@
   },
   "Henderson, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28710,7 +27464,6 @@
   },
   "Henderson, NV": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 7:20:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28730,7 +27483,6 @@
   },
   "Hendricks, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28750,7 +27502,6 @@
   },
   "Hennepin, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28770,7 +27521,6 @@
   },
   "Henry, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 12:57:12 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28790,7 +27540,6 @@
   },
   "Herington, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28810,7 +27559,6 @@
   },
   "Hermann, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28830,7 +27578,6 @@
   },
   "Hermosa, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28850,7 +27597,6 @@
   },
   "Hesston, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28870,7 +27616,6 @@
   },
   "Heyworth, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -28890,7 +27635,6 @@
   },
   "Hialeah, FL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 4:52:31 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28910,7 +27654,6 @@
   },
   "Hiawatha, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28930,7 +27673,6 @@
   },
   "Hibbing, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28950,7 +27692,6 @@
   },
   "Hickman, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28970,7 +27711,6 @@
   },
   "Hickory, NC": {
     "reporter": "Ross Zelenske",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -28990,7 +27730,6 @@
   },
   "Higginsville, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29010,7 +27749,6 @@
   },
   "High River, AB": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -29045,7 +27783,6 @@
   },
   "Highland Park, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -29082,7 +27819,6 @@
   },
   "Highland Park, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 5:18:34 PM UTC",
     "requirements": [
       "In Lieu Fees",
       "Other",
@@ -29118,7 +27854,6 @@
   },
   "Highland, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -29138,7 +27873,6 @@
   },
   "Highland, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Other", "Bike Parking"],
     "citations": [
       {
@@ -29168,7 +27902,6 @@
   },
   "Highland, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -29188,7 +27921,6 @@
   },
   "Highspire, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 19, 2024, 4:53:46 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -29213,7 +27945,6 @@
   },
   "Highwood, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -29233,7 +27964,6 @@
   },
   "Hillcrest, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "In Lieu Fees", "Other"],
     "citations": [
       {
@@ -29258,7 +27988,6 @@
   },
   "Hilliard, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 5:55:05 PM UTC",
     "requirements": ["Bike Parking", "By Right"],
     "citations": [
       {
@@ -29278,7 +28007,6 @@
   },
   "Hillman, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -29308,7 +28036,6 @@
   },
   "Hillsboro, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29328,7 +28055,6 @@
   },
   "Hillsboro, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 5:17:18 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29348,7 +28074,6 @@
   },
   "Hillsdale, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 31, 2024, 6:07:51 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -29378,7 +28103,6 @@
   },
   "Hinckley, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29398,7 +28122,6 @@
   },
   "Hinsdale, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -29418,7 +28141,6 @@
   },
   "Hixton, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29438,7 +28160,6 @@
   },
   "Holdrege, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29458,7 +28179,6 @@
   },
   "Holland, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 9:35:52 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29478,7 +28198,6 @@
   },
   "Hollandale, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -29498,7 +28217,6 @@
   },
   "Holly, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 5:28:04 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29523,7 +28241,6 @@
   },
   "Hollywood, FL": {
     "reporter": "Samuel Deetz",
-    "updated": "February 14, 2024, 9:37:58 PM UTC",
     "requirements": ["In Lieu Fees", "Size of Project", "By Right"],
     "citations": [
       {
@@ -29548,7 +28265,6 @@
   },
   "Holmen, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29568,7 +28284,6 @@
   },
   "Homer, AK": {
     "reporter": "Samuel Deetz",
-    "updated": "February 15, 2024, 6:25:21 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -29593,7 +28308,6 @@
   },
   "Homestead, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 3:25:43 AM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -29613,7 +28327,6 @@
   },
   "Homewood, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29633,7 +28346,6 @@
   },
   "Honolulu, HI": {
     "reporter": "Tim Streitz",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29653,7 +28365,6 @@
   },
   "Hopkins, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": [
       "By Right",
       "Affordable Housing",
@@ -29695,7 +28406,6 @@
   },
   "Hopkinsville, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29715,7 +28425,6 @@
   },
   "Hot Springs, AR": {
     "reporter": "Bobby Siemiaszko",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29748,7 +28457,6 @@
   },
   "Hot Springs, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29768,7 +28476,6 @@
   },
   "Hotchkiss, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 5:50:26 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -29788,7 +28495,6 @@
   },
   "Houghton, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29813,7 +28519,6 @@
   },
   "Houston, TX": {
     "reporter": "John Gardosik",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29859,7 +28564,6 @@
   },
   "Howard County, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 7:08:56 PM UTC",
     "requirements": ["TDM", "Size of Project"],
     "citations": [
       {
@@ -29879,7 +28583,6 @@
   },
   "Howell, MI": {
     "reporter": "Nani Wolf",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -29899,7 +28602,6 @@
   },
   "Hubbard, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29924,7 +28626,6 @@
   },
   "Hubbard, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29944,7 +28645,6 @@
   },
   "Hudson, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29964,7 +28664,6 @@
   },
   "Hudson, NY": {
     "reporter": "Betsy Gramkow",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -29984,7 +28683,6 @@
   },
   "Hudson, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 11, 2024, 11:39:31 PM UTC",
     "requirements": ["Historic Preservation"],
     "citations": [
       {
@@ -30019,7 +28717,6 @@
   },
   "Hudson, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Size of Project", "In Lieu Fees"],
     "citations": [
       {
@@ -30044,7 +28741,6 @@
   },
   "Hudsonville, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 9:43:11 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -30074,7 +28770,6 @@
   },
   "Hugo, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 4, 2024, 5:59:24 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -30094,7 +28789,6 @@
   },
   "Hugoton, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30114,7 +28808,6 @@
   },
   "Hummelstown, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 19, 2024, 5:03:31 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30134,7 +28827,6 @@
   },
   "Humphrey, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30154,7 +28846,6 @@
   },
   "Huntersville, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -30179,7 +28870,6 @@
   },
   "Huntertown, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right", "Other", "Bike Parking", "Frequent Transit"],
     "citations": [
       {
@@ -30204,7 +28894,6 @@
   },
   "Huntingburg, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30224,7 +28913,6 @@
   },
   "Huntingdon, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 26, 2024, 5:31:34 PM UTC",
     "requirements": ["In Lieu Fees", "Other"],
     "citations": [
       {
@@ -30244,7 +28932,6 @@
   },
   "Huntington Beach, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 12, 2024, 11:52:50 PM UTC",
     "requirements": ["ADU", "In Lieu Fees"],
     "citations": [
       {
@@ -30269,7 +28956,6 @@
   },
   "Huntington Woods, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 19, 2024, 11:01:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30289,7 +28975,6 @@
   },
   "Huntington, WV": {
     "reporter": "Shae Strait",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -30309,7 +28994,6 @@
   },
   "Huntsville, AL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30329,7 +29013,6 @@
   },
   "Huntsville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 5:35:13 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -30349,7 +29032,6 @@
   },
   "Hurley, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30369,7 +29051,6 @@
   },
   "Huron Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 2:55:53 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30389,7 +29070,6 @@
   },
   "Huron, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -30414,7 +29094,6 @@
   },
   "Hurstbourne, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "August 4, 2024, 3:01:00 AM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -30450,7 +29129,6 @@
   },
   "Hustisford, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30470,7 +29148,6 @@
   },
   "Hutchinson, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30490,7 +29167,6 @@
   },
   "Huxley, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30510,7 +29186,6 @@
   },
   "Ida Grove, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30530,7 +29205,6 @@
   },
   "Idaho Springs, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 1, 2024, 4:26:46 AM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -30550,7 +29224,6 @@
   },
   "Illinois, IL": {
     "reporter": "",
-    "updated": "February 26, 2024, 9:03:02 PM UTC",
     "requirements": ["Frequent Transit"],
     "citations": [
       {
@@ -30570,7 +29243,6 @@
   },
   "Imlay City, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 7:23:32 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -30595,7 +29267,6 @@
   },
   "Imperial, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30615,7 +29286,6 @@
   },
   "Independence, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30635,7 +29305,6 @@
   },
   "Independence, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right", "Car Share", "Bike Parking", "Other"],
     "citations": [
       {
@@ -30660,7 +29329,6 @@
   },
   "Independence, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -30680,7 +29348,6 @@
   },
   "Independence, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30700,7 +29367,6 @@
   },
   "Indian Hills, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "August 3, 2024, 8:21:28 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -30725,7 +29391,6 @@
   },
   "Indian Trail, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Bike Parking", "By Right"],
     "citations": [
       {
@@ -30755,7 +29420,6 @@
   },
   "Indiana, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 26, 2024, 6:06:04 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30775,7 +29439,6 @@
   },
   "Indianapolis, IN": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30800,7 +29463,6 @@
   },
   "Indianola, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30820,7 +29482,6 @@
   },
   "Ingolstadt, BY": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 5:39:57 PM UTC",
     "requirements": ["In Lieu Fees", "Bike Parking", "TDM"],
     "citations": [
       {
@@ -30850,7 +29511,6 @@
   },
   "Inman, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30870,7 +29530,6 @@
   },
   "Inola, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 3:22:07 PM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -30900,7 +29559,6 @@
   },
   "Iola, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30920,7 +29578,6 @@
   },
   "Iola, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30940,7 +29597,6 @@
   },
   "Ionia, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 6:15:25 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30960,7 +29616,6 @@
   },
   "Iowa City, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -30980,7 +29635,6 @@
   },
   "Ipswich, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31000,7 +29654,6 @@
   },
   "Iron Ridge, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31020,7 +29673,6 @@
   },
   "Iron River, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31040,7 +29692,6 @@
   },
   "Ironwood, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31060,7 +29711,6 @@
   },
   "Irvine, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 11:49:55 PM UTC",
     "requirements": ["ADU"],
     "citations": [
       {
@@ -31080,7 +29730,6 @@
   },
   "Irving, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 7:50:25 PM UTC",
     "requirements": ["Frequent Transit"],
     "citations": [
       {
@@ -31105,7 +29754,6 @@
   },
   "Irvington, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31125,7 +29773,6 @@
   },
   "Ishpeming, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31145,7 +29792,6 @@
   },
   "Israel": {
     "reporter": "Erel Herzog",
-    "updated": "July 17, 2024, 4:27:55 AM UTC",
     "requirements": ["Frequent Transit", "By Right"],
     "citations": [
       {
@@ -31165,7 +29811,6 @@
   },
   "Ithaca, NY": {
     "reporter": "Daniel Keough",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31198,7 +29843,6 @@
   },
   "Jackson, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 10:35:52 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31228,7 +29872,6 @@
   },
   "Jackson, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31248,7 +29891,6 @@
   },
   "Jackson, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 9:03:57 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31268,7 +29910,6 @@
   },
   "Jackson, TN": {
     "reporter": "Scott Conger",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -31288,7 +29929,6 @@
   },
   "Jacksonville, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31308,7 +29948,6 @@
   },
   "Jacksonville, FL": {
     "reporter": "Kevin O'Halloran",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31328,7 +29967,6 @@
   },
   "Jacksonville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -31353,7 +29991,6 @@
   },
   "Jamestown, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31373,7 +30010,6 @@
   },
   "Jamestown, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31393,7 +30029,6 @@
   },
   "Jamestown, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31413,7 +30048,6 @@
   },
   "Jamestown, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 4:03:12 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -31433,7 +30067,6 @@
   },
   "Janesville, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31453,7 +30086,6 @@
   },
   "Janesville, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31473,7 +30105,6 @@
   },
   "Jasper County, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31493,7 +30124,6 @@
   },
   "Jasper, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31518,7 +30148,6 @@
   },
   "Jefferson City, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -31538,7 +30167,6 @@
   },
   "Jefferson County, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 3:59:52 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -31558,7 +30186,6 @@
   },
   "Jefferson, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31583,7 +30210,6 @@
   },
   "Jefferson, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31608,7 +30234,6 @@
   },
   "Jeffersontown, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "August 2, 2024, 4:20:10 AM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -31643,7 +30268,6 @@
   },
   "Jeffersonville, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": [
       "Frequent Transit",
       "Bike Parking",
@@ -31679,7 +30303,6 @@
   },
   "Jenks, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 6:58:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31699,7 +30322,6 @@
   },
   "Jennings County, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "December 28, 2023, 11:43:10 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -31724,7 +30346,6 @@
   },
   "Jennings, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31744,7 +30365,6 @@
   },
   "Jerome, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 2:27:53 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31764,7 +30384,6 @@
   },
   "Jersey City, NJ": {
     "reporter": "Ed Gomez",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31784,7 +30403,6 @@
   },
   "Jerseyville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31804,7 +30422,6 @@
   },
   "Jim Thorpe, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 25, 2024, 7:32:21 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31829,7 +30446,6 @@
   },
   "Johnson City, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31849,7 +30465,6 @@
   },
   "Johnson Creek, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -31869,7 +30484,6 @@
   },
   "Johnson, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Other", "Bike Parking", "Frequent Transit"],
     "citations": [
       {
@@ -31894,7 +30508,6 @@
   },
   "Johnston City, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31914,7 +30527,6 @@
   },
   "Johnston, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 6:42:15 PM UTC",
     "requirements": ["Frequent Transit"],
     "citations": [
       {
@@ -31934,7 +30546,6 @@
   },
   "Johnstown, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 25, 2024, 2:11:46 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -31959,7 +30570,6 @@
   },
   "Joliet, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31979,7 +30589,6 @@
   },
   "Jonesboro, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -31999,7 +30608,6 @@
   },
   "Jonesboro, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32019,7 +30627,6 @@
   },
   "Jonesboro, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 5, 2024, 9:58:52 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32039,7 +30646,6 @@
   },
   "Joplin, MO": {
     "reporter": "Sam Anselm",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right", "Bike Parking", "Other"],
     "citations": [
       {
@@ -32064,7 +30670,6 @@
   },
   "Joy, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 4:27:42 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32084,7 +30689,6 @@
   },
   "Junction City, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -32104,7 +30708,6 @@
   },
   "Juneau, AK": {
     "reporter": "Samuel Deetz",
-    "updated": "February 15, 2024, 5:53:48 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -32139,7 +30742,6 @@
   },
   "Juneau, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32159,7 +30761,6 @@
   },
   "Kalamazoo Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 4:30:05 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32179,7 +30780,6 @@
   },
   "Kalamazoo, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 22, 2024, 8:35:55 PM UTC",
     "requirements": ["By Right", "Other", "Bike Parking", "Size of Project"],
     "citations": [
       {
@@ -32214,7 +30814,6 @@
   },
   "Kaleva, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 6:42:03 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32234,7 +30833,6 @@
   },
   "Kalispell, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -32269,7 +30867,6 @@
   },
   "Kalkaska, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 6:27:12 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32289,7 +30886,6 @@
   },
   "Kankakee County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -32309,7 +30905,6 @@
   },
   "Kankakee, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -32334,7 +30929,6 @@
   },
   "Kansas City, MO": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32354,7 +30948,6 @@
   },
   "Kassel, HE": {
     "reporter": "Samuel Deetz",
-    "updated": "May 4, 2024, 1:45:53 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32386,7 +30979,6 @@
   },
   "Kasson, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32406,7 +30998,6 @@
   },
   "Kearney, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32426,7 +31017,6 @@
   },
   "Keego Harbor, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 19, 2024, 11:07:10 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -32446,7 +31036,6 @@
   },
   "Kemmerer, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -32471,7 +31060,6 @@
   },
   "Kenilworth, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 28, 2023, 11:10:17 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -32496,7 +31084,6 @@
   },
   "Kenner, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 7:21:11 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32516,7 +31103,6 @@
   },
   "Kenora, ON": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -32536,7 +31122,6 @@
   },
   "Kenosha, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -32566,7 +31151,6 @@
   },
   "Kent, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 11, 2024, 4:17:28 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -32586,7 +31170,6 @@
   },
   "Kent, WA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 8:22:08 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32606,7 +31189,6 @@
   },
   "Kenton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 5, 2024, 6:08:03 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32626,7 +31208,6 @@
   },
   "Kenyon, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 7:37:10 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32646,7 +31227,6 @@
   },
   "Keokuk, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32666,7 +31246,6 @@
   },
   "Ketchum, ID": {
     "reporter": "Michael David",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Size of Project"],
     "citations": [
       {
@@ -32691,7 +31270,6 @@
   },
   "Ketchum, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 5:12:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32711,7 +31289,6 @@
   },
   "Kettering, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32736,7 +31313,6 @@
   },
   "Kewanee, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -32756,7 +31332,6 @@
   },
   "Kewaskum, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32776,7 +31351,6 @@
   },
   "Keyport, NJ": {
     "reporter": "Andrew Kelsey",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -32796,7 +31370,6 @@
   },
   "Kilkenny, County Kilkenny": {
     "reporter": "Samuel Deetz",
-    "updated": "July 9, 2024, 7:17:18 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -32821,7 +31394,6 @@
   },
   "Killeen, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "February 14, 2024, 9:14:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32841,7 +31413,6 @@
   },
   "Kimball, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32861,7 +31432,6 @@
   },
   "Kimberly, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32881,7 +31451,6 @@
   },
   "Kings Mountain, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32906,7 +31475,6 @@
   },
   "Kingsford, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32926,7 +31494,6 @@
   },
   "Kingston, NY": {
     "reporter": "Tanya Garment",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -32946,7 +31513,6 @@
   },
   "Kingston, ON": {
     "reporter": "Laura Flaherty",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [
       "Affordable Housing",
       "In Lieu Fees",
@@ -32980,7 +31546,6 @@
   },
   "Kiowa, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33000,7 +31565,6 @@
   },
   "Kirksville, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33020,7 +31584,6 @@
   },
   "Kirkwood, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -33045,7 +31608,6 @@
   },
   "Kissimmee, FL": {
     "reporter": "John Hambley",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -33065,7 +31627,6 @@
   },
   "Kitchener, ON": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33085,7 +31646,6 @@
   },
   "Klamath Falls, OR": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -33105,7 +31665,6 @@
   },
   "Knob Noster, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33125,7 +31684,6 @@
   },
   "Knoxville, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -33150,7 +31708,6 @@
   },
   "Koblenz, RP": {
     "reporter": "Samuel Deetz",
-    "updated": "May 2, 2024, 9:55:03 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -33195,7 +31752,6 @@
   },
   "Kochville Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 4, 2024, 3:40:43 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33215,7 +31771,6 @@
   },
   "Kokomo, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33235,7 +31790,6 @@
   },
   "Kouts, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -33265,7 +31819,6 @@
   },
   "Kronenwetter, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33285,7 +31838,6 @@
   },
   "Kutztown, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 18, 2024, 5:44:03 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33305,7 +31857,6 @@
   },
   "L'Anse, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33325,7 +31876,6 @@
   },
   "La Crescent, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 21, 2024, 4:20:11 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33345,7 +31895,6 @@
   },
   "La Crosse, WI": {
     "reporter": "Patrick Siegman",
-    "updated": "March 7, 2024, 9:53:05 PM UTC",
     "requirements": ["By Right", "ADU"],
     "citations": [
       {
@@ -33411,7 +31960,6 @@
   },
   "La Cygne, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33431,7 +31979,6 @@
   },
   "La Farge, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33451,7 +31998,6 @@
   },
   "La Grange Park, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -33471,7 +32017,6 @@
   },
   "La Grange, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33491,7 +32036,6 @@
   },
   "La Plata, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 11, 2024, 6:11:53 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33511,7 +32055,6 @@
   },
   "La Plata, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33536,7 +32079,6 @@
   },
   "La Porte City, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33556,7 +32098,6 @@
   },
   "La Porte, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["In Lieu Fees", "Size of Project", "By Right"],
     "citations": [
       {
@@ -33581,7 +32122,6 @@
   },
   "La Rochelle, Charente-Maritime": {
     "reporter": "Etienne Lefebvre",
-    "updated": "December 6, 2023, 11:09:55 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33606,7 +32146,6 @@
   },
   "LaSalle County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -33626,7 +32165,6 @@
   },
   "LaSalle, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33646,7 +32184,6 @@
   },
   "Ladysmith, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33666,7 +32203,6 @@
   },
   "Lafayette, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 4, 2024, 2:56:43 AM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -33691,7 +32227,6 @@
   },
   "Lafayette, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33711,7 +32246,6 @@
   },
   "Lafayette, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 22, 2024, 11:03:41 PM UTC",
     "requirements": [
       "Size of Project",
       "By Right",
@@ -33746,7 +32280,6 @@
   },
   "Laingsburg, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 13, 2024, 5:45:43 PM UTC",
     "requirements": ["Other", "Bike Parking"],
     "citations": [
       {
@@ -33766,7 +32299,6 @@
   },
   "Lake Barrington, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 16, 2024, 7:21:54 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33786,7 +32318,6 @@
   },
   "Lake Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 30, 2024, 1:31:02 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33806,7 +32337,6 @@
   },
   "Lake City, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 9:03:19 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33831,7 +32361,6 @@
   },
   "Lake City, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33851,7 +32380,6 @@
   },
   "Lake City, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33871,7 +32399,6 @@
   },
   "Lake Elmo, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33891,7 +32418,6 @@
   },
   "Lake Forest, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -33921,7 +32447,6 @@
   },
   "Lake Geneva, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33941,7 +32466,6 @@
   },
   "Lake Havasu City, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 5:26:16 PM UTC",
     "requirements": ["Other", "By Right", "Size of Project", "Bike Parking"],
     "citations": [
       {
@@ -33966,7 +32490,6 @@
   },
   "Lake Lillian, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -33986,7 +32509,6 @@
   },
   "Lake Mills, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -34006,7 +32528,6 @@
   },
   "Lake Mills, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Other", "Bike Parking"],
     "citations": [
       {
@@ -34036,7 +32557,6 @@
   },
   "Lake Norden, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34056,7 +32576,6 @@
   },
   "Lake Orion, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 5:37:37 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -34081,7 +32600,6 @@
   },
   "Lake Ozark, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34101,7 +32619,6 @@
   },
   "Lake Park, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34121,7 +32638,6 @@
   },
   "Lake Park, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34141,7 +32657,6 @@
   },
   "Lake Preston, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34161,7 +32676,6 @@
   },
   "Lake St. Louis, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Bike Parking", "Other"],
     "citations": [
       {
@@ -34181,7 +32695,6 @@
   },
   "Lake View, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34201,7 +32714,6 @@
   },
   "Lake Zurich, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34221,7 +32733,6 @@
   },
   "Lakeland, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -34246,7 +32757,6 @@
   },
   "Lakesite, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34266,7 +32776,6 @@
   },
   "Lakeville, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -34286,7 +32795,6 @@
   },
   "Lakewood Club, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 10:16:19 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -34311,7 +32819,6 @@
   },
   "Lakewood Township, NJ": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 8:39:30 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -34331,7 +32838,6 @@
   },
   "Lakewood, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 11:37:36 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -34356,7 +32862,6 @@
   },
   "Lakewood, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -34376,7 +32881,6 @@
   },
   "Lakewood, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34396,7 +32900,6 @@
   },
   "Lakin, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34416,7 +32919,6 @@
   },
   "Lamoni, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34436,7 +32938,6 @@
   },
   "Lanark, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34456,7 +32957,6 @@
   },
   "Lancaster, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 21, 2024, 1:07:33 AM UTC",
     "requirements": [
       "ADU",
       "Car Share",
@@ -34500,7 +33000,6 @@
   },
   "Lancaster, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 3, 2024, 7:13:29 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -34525,7 +33024,6 @@
   },
   "Lancaster, PA": {
     "reporter": "Brian Ludicke",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34545,7 +33043,6 @@
   },
   "Lancaster, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Size of Project", "Historic Preservation"],
     "citations": [
       {
@@ -34565,7 +33062,6 @@
   },
   "Landis, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "Bike Parking", "In Lieu Fees"],
     "citations": [
       {
@@ -34600,7 +33096,6 @@
   },
   "Landshut, BY": {
     "reporter": "Samuel Deetz",
-    "updated": "March 7, 2024, 11:35:53 PM UTC",
     "requirements": ["In Lieu Fees", "Other"],
     "citations": [
       {
@@ -34630,7 +33125,6 @@
   },
   "Langhorne, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 22, 2024, 4:45:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34650,7 +33144,6 @@
   },
   "Lansdowne, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 23, 2024, 5:44:08 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -34670,7 +33163,6 @@
   },
   "Lansing , MI": {
     "reporter": "Andrew Fedewa",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -34695,7 +33187,6 @@
   },
   "Lansing, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "May 27, 2024, 10:44:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34728,7 +33219,6 @@
   },
   "Lapeer, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 7:30:13 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34753,7 +33243,6 @@
   },
   "Lapel, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34773,7 +33262,6 @@
   },
   "Laramie, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -34803,7 +33291,6 @@
   },
   "Laredo, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 6:00:50 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34823,7 +33310,6 @@
   },
   "Larimer County, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 7:20:11 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -34843,7 +33329,6 @@
   },
   "Larned, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34863,7 +33348,6 @@
   },
   "Las Cruces, NM": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Bike Parking", "Tree Preservation", "Other"],
     "citations": [
       {
@@ -34888,7 +33372,6 @@
   },
   "Las Vegas, NV": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 7:40:37 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -34913,7 +33396,6 @@
   },
   "Laurel, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 12, 2024, 3:13:06 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34933,7 +33415,6 @@
   },
   "Laurel, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 2, 2024, 5:38:52 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34953,7 +33434,6 @@
   },
   "Laurel, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["In Lieu Fees", "By Right"],
     "citations": [
       {
@@ -34978,7 +33458,6 @@
   },
   "Laurie, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -34998,7 +33477,6 @@
   },
   "Laval, QC": {
     "reporter": "Charles Lemieux",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35018,7 +33496,6 @@
   },
   "Lawrence County, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35038,7 +33515,6 @@
   },
   "Lawrence, KS": {
     "reporter": "Stefan Cerbin",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35058,7 +33534,6 @@
   },
   "Lawrenceville, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -35078,7 +33553,6 @@
   },
   "Lawson, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35098,7 +33572,6 @@
   },
   "Lawton, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 9:19:05 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35118,7 +33591,6 @@
   },
   "Lawton, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 7:45:29 PM UTC",
     "requirements": ["By Right", "Bike Parking", "Other"],
     "citations": [
       {
@@ -35143,7 +33615,6 @@
   },
   "Le Claire, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35163,7 +33634,6 @@
   },
   "Le Mars, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35183,7 +33653,6 @@
   },
   "Leadville, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 4, 2024, 9:12:17 PM UTC",
     "requirements": ["Other", "By Right", "ADU"],
     "citations": [
       {
@@ -35208,7 +33677,6 @@
   },
   "Leavenworth, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35228,7 +33696,6 @@
   },
   "Lebanon, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35248,7 +33715,6 @@
   },
   "Lebanon, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -35278,7 +33744,6 @@
   },
   "Leduc, AB": {
     "reporter": "Mike Norris",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -35303,7 +33768,6 @@
   },
   "Lee's Summit, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -35328,7 +33792,6 @@
   },
   "Lee, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35348,7 +33811,6 @@
   },
   "Leesport, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 18, 2024, 5:37:32 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -35368,7 +33830,6 @@
   },
   "Lehighton, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 25, 2024, 7:52:15 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35388,7 +33849,6 @@
   },
   "Leland Grove, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 2:51:09 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35408,7 +33868,6 @@
   },
   "Leland, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 4:23:51 AM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -35428,7 +33887,6 @@
   },
   "Lemont, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 4:36:30 AM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -35453,7 +33911,6 @@
   },
   "Lemoyne, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 12, 2024, 3:54:39 AM UTC",
     "requirements": ["Bike Parking", "Other"],
     "citations": [
       {
@@ -35478,7 +33935,6 @@
   },
   "Lennon, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 9:05:33 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -35498,7 +33954,6 @@
   },
   "Lennox, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35518,7 +33973,6 @@
   },
   "Leon, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35538,7 +33992,6 @@
   },
   "Leonard, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 5:42:59 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -35558,7 +34011,6 @@
   },
   "Leonardtown, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 11, 2024, 5:53:06 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -35578,7 +34030,6 @@
   },
   "Lewes, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35598,7 +34049,6 @@
   },
   "Lewisburg, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35618,7 +34068,6 @@
   },
   "Lewisburg, PA": {
     "reporter": "Joe Beattie",
-    "updated": "January 23, 2024, 3:14:32 AM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -35661,7 +34110,6 @@
   },
   "Lewistown, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35681,7 +34129,6 @@
   },
   "Lexington, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35701,7 +34148,6 @@
   },
   "Lexington, KY": {
     "reporter": "Joseph Edmiston",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35726,7 +34172,6 @@
   },
   "Lexington, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 6:02:18 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35746,7 +34191,6 @@
   },
   "Lexington, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35766,7 +34210,6 @@
   },
   "Liberal, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35786,7 +34229,6 @@
   },
   "Liberty, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35806,7 +34248,6 @@
   },
   "Liberty, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35826,7 +34267,6 @@
   },
   "Libertyville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Size of Project", "In Lieu Fees"],
     "citations": [
       {
@@ -35851,7 +34291,6 @@
   },
   "Ligonier, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35871,7 +34310,6 @@
   },
   "Lilburn, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35891,7 +34329,6 @@
   },
   "Limon, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 4, 2024, 6:16:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35911,7 +34348,6 @@
   },
   "Lincoln Heights, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -35931,7 +34367,6 @@
   },
   "Lincoln Park, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 5:30:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35951,7 +34386,6 @@
   },
   "Lincoln, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35971,7 +34405,6 @@
   },
   "Lincoln, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -35991,7 +34424,6 @@
   },
   "Lincoln, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 7:29:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36016,7 +34448,6 @@
   },
   "Lincoln, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36036,7 +34467,6 @@
   },
   "Lincoln, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "January 24, 2024, 6:06:10 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36069,7 +34499,6 @@
   },
   "Lincolnwood, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -36089,7 +34518,6 @@
   },
   "Linden, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 8:36:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36109,7 +34537,6 @@
   },
   "Lindstrom, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36129,7 +34556,6 @@
   },
   "Lisle, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -36149,7 +34575,6 @@
   },
   "Litchfield, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36169,7 +34594,6 @@
   },
   "Little Falls, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36189,7 +34613,6 @@
   },
   "Little Rock, AR": {
     "reporter": "Gillian Gullett",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36209,7 +34632,6 @@
   },
   "Littlestown, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 12, 2024, 5:09:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36239,7 +34661,6 @@
   },
   "Littleton, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 6, 2024, 7:09:28 PM UTC",
     "requirements": [
       "Frequent Transit",
       "Bike Parking",
@@ -36290,7 +34711,6 @@
   },
   "Livingston, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36310,7 +34730,6 @@
   },
   "Livonia, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 5:35:58 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36330,7 +34749,6 @@
   },
   "Lock Haven, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 10, 2024, 11:22:08 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36350,7 +34768,6 @@
   },
   "Lockport, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36370,7 +34787,6 @@
   },
   "Locust, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36395,7 +34811,6 @@
   },
   "Lodi, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36415,7 +34830,6 @@
   },
   "Logan, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 5, 2024, 6:34:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36435,7 +34849,6 @@
   },
   "Logansport, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -36460,7 +34873,6 @@
   },
   "Loganville, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36480,7 +34892,6 @@
   },
   "Loganville, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36500,7 +34911,6 @@
   },
   "Lombard, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36520,7 +34930,6 @@
   },
   "Lomira, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36540,7 +34949,6 @@
   },
   "London, England": {
     "reporter": "Samuel Deetz",
-    "updated": "March 7, 2024, 10:41:27 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36560,7 +34968,6 @@
   },
   "London, ON": {
     "reporter": "Isaac de Ceuster",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36585,7 +34992,6 @@
   },
   "Lone Tree, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 4:54:08 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36605,7 +35011,6 @@
   },
   "Long Beach, CA": {
     "reporter": "Bobby Siemiaszko",
-    "updated": "June 21, 2024, 2:37:58 AM UTC",
     "requirements": ["By Right", "ADU"],
     "citations": [
       {
@@ -36651,7 +35056,6 @@
   },
   "Long Beach, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36671,7 +35075,6 @@
   },
   "Long Beach, WA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36691,7 +35094,6 @@
   },
   "Long Grove, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "In Lieu Fees", "Other"],
     "citations": [
       {
@@ -36721,7 +35123,6 @@
   },
   "Long Lake Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "December 9, 2023, 2:11:41 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36741,7 +35142,6 @@
   },
   "Longmont, CO": {
     "reporter": "Ben Ortiz",
-    "updated": "May 29, 2024, 11:41:01 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36786,7 +35186,6 @@
   },
   "Longview, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 7:52:43 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36806,7 +35205,6 @@
   },
   "Longville, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -36826,7 +35224,6 @@
   },
   "Lonoke, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36846,7 +35243,6 @@
   },
   "Lorain, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36866,7 +35262,6 @@
   },
   "Los Angeles, CA": {
     "reporter": "Jonathan Raspa",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36886,7 +35281,6 @@
   },
   "Los Lunas, NM": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 5:40:12 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -36911,7 +35305,6 @@
   },
   "Loudonville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 9:01:29 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36931,7 +35324,6 @@
   },
   "Louisburg, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -36951,7 +35343,6 @@
   },
   "Louisville, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 4, 2024, 3:08:14 AM UTC",
     "requirements": ["Other", "By Right", "Size of Project", "In Lieu Fees"],
     "citations": [
       {
@@ -36976,7 +35367,6 @@
   },
   "Louisville, KY": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37001,7 +35391,6 @@
   },
   "Louisville, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 2, 2024, 8:29:05 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37021,7 +35410,6 @@
   },
   "Louisville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 11, 2024, 7:08:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37041,7 +35429,6 @@
   },
   "Loveland, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 11:27:42 PM UTC",
     "requirements": [
       "Other",
       "Affordable Housing",
@@ -37076,7 +35463,6 @@
   },
   "Lovington, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37096,7 +35482,6 @@
   },
   "Lowell Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 8:50:30 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37116,7 +35501,6 @@
   },
   "Lowell, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -37136,7 +35520,6 @@
   },
   "Lowell, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37156,7 +35539,6 @@
   },
   "Lowell, MA": {
     "reporter": "Brian Meade",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37176,7 +35558,6 @@
   },
   "Lowell, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 7:53:37 PM UTC",
     "requirements": ["Bike Parking", "Size of Project", "Other"],
     "citations": [
       {
@@ -37201,7 +35582,6 @@
   },
   "Lowell, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "Bike Parking", "In Lieu Fees"],
     "citations": [
       {
@@ -37236,7 +35616,6 @@
   },
   "Lower Macungie Township, PA": {
     "reporter": "Maggie Kochman",
-    "updated": "May 19, 2024, 5:25:19 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37256,7 +35635,6 @@
   },
   "Lubbock, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 6:05:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37276,7 +35654,6 @@
   },
   "Lucedale, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 11:07:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37301,7 +35678,6 @@
   },
   "Luck, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37321,7 +35697,6 @@
   },
   "Ludington, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 24, 2024, 10:03:13 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37341,7 +35716,6 @@
   },
   "Ludlow, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37361,7 +35735,6 @@
   },
   "Luna Pier, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 4:04:11 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37381,7 +35754,6 @@
   },
   "Lunenburg, NS": {
     "reporter": "Patrick Siegman",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37408,7 +35780,6 @@
   },
   "Lyman, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37428,7 +35799,6 @@
   },
   "Lynchburg, VA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37442,7 +35812,6 @@
   },
   "Lyndon, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37462,7 +35831,6 @@
   },
   "Lyon County, NV": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -37482,7 +35850,6 @@
   },
   "Lyons, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 4, 2024, 3:20:29 AM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -37507,7 +35874,6 @@
   },
   "Mackinac Island, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 7, 2024, 10:30:02 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37527,7 +35893,6 @@
   },
   "Mackinaw City, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -37552,7 +35917,6 @@
   },
   "Macomb Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 5, 2024, 1:49:42 AM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -37577,7 +35941,6 @@
   },
   "Macomb, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37597,7 +35960,6 @@
   },
   "Macon County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 29, 2023, 1:22:26 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37617,7 +35979,6 @@
   },
   "Macon-Bibb County, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 14, 2024, 9:02:18 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37637,7 +35998,6 @@
   },
   "Madeira, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37657,7 +36017,6 @@
   },
   "Madison, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37682,7 +36041,6 @@
   },
   "Madison, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37702,7 +36060,6 @@
   },
   "Madison, WI": {
     "reporter": "Zane Jacobson",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37722,7 +36079,6 @@
   },
   "Madras, OR": {
     "reporter": "Patrick Siegman",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37762,7 +36118,6 @@
   },
   "Madrid, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37782,7 +36137,6 @@
   },
   "Magnolia, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37802,7 +36156,6 @@
   },
   "Mahtomedi, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Other", "By Right", "Tree Preservation"],
     "citations": [
       {
@@ -37822,7 +36175,6 @@
   },
   "Maiden, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37842,7 +36194,6 @@
   },
   "Maine, ME": {
     "reporter": "Jeff Levine",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right", "ADU"],
     "citations": [
       {
@@ -37867,7 +36218,6 @@
   },
   "Maize, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37887,7 +36237,6 @@
   },
   "Malden, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37907,7 +36256,6 @@
   },
   "Malvern, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37927,7 +36275,6 @@
   },
   "Malvern, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 30, 2024, 7:26:14 PM UTC",
     "requirements": ["In Lieu Fees", "Other"],
     "citations": [
       {
@@ -37952,7 +36299,6 @@
   },
   "Manawa, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -37972,7 +36318,6 @@
   },
   "Mancelona, MI": {
     "reporter": "Sara Kopriva",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -37992,7 +36337,6 @@
   },
   "Manchester, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38012,7 +36356,6 @@
   },
   "Manchester, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 8:25:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38032,7 +36375,6 @@
   },
   "Manchester, NH": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38046,7 +36388,6 @@
   },
   "Mancos, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38066,7 +36407,6 @@
   },
   "Mandeville, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 26, 2024, 4:28:49 PM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -38091,7 +36431,6 @@
   },
   "Manhattan, KS": {
     "reporter": "Chad Bunger",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38111,7 +36450,6 @@
   },
   "Manhattan, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38131,7 +36469,6 @@
   },
   "Manheim Township, PA": {
     "reporter": "Anthony Vallone",
-    "updated": "February 20, 2024, 8:13:07 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -38151,7 +36488,6 @@
   },
   "Manistee, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 6:13:04 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38176,7 +36512,6 @@
   },
   "Manistique, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 12:01:54 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38196,7 +36531,6 @@
   },
   "Manitou Springs, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 5:18:53 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38216,7 +36550,6 @@
   },
   "Manitowoc, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38236,7 +36569,6 @@
   },
   "Mankato, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38256,7 +36588,6 @@
   },
   "Manley, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38276,7 +36607,6 @@
   },
   "Manning, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38296,7 +36626,6 @@
   },
   "Mannington, WV": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38316,7 +36645,6 @@
   },
   "Mansfield, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 11, 2024, 4:57:07 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38336,7 +36664,6 @@
   },
   "Manteno, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38356,7 +36683,6 @@
   },
   "Manton, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 7:26:22 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38376,7 +36702,6 @@
   },
   "Mantua, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 11, 2024, 4:27:44 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -38401,7 +36726,6 @@
   },
   "Mapleton, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38421,7 +36745,6 @@
   },
   "Maplewood, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 21, 2024, 3:01:49 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -38441,7 +36764,6 @@
   },
   "Maquoketa, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38461,7 +36783,6 @@
   },
   "Marathon City, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38481,7 +36802,6 @@
   },
   "Marathon County, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 2, 2024, 5:44:55 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38501,7 +36821,6 @@
   },
   "Marcellus, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 30, 2024, 5:31:38 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38521,7 +36840,6 @@
   },
   "Marcus Hook, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 23, 2024, 5:55:20 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38541,7 +36859,6 @@
   },
   "Marcus, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38561,7 +36878,6 @@
   },
   "Marengo, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38581,7 +36897,6 @@
   },
   "Marine City, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 6:28:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38606,7 +36921,6 @@
   },
   "Marion, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38626,7 +36940,6 @@
   },
   "Marion, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38646,7 +36959,6 @@
   },
   "Marion, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 11:35:30 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38666,7 +36978,6 @@
   },
   "Marion, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38686,7 +36997,6 @@
   },
   "Markesan, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38706,7 +37016,6 @@
   },
   "Marlette, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 11, 2024, 9:18:13 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -38726,7 +37035,6 @@
   },
   "Marlow, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 10:37:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38746,7 +37054,6 @@
   },
   "Marquette, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38766,7 +37073,6 @@
   },
   "Marquette, MI": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38786,7 +37092,6 @@
   },
   "Marshall, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 1:02:33 AM UTC",
     "requirements": ["By Right", "ADU"],
     "citations": [
       {
@@ -38806,7 +37111,6 @@
   },
   "Marshall, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 3:35:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38826,7 +37130,6 @@
   },
   "Marshall, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38846,7 +37149,6 @@
   },
   "Marshall, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38866,7 +37168,6 @@
   },
   "Marshall, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38886,7 +37187,6 @@
   },
   "Marshalltown, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "December 28, 2023, 11:30:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38911,7 +37211,6 @@
   },
   "Marshville, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "Bike Parking", "In Lieu Fees"],
     "citations": [
       {
@@ -38941,7 +37240,6 @@
   },
   "Marysville, OH": {
     "reporter": "Chad Flowers",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -38961,7 +37259,6 @@
   },
   "Marysville, WA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -38981,7 +37278,6 @@
   },
   "Maryville, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39001,7 +37297,6 @@
   },
   "Mascoutah, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39021,7 +37316,6 @@
   },
   "Mason City, IA": {
     "reporter": "Zane Jacobson",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39041,7 +37335,6 @@
   },
   "Mason, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 8:10:12 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -39061,7 +37354,6 @@
   },
   "Mason, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39081,7 +37373,6 @@
   },
   "Massillon, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 11, 2024, 7:13:44 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -39101,7 +37392,6 @@
   },
   "Matteson, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 4:15:11 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39121,7 +37411,6 @@
   },
   "Matthews, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -39151,7 +37440,6 @@
   },
   "Mattoon, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -39171,7 +37459,6 @@
   },
   "Maumee, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 2:09:55 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39204,7 +37491,6 @@
   },
   "Mauston, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -39224,7 +37510,6 @@
   },
   "Mayfield, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other", "In Lieu Fees"],
     "citations": [
       {
@@ -39244,7 +37529,6 @@
   },
   "Maysville, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39264,7 +37548,6 @@
   },
   "Mayville, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 11, 2024, 8:10:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39284,7 +37567,6 @@
   },
   "Mayville, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39304,7 +37586,6 @@
   },
   "Maywood, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other", "In Lieu Fees"],
     "citations": [
       {
@@ -39329,7 +37610,6 @@
   },
   "Mazomanie, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39349,7 +37629,6 @@
   },
   "Mazon, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 29, 2023, 1:12:58 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39369,7 +37648,6 @@
   },
   "McAdenville, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -39399,7 +37677,6 @@
   },
   "McAllen, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 12:09:17 AM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -39419,7 +37696,6 @@
   },
   "McBain, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 9:09:06 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39439,7 +37715,6 @@
   },
   "McCall, ID": {
     "reporter": "Brian Parker",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39459,7 +37734,6 @@
   },
   "McComb, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 2, 2024, 12:28:02 AM UTC",
     "requirements": ["Tree Preservation"],
     "citations": [
       {
@@ -39479,7 +37753,6 @@
   },
   "McComb, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 5, 2024, 5:59:18 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39504,7 +37777,6 @@
   },
   "McCook, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39524,7 +37796,6 @@
   },
   "McCool Junction, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -39544,7 +37815,6 @@
   },
   "McDonald, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 4:15:30 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39564,7 +37834,6 @@
   },
   "McFarland, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39584,7 +37853,6 @@
   },
   "McGregor, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39604,7 +37872,6 @@
   },
   "McGregor, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 8:10:05 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39624,7 +37891,6 @@
   },
   "McHenry County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -39644,7 +37910,6 @@
   },
   "McHenry, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39664,7 +37929,6 @@
   },
   "McKees Rocks, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 23, 2024, 8:02:10 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39684,7 +37948,6 @@
   },
   "McKinney, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "February 14, 2024, 8:40:06 PM UTC",
     "requirements": ["Tree Preservation", "By Right"],
     "citations": [
       {
@@ -39739,7 +38002,6 @@
   },
   "McPherson, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39759,7 +38021,6 @@
   },
   "Meadville, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 11, 2024, 2:39:18 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -39779,7 +38040,6 @@
   },
   "Mechanicsburg, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 13, 2024, 2:36:40 PM UTC",
     "requirements": ["By Right", "Other", "Size of Project"],
     "citations": [
       {
@@ -39804,7 +38064,6 @@
   },
   "Mechanicsville, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39824,7 +38083,6 @@
   },
   "Mediapolis, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39844,7 +38102,6 @@
   },
   "Medicine Bow, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -39864,7 +38121,6 @@
   },
   "Medina, OH": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39884,7 +38140,6 @@
   },
   "Melbourne, FL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 22, 2024, 11:52:03 PM UTC",
     "requirements": ["ADU", "In Lieu Fees"],
     "citations": [
       {
@@ -39909,7 +38164,6 @@
   },
   "Memphis, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 6:35:11 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39929,7 +38183,6 @@
   },
   "Memphis, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -39949,7 +38202,6 @@
   },
   "Memphis, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -39985,7 +38237,6 @@
   },
   "Menahga, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40005,7 +38256,6 @@
   },
   "Menard County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40025,7 +38275,6 @@
   },
   "Menasha, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40045,7 +38294,6 @@
   },
   "Mendota, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -40065,7 +38313,6 @@
   },
   "Mendota, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 12:10:05 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40085,7 +38332,6 @@
   },
   "Menlo, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40105,7 +38351,6 @@
   },
   "Menominee, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -40125,7 +38370,6 @@
   },
   "Menomonie, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 10, 2024, 9:21:06 PM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -40150,7 +38394,6 @@
   },
   "Mentor, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40170,7 +38413,6 @@
   },
   "Mercersburg, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 26, 2024, 12:19:26 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40190,7 +38432,6 @@
   },
   "Meridian Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 8:03:37 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -40215,7 +38456,6 @@
   },
   "Meridian, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40235,7 +38475,6 @@
   },
   "Merrill, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 1:10:27 AM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -40255,7 +38494,6 @@
   },
   "Merrillan, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40275,7 +38513,6 @@
   },
   "Merrimac, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40295,7 +38532,6 @@
   },
   "Merritt, BC": {
     "reporter": "Don McArthur",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -40320,7 +38556,6 @@
   },
   "Mesa, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 1:34:25 AM UTC",
     "requirements": ["By Right", "Frequent Transit", "Bike Parking", "Other"],
     "citations": [
       {
@@ -40365,7 +38600,6 @@
   },
   "Mesquite, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "February 14, 2024, 8:56:21 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40385,7 +38619,6 @@
   },
   "Metropolis, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40405,7 +38638,6 @@
   },
   "Metuchen, NJ": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["In Lieu Fees", "By Right"],
     "citations": [
       {
@@ -40425,7 +38657,6 @@
   },
   "Mexico City, DF": {
     "reporter": "Chris Riley",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40445,7 +38676,6 @@
   },
   "Mexico, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40465,7 +38695,6 @@
   },
   "Miami, FL": {
     "reporter": "Maggie Kochman",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -40505,7 +38734,6 @@
   },
   "Michigan City, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -40530,7 +38758,6 @@
   },
   "Middleburg Heights, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Size of Project", "Other"],
     "citations": [
       {
@@ -40550,7 +38777,6 @@
   },
   "Middletown, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40570,7 +38796,6 @@
   },
   "Middletown, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 21, 2024, 3:04:45 AM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -40600,7 +38825,6 @@
   },
   "Middletown, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40620,7 +38844,6 @@
   },
   "Middleville, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 6:12:31 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40650,7 +38873,6 @@
   },
   "Midland, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 25, 2024, 6:29:23 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40675,7 +38897,6 @@
   },
   "Midland, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Bike Parking", "Other", "By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -40700,7 +38921,6 @@
   },
   "Midland, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 9:17:30 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40720,7 +38940,6 @@
   },
   "Midwest City, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 16, 2024, 8:14:15 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40740,7 +38959,6 @@
   },
   "Milan, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40760,7 +38978,6 @@
   },
   "Milan, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -40780,7 +38997,6 @@
   },
   "Miles City, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -40800,7 +39016,6 @@
   },
   "Milford Center, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 5:54:07 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -40820,7 +39035,6 @@
   },
   "Milford, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40840,7 +39054,6 @@
   },
   "Milford, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40860,7 +39073,6 @@
   },
   "Milford, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 5:54:08 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -40890,7 +39102,6 @@
   },
   "Milford, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40910,7 +39121,6 @@
   },
   "Millbourne, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 23, 2024, 6:18:20 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -40930,7 +39140,6 @@
   },
   "Millersburg, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 5, 2024, 6:42:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40950,7 +39159,6 @@
   },
   "Millersburg, OR": {
     "reporter": "Evan Manvel",
-    "updated": "January 23, 2024, 4:14:59 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -40970,7 +39178,6 @@
   },
   "Millersburg, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 21, 2024, 3:18:50 AM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -40995,7 +39202,6 @@
   },
   "Milltown, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41015,7 +39221,6 @@
   },
   "Millvale, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 4:28:30 AM UTC",
     "requirements": ["Size of Project", "By Right", "Other"],
     "citations": [
       {
@@ -41035,7 +39240,6 @@
   },
   "Milton, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41055,7 +39259,6 @@
   },
   "Milton, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41075,7 +39278,6 @@
   },
   "Milwaukee, WI": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41100,7 +39302,6 @@
   },
   "Milwaukie, OR": {
     "reporter": "",
-    "updated": "May 28, 2024, 1:05:57 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41171,7 +39372,6 @@
   },
   "Minden, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 5, 2024, 10:42:30 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41191,7 +39391,6 @@
   },
   "Minden, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41211,7 +39410,6 @@
   },
   "Mineral Point, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41231,7 +39429,6 @@
   },
   "Mineral Springs, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Size of Project"],
     "citations": [
       {
@@ -41251,7 +39448,6 @@
   },
   "Minneapolis, MN": {
     "reporter": "Matt Steele",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41307,7 +39503,6 @@
   },
   "Minnesota, MN": {
     "reporter": "",
-    "updated": "January 24, 2024, 6:14:16 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41327,7 +39522,6 @@
   },
   "Minnetonka, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 2:15:42 AM UTC",
     "requirements": ["TDM"],
     "citations": [
       {
@@ -41347,7 +39541,6 @@
   },
   "Minnetrista, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 21, 2024, 11:45:18 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41367,7 +39560,6 @@
   },
   "Minong, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41387,7 +39579,6 @@
   },
   "Minonk, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41407,7 +39598,6 @@
   },
   "Minooka, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 29, 2023, 1:40:55 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41427,7 +39617,6 @@
   },
   "Minot, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41447,7 +39636,6 @@
   },
   "Mint Hill, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -41467,7 +39655,6 @@
   },
   "Minturn, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 11:03:34 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -41487,7 +39674,6 @@
   },
   "Mishawaka, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41507,7 +39693,6 @@
   },
   "Missoula, MT": {
     "reporter": "Patrick Siegman",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -41527,7 +39712,6 @@
   },
   "Moberly, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41547,7 +39731,6 @@
   },
   "Mobile, AL": {
     "reporter": "Daniel Christiansen",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41567,7 +39750,6 @@
   },
   "Modena, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 30, 2024, 7:38:34 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -41592,7 +39774,6 @@
   },
   "Modesto, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 8:22:50 PM UTC",
     "requirements": ["ADU"],
     "citations": [
       {
@@ -41622,7 +39803,6 @@
   },
   "Mokena, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41642,7 +39822,6 @@
   },
   "Moline, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41662,7 +39841,6 @@
   },
   "Moncton, NB": {
     "reporter": "Etienne Lefebvre",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41687,7 +39865,6 @@
   },
   "Mondovi, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41712,7 +39889,6 @@
   },
   "Monett, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41732,7 +39908,6 @@
   },
   "Monona, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41752,7 +39927,6 @@
   },
   "Monona, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41772,7 +39946,6 @@
   },
   "Monroe, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 7:31:38 AM UTC",
     "requirements": ["Bike Parking", "Other"],
     "citations": [
       {
@@ -41797,7 +39970,6 @@
   },
   "Monroe, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 4:22:23 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41817,7 +39989,6 @@
   },
   "Monroe, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41837,7 +40008,6 @@
   },
   "Monroe, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41857,7 +40027,6 @@
   },
   "Monroe, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41877,7 +40046,6 @@
   },
   "Monroe, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41897,7 +40065,6 @@
   },
   "Monrovia, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -41917,7 +40084,6 @@
   },
   "Montague, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 6, 2024, 7:11:57 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -41942,7 +40108,6 @@
   },
   "Monte Vista, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 6:30:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41962,7 +40127,6 @@
   },
   "Montello, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -41987,7 +40151,6 @@
   },
   "Montevideo, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -42007,7 +40170,6 @@
   },
   "Montgomery City, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42027,7 +40189,6 @@
   },
   "Montgomery County, MD": {
     "reporter": "Ben Ross",
-    "updated": "June 21, 2024, 12:26:23 AM UTC",
     "requirements": ["In Lieu Fees", "By Right"],
     "citations": [
       {
@@ -42080,7 +40241,6 @@
   },
   "Montgomery, AL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 7:01:38 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42100,7 +40260,6 @@
   },
   "Montgomery, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 3:02:29 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42125,7 +40284,6 @@
   },
   "Montgomery, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42145,7 +40303,6 @@
   },
   "Montgomery, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42170,7 +40327,6 @@
   },
   "Monticello, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 21, 2024, 10:06:56 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42190,7 +40346,6 @@
   },
   "Monticello, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42210,7 +40365,6 @@
   },
   "Montpelier, VT": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 2:26:14 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42235,7 +40389,6 @@
   },
   "Montreal, QC": {
     "reporter": "Craig Sauvé",
-    "updated": "June 23, 2024, 7:08:32 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42273,7 +40426,6 @@
   },
   "Montreal, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42293,7 +40445,6 @@
   },
   "Montrose, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 8:41:20 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42313,7 +40464,6 @@
   },
   "Monument, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 5:28:17 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -42333,7 +40483,6 @@
   },
   "Mooresville , NC": {
     "reporter": "David Cole",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42353,7 +40502,6 @@
   },
   "Moorhead, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42373,7 +40521,6 @@
   },
   "Mora, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees", "Other"],
     "citations": [
       {
@@ -42393,7 +40540,6 @@
   },
   "Morenci, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 31, 2024, 7:01:17 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42413,7 +40559,6 @@
   },
   "Moreno Valley, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 7:31:53 PM UTC",
     "requirements": ["ADU"],
     "citations": [
       {
@@ -42433,7 +40578,6 @@
   },
   "Morgan City, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 7:27:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42453,7 +40597,6 @@
   },
   "Morning Sun, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42473,7 +40616,6 @@
   },
   "Morrice, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 13, 2024, 7:28:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42493,7 +40635,6 @@
   },
   "Morris, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -42513,7 +40654,6 @@
   },
   "Morrison, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42533,7 +40673,6 @@
   },
   "Morrison, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 10:02:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42553,7 +40692,6 @@
   },
   "Morristown, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42573,7 +40711,6 @@
   },
   "Morristown, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42593,7 +40730,6 @@
   },
   "Morrisville, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 22, 2024, 4:54:10 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -42613,7 +40749,6 @@
   },
   "Morton, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42633,7 +40768,6 @@
   },
   "Morton, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42653,7 +40787,6 @@
   },
   "Morven, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "Bike Parking", "In Lieu Fees"],
     "citations": [
       {
@@ -42683,7 +40816,6 @@
   },
   "Mosinee, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42703,7 +40835,6 @@
   },
   "Moss Point, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 6:17:35 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -42723,7 +40854,6 @@
   },
   "Mound, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42743,7 +40873,6 @@
   },
   "Moundridge, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42763,7 +40892,6 @@
   },
   "Mount Airy, NC": {
     "reporter": "Etienne Lefebvre",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42788,7 +40916,6 @@
   },
   "Mount Carmel, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42808,7 +40935,6 @@
   },
   "Mount Horeb, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -42833,7 +40959,6 @@
   },
   "Mount Pleasant, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42853,7 +40978,6 @@
   },
   "Mount Pleasant, MI": {
     "reporter": "Nani Wolf",
-    "updated": "February 20, 2024, 12:02:54 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42867,7 +40991,6 @@
   },
   "Mount Prospect, IL": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -42887,7 +41010,6 @@
   },
   "Mount Pulaski, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42907,7 +41029,6 @@
   },
   "Mount Sterling, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42927,7 +41048,6 @@
   },
   "Mountain Grove, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42947,7 +41067,6 @@
   },
   "Mountain Home, ID": {
     "reporter": "Brock Cherry",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42967,7 +41086,6 @@
   },
   "Mountain View, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -42987,7 +41105,6 @@
   },
   "Mountain View, CA": {
     "reporter": "Jeffrey Tumlin",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43012,7 +41129,6 @@
   },
   "Moville, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43032,7 +41148,6 @@
   },
   "Mt. Carroll, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43052,7 +41167,6 @@
   },
   "Mt. Clemens, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 7:50:21 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -43087,7 +41201,6 @@
   },
   "Mt. Healthy, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43107,7 +41220,6 @@
   },
   "Mt. Holly Springs, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 13, 2024, 2:41:00 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -43127,7 +41239,6 @@
   },
   "Mt. Holly, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43147,7 +41258,6 @@
   },
   "Mt. Olive, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 2, 2024, 5:21:33 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43167,7 +41277,6 @@
   },
   "Mt. Oliver, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 4:48:55 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43187,7 +41296,6 @@
   },
   "Mt. Penn, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 18, 2024, 5:58:05 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43212,7 +41320,6 @@
   },
   "Mt. Pleasant, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43232,7 +41339,6 @@
   },
   "Mt. Pleasant, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Bike Parking", "Other"],
     "citations": [
       {
@@ -43257,7 +41363,6 @@
   },
   "Mt. Union, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 26, 2024, 5:41:35 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -43277,7 +41382,6 @@
   },
   "Mt. Vernon, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 27, 2024, 6:23:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43297,7 +41401,6 @@
   },
   "Mt. Vernon, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43317,7 +41420,6 @@
   },
   "Mt. Vernon, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43337,7 +41439,6 @@
   },
   "Mt. Vernon, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43357,7 +41458,6 @@
   },
   "Mt. Washington, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -43377,7 +41477,6 @@
   },
   "Mt. Zion, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 26, 2024, 8:55:51 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -43402,7 +41501,6 @@
   },
   "Muir, MI": {
     "reporter": "Nani Wolf",
-    "updated": "February 20, 2024, 12:09:18 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43422,7 +41520,6 @@
   },
   "Mulliken, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 6:34:11 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43442,7 +41539,6 @@
   },
   "Mullins, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43462,7 +41558,6 @@
   },
   "Mulvane, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43482,7 +41577,6 @@
   },
   "Muncie, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -43502,7 +41596,6 @@
   },
   "Mundelein, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -43537,7 +41630,6 @@
   },
   "Munhall, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 4:57:53 AM UTC",
     "requirements": ["Frequent Transit"],
     "citations": [
       {
@@ -43557,7 +41649,6 @@
   },
   "Munising, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43582,7 +41673,6 @@
   },
   "Munster, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43607,7 +41697,6 @@
   },
   "Murfreesboro, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 9:59:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43627,7 +41716,6 @@
   },
   "Muscatine, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 12:40:10 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43647,7 +41735,6 @@
   },
   "Muskegon Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 11:17:28 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43667,7 +41754,6 @@
   },
   "Muskegon Heights, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 6, 2024, 7:18:11 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -43692,7 +41778,6 @@
   },
   "Muskegon, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 9:51:04 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43725,7 +41810,6 @@
   },
   "Muskogee, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 16, 2024, 5:22:02 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43745,7 +41829,6 @@
   },
   "München, BY": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 2:28:44 AM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -43778,7 +41861,6 @@
   },
   "Münster, NW": {
     "reporter": "Samuel Deetz",
-    "updated": "May 3, 2024, 9:15:35 PM UTC",
     "requirements": [
       "Frequent Transit",
       "By Right",
@@ -43815,7 +41897,6 @@
   },
   "Nanty Glo, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 25, 2024, 5:39:57 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43835,7 +41916,6 @@
   },
   "Naperville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 9:42:17 PM UTC",
     "requirements": ["In Lieu Fees", "By Right"],
     "citations": [
       {
@@ -43855,7 +41935,6 @@
   },
   "Napoleon, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 19, 2024, 5:47:47 AM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -43875,7 +41954,6 @@
   },
   "Nappanee, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -43895,7 +41973,6 @@
   },
   "Nashville, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43915,7 +41992,6 @@
   },
   "Nashville, TN": {
     "reporter": "Neil Kornutick",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43935,7 +42011,6 @@
   },
   "Natchez, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43955,7 +42030,6 @@
   },
   "Natchitoches, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -43975,7 +42049,6 @@
   },
   "Natick, MA": {
     "reporter": "James Freas",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -43995,7 +42068,6 @@
   },
   "Nauvoo, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44015,7 +42087,6 @@
   },
   "Nebraska City, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44035,7 +42106,6 @@
   },
   "Nederland, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 4, 2024, 3:25:54 AM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -44055,7 +42125,6 @@
   },
   "Neenah, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44075,7 +42144,6 @@
   },
   "Negaunee, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44095,7 +42163,6 @@
   },
   "Neillsville, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44115,7 +42182,6 @@
   },
   "Nekoosa, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44135,7 +42201,6 @@
   },
   "Nelson County, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -44160,7 +42225,6 @@
   },
   "Neosho, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44180,7 +42244,6 @@
   },
   "Nevada, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44200,7 +42263,6 @@
   },
   "Nevada, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44220,7 +42282,6 @@
   },
   "New Albany, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -44245,7 +42306,6 @@
   },
   "New Auburn, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44265,7 +42325,6 @@
   },
   "New Auburn, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44285,7 +42344,6 @@
   },
   "New Baltimore, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 7:56:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44310,7 +42368,6 @@
   },
   "New Berlin, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44330,7 +42387,6 @@
   },
   "New Bremen, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 18, 2024, 3:04:33 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44350,7 +42406,6 @@
   },
   "New Brighton, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 24, 2024, 9:42:41 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -44370,7 +42425,6 @@
   },
   "New Buffalo, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 10:43:53 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44390,7 +42444,6 @@
   },
   "New Carlisle, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -44410,7 +42463,6 @@
   },
   "New Castle, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 9:56:50 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -44435,7 +42487,6 @@
   },
   "New Castle, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -44465,7 +42516,6 @@
   },
   "New Castle, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -44485,7 +42535,6 @@
   },
   "New Cumberland, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 14, 2024, 4:28:25 AM UTC",
     "requirements": ["In Lieu Fees", "Size of Project", "By Right", "Other"],
     "citations": [
       {
@@ -44515,7 +42564,6 @@
   },
   "New Franklin, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44535,7 +42583,6 @@
   },
   "New Haven, CT": {
     "reporter": "Bobby Siemiaszko",
-    "updated": "January 22, 2024, 10:52:05 PM UTC",
     "requirements": ["By Right", "Size of Project", "Car Share"],
     "citations": [
       {
@@ -44583,7 +42630,6 @@
   },
   "New Haven, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right", "Other", "Bike Parking", "Frequent Transit"],
     "citations": [
       {
@@ -44613,7 +42659,6 @@
   },
   "New Haven, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44633,7 +42678,6 @@
   },
   "New Hope, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -44668,7 +42712,6 @@
   },
   "New Hope, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 22, 2024, 5:00:28 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -44688,7 +42731,6 @@
   },
   "New Iberia, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 26, 2024, 4:20:46 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44708,7 +42750,6 @@
   },
   "New London, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44728,7 +42769,6 @@
   },
   "New London, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44748,7 +42788,6 @@
   },
   "New Market, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 9:18:43 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44768,7 +42807,6 @@
   },
   "New Morgan, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 18, 2024, 6:13:22 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -44793,7 +42831,6 @@
   },
   "New Orleans, LA": {
     "reporter": "Maggie Kochman",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Historic Preservation", "Other"],
     "citations": [
       {
@@ -44823,7 +42860,6 @@
   },
   "New Palestine, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -44843,7 +42879,6 @@
   },
   "New Prague, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44863,7 +42898,6 @@
   },
   "New Richland, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44888,7 +42922,6 @@
   },
   "New Richmond, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44908,7 +42941,6 @@
   },
   "New Roads, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 4, 2024, 11:20:01 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44928,7 +42960,6 @@
   },
   "New Shoreham, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 7:59:00 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44948,7 +42979,6 @@
   },
   "New Strawn, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -44968,7 +42998,6 @@
   },
   "New Ulm, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -44988,7 +43017,6 @@
   },
   "New York City, NY": {
     "reporter": "Laura Smith",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45046,7 +43074,6 @@
   },
   "New Zealand": {
     "reporter": "Patrick Siegman",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45073,7 +43100,6 @@
   },
   "Newark, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Affordable Housing", "Other"],
     "citations": [
       {
@@ -45098,7 +43124,6 @@
   },
   "Newark, NJ": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Frequent Transit", "By Right"],
     "citations": [
       {
@@ -45118,7 +43143,6 @@
   },
   "Newark, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 4:37:00 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45138,7 +43162,6 @@
   },
   "Newburg, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 3:36:42 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45163,7 +43186,6 @@
   },
   "Newburgh Heights, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45183,7 +43205,6 @@
   },
   "Newhall, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45203,7 +43224,6 @@
   },
   "Newport News, VA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 12, 2024, 8:38:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45223,7 +43243,6 @@
   },
   "Newport, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45243,7 +43262,6 @@
   },
   "Newport, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -45263,7 +43281,6 @@
   },
   "Newport, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 22, 2024, 11:27:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45288,7 +43305,6 @@
   },
   "Newton Falls, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 12, 2024, 2:31:09 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -45308,7 +43324,6 @@
   },
   "Newton, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Bike Parking", "Other"],
     "citations": [
       {
@@ -45378,7 +43393,6 @@
   },
   "Newville, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 19, 2024, 2:06:32 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -45398,7 +43412,6 @@
   },
   "Nichols Hills, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 16, 2024, 8:18:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45418,7 +43431,6 @@
   },
   "Nichols, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45438,7 +43450,6 @@
   },
   "Niles, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 23, 2024, 2:49:08 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45463,7 +43474,6 @@
   },
   "Noble, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 2:24:02 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45483,7 +43493,6 @@
   },
   "Noblesville, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45503,7 +43512,6 @@
   },
   "Norcross, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Other", "Frequent Transit", "Car Share"],
     "citations": [
       {
@@ -45528,7 +43536,6 @@
   },
   "Norfolk, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45548,7 +43555,6 @@
   },
   "Norfolk, VA": {
     "reporter": "Kevin R. Murphy",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["Size of Project"],
     "citations": [
       {
@@ -45580,7 +43586,6 @@
   },
   "Normal, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 3:46:31 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45605,7 +43610,6 @@
   },
   "Norman, OK": {
     "reporter": "Matthew Peacock",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45630,7 +43634,6 @@
   },
   "North Baltimore, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 1:55:06 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -45650,7 +43653,6 @@
   },
   "North Beach, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 11, 2024, 5:42:17 PM UTC",
     "requirements": ["Other", "Size of Project"],
     "citations": [
       {
@@ -45670,7 +43672,6 @@
   },
   "North Branch, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 7:46:15 PM UTC",
     "requirements": ["Bike Parking", "By Right"],
     "citations": [
       {
@@ -45695,7 +43696,6 @@
   },
   "North Canton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 11, 2024, 7:30:52 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45728,7 +43728,6 @@
   },
   "North Chicago, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45753,7 +43752,6 @@
   },
   "North East, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 10, 2024, 11:41:39 PM UTC",
     "requirements": ["In Lieu Fees", "By Right", "Frequent Transit", "Other"],
     "citations": [
       {
@@ -45798,7 +43796,6 @@
   },
   "North East, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45818,7 +43815,6 @@
   },
   "North Fond du Lac, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45838,7 +43834,6 @@
   },
   "North Hampton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 29, 2024, 3:20:06 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45858,7 +43853,6 @@
   },
   "North Kansas City, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -45883,7 +43877,6 @@
   },
   "North Kingstown, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 8:22:32 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -45903,7 +43896,6 @@
   },
   "North Las Vegas, NV": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 5:15:42 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -45923,7 +43915,6 @@
   },
   "North Lewisburg, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 5:40:39 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -45943,7 +43934,6 @@
   },
   "North Little Rock, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -45968,7 +43958,6 @@
   },
   "North Manchester, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -45988,7 +43977,6 @@
   },
   "North Mankato, MN": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -46008,7 +43996,6 @@
   },
   "North Muskegon, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 9:55:24 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46028,7 +44015,6 @@
   },
   "North Olmsted, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46048,7 +44034,6 @@
   },
   "North Pekin, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 2:47:21 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46068,7 +44053,6 @@
   },
   "North Platte, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46088,7 +44072,6 @@
   },
   "North Prairie, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46108,7 +44091,6 @@
   },
   "North Riverside, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 4:27:33 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46128,7 +44110,6 @@
   },
   "North St. Paul, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -46148,7 +44129,6 @@
   },
   "North Utica, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46168,7 +44148,6 @@
   },
   "Northfield, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 4:53:51 AM UTC",
     "requirements": [
       "Frequent Transit",
       "Planned Frequent Transit",
@@ -46199,7 +44178,6 @@
   },
   "Northfield, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46229,7 +44207,6 @@
   },
   "Northglenn, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 12:19:16 AM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -46269,7 +44246,6 @@
   },
   "Northville Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 3:02:20 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46289,7 +44265,6 @@
   },
   "Northville, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 2:29:29 AM UTC",
     "requirements": ["In Lieu Fees", "By Right", "Other"],
     "citations": [
       {
@@ -46319,7 +44294,6 @@
   },
   "Norwalk, CT": {
     "reporter": "Bryan Baker",
-    "updated": "February 20, 2024, 2:23:41 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46367,7 +44341,6 @@
   },
   "Norwalk, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 2:29:41 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46387,7 +44360,6 @@
   },
   "Norway, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -46407,7 +44379,6 @@
   },
   "Norwich, CT": {
     "reporter": "Jason Vincent",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46440,7 +44411,6 @@
   },
   "Norwood, MA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Size of Project"],
     "citations": [
       {
@@ -46460,7 +44430,6 @@
   },
   "Norwood, OH": {
     "reporter": "Christopher Brown",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46480,7 +44449,6 @@
   },
   "Novi, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 2:39:49 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -46500,7 +44468,6 @@
   },
   "Nürnberg, BY": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 2:58:08 AM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -46525,7 +44492,6 @@
   },
   "O'Fallon, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Other", "Size of Project"],
     "citations": [
       {
@@ -46545,7 +44511,6 @@
   },
   "O'Neill, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46565,7 +44530,6 @@
   },
   "Oak Creek, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46585,7 +44549,6 @@
   },
   "Oak Creek, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46605,7 +44568,6 @@
   },
   "Oak Lawn, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46625,7 +44587,6 @@
   },
   "Oak Park, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": [
       "Size of Project",
       "By Right",
@@ -46657,7 +44618,6 @@
   },
   "Oak Park, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 2:48:51 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46677,7 +44637,6 @@
   },
   "Oakboro, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -46697,7 +44656,6 @@
   },
   "Oakdale, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 4:18:03 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46717,7 +44675,6 @@
   },
   "Oakland, CA": {
     "reporter": "Tom Radulovich",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46750,7 +44707,6 @@
   },
   "Oakland, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46770,7 +44726,6 @@
   },
   "Oakland, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46790,7 +44745,6 @@
   },
   "Oakley, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 9, 2024, 9:51:18 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -46810,7 +44764,6 @@
   },
   "Oakville, ON": {
     "reporter": "Joe Nether",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46830,7 +44783,6 @@
   },
   "Oakwood, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 26, 2024, 8:02:52 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -46850,7 +44802,6 @@
   },
   "Oberlin, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46870,7 +44821,6 @@
   },
   "Oberlin, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46890,7 +44840,6 @@
   },
   "Obetz, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 5:59:31 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -46910,7 +44859,6 @@
   },
   "Ocean Springs, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -46930,7 +44878,6 @@
   },
   "Oceanside, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 20, 2024, 9:22:02 PM UTC",
     "requirements": [
       "Other",
       "Car Share",
@@ -46962,7 +44909,6 @@
   },
   "Ochtrup, NW": {
     "reporter": "Samuel Deetz",
-    "updated": "May 3, 2024, 9:05:53 PM UTC",
     "requirements": ["Bike Parking", "Other", "In Lieu Fees"],
     "citations": [
       {
@@ -46997,7 +44943,6 @@
   },
   "Oconomowoc, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47022,7 +44967,6 @@
   },
   "Oelwein, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47042,7 +44986,6 @@
   },
   "Ogle County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -47062,7 +45005,6 @@
   },
   "Ohio County, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 5:48:48 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -47082,7 +45024,6 @@
   },
   "Okemah, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 16, 2024, 7:11:18 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47102,7 +45043,6 @@
   },
   "Oklahoma City, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47122,7 +45062,6 @@
   },
   "Okolona, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 2, 2024, 9:37:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47142,7 +45081,6 @@
   },
   "Oldham, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47162,7 +45100,6 @@
   },
   "Olivia, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47182,7 +45119,6 @@
   },
   "Olney, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47202,7 +45138,6 @@
   },
   "Olympia Fields, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47222,7 +45157,6 @@
   },
   "Olympia, WA": {
     "reporter": "Max DeJarnatt",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -47252,7 +45186,6 @@
   },
   "Omaha, NE": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47277,7 +45210,6 @@
   },
   "Onawa, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47297,7 +45229,6 @@
   },
   "Onaway, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47317,7 +45248,6 @@
   },
   "Oneida Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 7:49:25 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47337,7 +45267,6 @@
   },
   "Ontario, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 13, 2024, 4:36:39 PM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -47369,7 +45298,6 @@
   },
   "Ontonagon, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47389,7 +45317,6 @@
   },
   "Oologah, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 3:28:19 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47414,7 +45341,6 @@
   },
   "Opelousas, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 5, 2024, 6:30:48 PM UTC",
     "requirements": ["By Right", "Size of Project", "In Lieu Fees"],
     "citations": [
       {
@@ -47439,7 +45365,6 @@
   },
   "Orange City, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47459,7 +45384,6 @@
   },
   "Orange, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 16, 2024, 8:26:37 PM UTC",
     "requirements": ["ADU", "In Lieu Fees", "By Right"],
     "citations": [
       {
@@ -47489,7 +45413,6 @@
   },
   "Oregon, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 6:54:45 AM UTC",
     "requirements": ["By Right", "Other", "In Lieu Fees"],
     "citations": [
       {
@@ -47509,7 +45432,6 @@
   },
   "Oregon, OR": {
     "reporter": "Patrick Siegman",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -47537,7 +45459,6 @@
   },
   "Oregon, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47562,7 +45483,6 @@
   },
   "Orion, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 2:37:17 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47582,7 +45502,6 @@
   },
   "Orlando, FL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 22, 2024, 8:24:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47612,7 +45531,6 @@
   },
   "Oronoko Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 30, 2024, 2:45:24 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -47632,7 +45550,6 @@
   },
   "Ortonville, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 6:00:55 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47652,7 +45569,6 @@
   },
   "Orwell, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47672,7 +45588,6 @@
   },
   "Osakis, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47692,7 +45607,6 @@
   },
   "Osceola, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47712,7 +45626,6 @@
   },
   "Oscoda Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 24, 2024, 5:51:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47742,7 +45655,6 @@
   },
   "Oshawa, ON": {
     "reporter": "David Sappleton",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Size of Project"],
     "citations": [
       {
@@ -47767,7 +45679,6 @@
   },
   "Oshkosh, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 7, 2024, 9:02:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47792,7 +45703,6 @@
   },
   "Oshtemo Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 4:56:56 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -47822,7 +45732,6 @@
   },
   "Oskaloosa, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47842,7 +45751,6 @@
   },
   "Ostrander, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47862,7 +45770,6 @@
   },
   "Oswego, IL": {
     "reporter": "Jake Seid",
-    "updated": "July 25, 2024, 7:01:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47887,7 +45794,6 @@
   },
   "Otsego, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 5:26:37 PM UTC",
     "requirements": ["Size of Project"],
     "citations": [
       {
@@ -47907,7 +45813,6 @@
   },
   "Ottawa, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47927,7 +45832,6 @@
   },
   "Ottawa, ON": {
     "reporter": "Alain Miguelez",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47957,7 +45861,6 @@
   },
   "Otter Lake, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 7:50:22 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47977,7 +45880,6 @@
   },
   "Ottumwa, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -47997,7 +45899,6 @@
   },
   "Overbrook, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48017,7 +45918,6 @@
   },
   "Overland Park, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -48037,7 +45937,6 @@
   },
   "Ovid, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 13, 2024, 5:50:23 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48057,7 +45956,6 @@
   },
   "Owasso, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 2:17:51 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -48077,7 +45975,6 @@
   },
   "Owensboro, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48097,7 +45994,6 @@
   },
   "Owingsville, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48117,7 +46013,6 @@
   },
   "Owosso, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 13, 2024, 5:55:33 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48137,7 +46032,6 @@
   },
   "Oxford Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 10:11:30 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48157,7 +46051,6 @@
   },
   "Oxford, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48177,7 +46070,6 @@
   },
   "Oxford, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 2, 2024, 10:22:13 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -48207,7 +46099,6 @@
   },
   "Oxford, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Frequent Transit", "Bike Parking", "Other"],
     "citations": [
       {
@@ -48237,7 +46128,6 @@
   },
   "Oxford, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 30, 2024, 7:56:24 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48257,7 +46147,6 @@
   },
   "Oxnard, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 4:44:34 AM UTC",
     "requirements": ["ADU"],
     "citations": [
       {
@@ -48277,7 +46166,6 @@
   },
   "Ozark, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48297,7 +46185,6 @@
   },
   "Paducah, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48317,7 +46204,6 @@
   },
   "Page, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "July 31, 2024, 8:12:17 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -48337,7 +46223,6 @@
   },
   "Pagosa Springs, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 9:51:33 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48357,7 +46242,6 @@
   },
   "Palmdale, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 20, 2024, 9:50:43 PM UTC",
     "requirements": [
       "ADU",
       "Historic Preservation",
@@ -48383,7 +46267,6 @@
   },
   "Palmer, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48403,7 +46286,6 @@
   },
   "Palmerton, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 25, 2024, 6:25:25 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -48423,7 +46305,6 @@
   },
   "Palmyra, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -48443,7 +46324,6 @@
   },
   "Panama City, FL": {
     "reporter": "Eric Pate",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -48476,7 +46356,6 @@
   },
   "Paola, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -48496,7 +46375,6 @@
   },
   "Paoli, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48516,7 +46394,6 @@
   },
   "Paonia, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 5:56:19 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -48536,7 +46413,6 @@
   },
   "Papillion, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48556,7 +46432,6 @@
   },
   "Parchment, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 6:36:31 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -48586,7 +46461,6 @@
   },
   "Paris, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48606,7 +46480,6 @@
   },
   "Park City, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 2:06:47 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48631,7 +46504,6 @@
   },
   "Park Forest, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -48662,7 +46534,6 @@
   },
   "Park Ridge, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -48682,7 +46553,6 @@
   },
   "Parker, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 5:02:37 PM UTC",
     "requirements": ["By Right", "Size of Project", "TDM"],
     "citations": [
       {
@@ -48712,7 +46582,6 @@
   },
   "Parker, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48732,7 +46601,6 @@
   },
   "Parkersburg, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48752,7 +46620,6 @@
   },
   "Parkesburg, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 30, 2024, 8:07:09 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -48772,7 +46639,6 @@
   },
   "Parkville, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project", "Bike Parking", "Other"],
     "citations": [
       {
@@ -48792,7 +46658,6 @@
   },
   "Parma Heights, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48812,7 +46677,6 @@
   },
   "Parma, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 10:59:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48832,7 +46696,6 @@
   },
   "Parsons, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48852,7 +46715,6 @@
   },
   "Pasadena, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 16, 2024, 7:59:21 PM UTC",
     "requirements": ["ADU", "Frequent Transit", "Car Share", "Other"],
     "citations": [
       {
@@ -48892,7 +46754,6 @@
   },
   "Pascagoula, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 6:13:54 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -48922,7 +46783,6 @@
   },
   "Pasco, WA": {
     "reporter": "Jacob Gonzalez",
-    "updated": "January 23, 2024, 3:59:32 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48947,7 +46807,6 @@
   },
   "Pass Christian, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 6:50:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -48967,7 +46826,6 @@
   },
   "Passau, BY": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 2:09:01 AM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -48992,7 +46850,6 @@
   },
   "Pataskala, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 4:58:34 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49012,7 +46869,6 @@
   },
   "Paterson, NJ": {
     "reporter": "Samuel Deetz",
-    "updated": "February 14, 2024, 9:28:11 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -49042,7 +46898,6 @@
   },
   "Paw Paw, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 9:28:58 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49062,7 +46917,6 @@
   },
   "Pawnee City, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49082,7 +46936,6 @@
   },
   "Pawnee, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 29, 2023, 1:29:39 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49102,7 +46955,6 @@
   },
   "Pawtucket, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 4:53:29 PM UTC",
     "requirements": ["Other", "By Right", "Size of Project"],
     "citations": [
       {
@@ -49142,7 +46994,6 @@
   },
   "Paxtang, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 21, 2024, 3:45:47 AM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -49167,7 +47018,6 @@
   },
   "Paxton, IL": {
     "reporter": "",
-    "updated": "December 28, 2023, 11:54:03 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -49197,7 +47047,6 @@
   },
   "Peachtree Corners, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49217,7 +47066,6 @@
   },
   "Pearl City, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 16, 2024, 6:24:52 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49237,7 +47085,6 @@
   },
   "Pearland, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 10:49:14 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -49267,7 +47114,6 @@
   },
   "Peculiar, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49287,7 +47133,6 @@
   },
   "Pekin, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49307,7 +47152,6 @@
   },
   "Pella, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49327,7 +47171,6 @@
   },
   "Pellston, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49347,7 +47190,6 @@
   },
   "Pender, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49367,7 +47209,6 @@
   },
   "Penetanguishene, ON": {
     "reporter": "Maggie Kochman",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49387,7 +47228,6 @@
   },
   "Penndel, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 22, 2024, 5:07:08 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49407,7 +47247,6 @@
   },
   "Pensacola, FL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 23, 2024, 12:00:12 AM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -49432,7 +47271,6 @@
   },
   "Penticton, BC": {
     "reporter": "Anthony Haddad",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49462,7 +47300,6 @@
   },
   "Pentwater, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 6, 2024, 6:32:29 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49487,7 +47324,6 @@
   },
   "Peoria, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -49507,7 +47343,6 @@
   },
   "Peoria, IL": {
     "reporter": "Maggie Kochman",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -49537,7 +47372,6 @@
   },
   "Pere Marquette Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 24, 2024, 10:16:15 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49557,7 +47391,6 @@
   },
   "Perham, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -49577,7 +47410,6 @@
   },
   "Perkins, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 16, 2024, 6:39:48 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -49597,7 +47429,6 @@
   },
   "Perry, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49617,7 +47448,6 @@
   },
   "Perry, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49637,7 +47467,6 @@
   },
   "Perrysburg, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 1:30:25 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49657,7 +47486,6 @@
   },
   "Perryville, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49677,7 +47505,6 @@
   },
   "Perth, WA": {
     "reporter": "Samuel Deetz",
-    "updated": "April 11, 2024, 5:17:08 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49710,7 +47537,6 @@
   },
   "Petal, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49730,7 +47556,6 @@
   },
   "Petaluma, CA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -49763,7 +47588,6 @@
   },
   "Petersburg, AK": {
     "reporter": "Samuel Deetz",
-    "updated": "February 15, 2024, 6:02:02 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49783,7 +47607,6 @@
   },
   "Peterson, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49803,7 +47626,6 @@
   },
   "Petoskey, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49843,7 +47665,6 @@
   },
   "Pewaukee (City), WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 1:43:07 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -49863,7 +47684,6 @@
   },
   "Philadelphia, PA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49901,7 +47721,6 @@
   },
   "Phillipsburg, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49921,7 +47740,6 @@
   },
   "Philo, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49941,7 +47759,6 @@
   },
   "Phoenix, AZ": {
     "reporter": "Sean Sweat",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -49987,7 +47804,6 @@
   },
   "Phoenixville, PA": {
     "reporter": "Ray Ott",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50020,7 +47836,6 @@
   },
   "Picayune, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 8:03:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50040,7 +47855,6 @@
   },
   "Pickens, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50060,7 +47874,6 @@
   },
   "Pickerington, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 3:45:23 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -50080,7 +47893,6 @@
   },
   "Piedmont, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 16, 2024, 7:44:03 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -50100,7 +47912,6 @@
   },
   "Pierre, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50120,7 +47931,6 @@
   },
   "Pierz, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50140,7 +47950,6 @@
   },
   "Pikeville, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50160,7 +47969,6 @@
   },
   "Pima County, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 5:59:53 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50180,7 +47988,6 @@
   },
   "Pinckney, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 8:55:55 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50200,7 +48007,6 @@
   },
   "Pinckneyville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 1:39:06 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50220,7 +48026,6 @@
   },
   "Pinconning, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 25, 2024, 6:01:15 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -50245,7 +48050,6 @@
   },
   "Pine Bluff, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50265,7 +48069,6 @@
   },
   "Pine City, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50285,7 +48088,6 @@
   },
   "Pinedale, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50310,7 +48112,6 @@
   },
   "Pineville, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "By Right", "Historic Preservation"],
     "citations": [
       {
@@ -50330,7 +48131,6 @@
   },
   "Piqua, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 17, 2024, 8:07:06 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -50350,7 +48150,6 @@
   },
   "Pittsboro, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50370,7 +48169,6 @@
   },
   "Pittsburgh, PA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50395,7 +48193,6 @@
   },
   "Pittsfield Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 9:37:15 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50415,7 +48212,6 @@
   },
   "Pittsfield, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 3:24:21 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50435,7 +48231,6 @@
   },
   "Pittsfield, MA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 22, 2024, 8:49:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50465,7 +48260,6 @@
   },
   "Plain City, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 5:56:29 PM UTC",
     "requirements": ["Size of Project"],
     "citations": [
       {
@@ -50485,7 +48279,6 @@
   },
   "Plainfield , IN": {
     "reporter": "Eric Berg",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50510,7 +48303,6 @@
   },
   "Plainfield, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -50530,7 +48322,6 @@
   },
   "Plainview, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50550,7 +48341,6 @@
   },
   "Plainview, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50570,7 +48360,6 @@
   },
   "Plano, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 29, 2023, 12:04:57 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50590,7 +48379,6 @@
   },
   "Plano, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "January 23, 2024, 2:57:01 AM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -50643,7 +48431,6 @@
   },
   "Platteville, WI": {
     "reporter": "Jake Schreiner",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -50668,7 +48455,6 @@
   },
   "Plattsmouth, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50688,7 +48474,6 @@
   },
   "Pleasant Ridge, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 3:09:22 AM UTC",
     "requirements": ["Bike Parking", "Other"],
     "citations": [
       {
@@ -50713,7 +48498,6 @@
   },
   "Pleasantville, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50733,7 +48517,6 @@
   },
   "Plymouth, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 5:51:07 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -50763,7 +48546,6 @@
   },
   "Plymouth, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50783,7 +48565,6 @@
   },
   "Pocahontas, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50803,7 +48584,6 @@
   },
   "Pocatello, ID": {
     "reporter": "Jim Anglesey",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50843,7 +48623,6 @@
   },
   "Pocomoke City, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 10, 2024, 5:06:21 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50863,7 +48642,6 @@
   },
   "Polk City, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50883,7 +48661,6 @@
   },
   "Pollock, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 5, 2024, 9:36:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50903,7 +48680,6 @@
   },
   "Polson, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Bike Parking", "Other"],
     "citations": [
       {
@@ -50923,7 +48699,6 @@
   },
   "Pomona, CA": {
     "reporter": "Patrick Siegman",
-    "updated": "February 20, 2024, 9:56:07 PM UTC",
     "requirements": ["Size of Project", "ADU"],
     "citations": [
       {
@@ -50956,7 +48731,6 @@
   },
   "Ponca City, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 8:53:54 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50976,7 +48750,6 @@
   },
   "Ponchatoula, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 4, 2024, 3:27:33 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -50996,7 +48769,6 @@
   },
   "Pontiac, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -51016,7 +48788,6 @@
   },
   "Pontiac, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 11:39:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51036,7 +48807,6 @@
   },
   "Poplar Bluff, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51056,7 +48826,6 @@
   },
   "Poplar Grove, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -51076,7 +48845,6 @@
   },
   "Port Allen, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 4, 2024, 11:06:18 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -51101,7 +48869,6 @@
   },
   "Port Austin, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 11, 2024, 8:53:15 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51121,7 +48888,6 @@
   },
   "Port Chester, NY": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51141,7 +48907,6 @@
   },
   "Port Clinton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51161,7 +48926,6 @@
   },
   "Port Edwards, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51181,7 +48945,6 @@
   },
   "Port Huron, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 6:41:34 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -51201,7 +48964,6 @@
   },
   "Port Sanilac, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 6:11:53 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -51221,7 +48983,6 @@
   },
   "Port St. Lucie, FL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 5:51:14 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -51241,7 +49002,6 @@
   },
   "Port Townsend, WA": {
     "reporter": "David Faber",
-    "updated": "March 7, 2024, 10:04:52 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -51284,7 +49044,6 @@
   },
   "Port Washington, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51304,7 +49063,6 @@
   },
   "Portage, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51324,7 +49082,6 @@
   },
   "Portage, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 7:04:28 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -51344,7 +49101,6 @@
   },
   "Portage, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -51364,7 +49120,6 @@
   },
   "Portland, ME": {
     "reporter": "Jacob Lavarnway",
-    "updated": "April 4, 2024, 2:42:22 AM UTC",
     "requirements": ["ADU", "Historic Preservation"],
     "citations": [
       {
@@ -51397,7 +49152,6 @@
   },
   "Portland, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 6:22:18 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -51422,7 +49176,6 @@
   },
   "Portland, OR": {
     "reporter": "Tony Jordan",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": [
       "Frequent Transit",
       "Inclusionary Housing",
@@ -51447,7 +49200,6 @@
   },
   "Portsmouth, OH": {
     "reporter": "Nolan Nicaise",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51467,7 +49219,6 @@
   },
   "Postville, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51487,7 +49238,6 @@
   },
   "Poteau, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 5:58:20 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51507,7 +49257,6 @@
   },
   "Pottsville, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51527,7 +49276,6 @@
   },
   "Poynette, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51552,7 +49300,6 @@
   },
   "Prairie du Chien, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51572,7 +49319,6 @@
   },
   "Prairie du Sac, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51592,7 +49338,6 @@
   },
   "Prescott, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51612,7 +49357,6 @@
   },
   "Prestonsburg, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51632,7 +49376,6 @@
   },
   "Primghar, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51652,7 +49395,6 @@
   },
   "Prince George's County, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 12, 2024, 4:22:32 AM UTC",
     "requirements": ["By Right", "TDM"],
     "citations": [
       {
@@ -51692,7 +49434,6 @@
   },
   "Princess Anne, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 10, 2024, 4:50:06 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -51712,7 +49453,6 @@
   },
   "Princeton, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees", "Other"],
     "citations": [
       {
@@ -51732,7 +49472,6 @@
   },
   "Princeton, NJ": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 2:32:57 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -51752,7 +49491,6 @@
   },
   "Princeton, WV": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51772,7 +49510,6 @@
   },
   "Princeville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51792,7 +49529,6 @@
   },
   "Prophetstown, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51812,7 +49548,6 @@
   },
   "Prospect, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "August 3, 2024, 3:27:03 PM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -51848,7 +49583,6 @@
   },
   "Providence, RI": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Bike Parking", "Frequent Transit", "By Right", "Other"],
     "citations": [
       {
@@ -51883,7 +49617,6 @@
   },
   "Provincetown, MA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51903,7 +49636,6 @@
   },
   "Provo, UT": {
     "reporter": "Austin Taylor",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["TDM", "Bike Parking", "Car Share"],
     "citations": [
       {
@@ -51917,7 +49649,6 @@
   },
   "Pryor Creek, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 3:40:20 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51937,7 +49668,6 @@
   },
   "Pulaski, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -51957,7 +49687,6 @@
   },
   "Punta Gorda, FL": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -51982,7 +49711,6 @@
   },
   "Punxsutawney, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "September 1, 2024, 2:46:14 AM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -52002,7 +49730,6 @@
   },
   "Quakertown, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 22, 2024, 5:20:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52022,7 +49749,6 @@
   },
   "Quincy, FL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 2:22:28 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52042,7 +49768,6 @@
   },
   "Quincy, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -52067,7 +49792,6 @@
   },
   "Quincy, MA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 31, 2024, 8:26:13 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52092,7 +49816,6 @@
   },
   "Quincy, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52112,7 +49835,6 @@
   },
   "Quitman County, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 2, 2024, 9:27:27 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -52132,7 +49854,6 @@
   },
   "Racine, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52152,7 +49873,6 @@
   },
   "Raleigh, NC": {
     "reporter": "Keegan McDonald",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52240,7 +49960,6 @@
   },
   "Ralston, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52260,7 +49979,6 @@
   },
   "Rancho Cucamonga, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 15, 2024, 7:59:28 PM UTC",
     "requirements": [
       "Frequent Transit",
       "Car Share",
@@ -52285,7 +50003,6 @@
   },
   "Randolph, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52305,7 +50022,6 @@
   },
   "Random Lake, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52325,7 +50041,6 @@
   },
   "Rankin, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 4:43:12 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -52345,7 +50060,6 @@
   },
   "Ranlo, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees", "Bike Parking", "Other"],
     "citations": [
       {
@@ -52375,7 +50089,6 @@
   },
   "Rantoul, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 11:33:17 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52395,7 +50108,6 @@
   },
   "Rapid City, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52415,7 +50127,6 @@
   },
   "Raton, NM": {
     "reporter": "Samuel Deetz",
-    "updated": "January 1, 2024, 8:15:54 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52435,7 +50146,6 @@
   },
   "Rawlins, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52455,7 +50165,6 @@
   },
   "Ray, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52480,7 +50189,6 @@
   },
   "Raytown, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52500,7 +50208,6 @@
   },
   "Reading, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 31, 2024, 6:37:21 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -52520,7 +50227,6 @@
   },
   "Reading, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -52540,7 +50246,6 @@
   },
   "Reading, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52560,7 +50265,6 @@
   },
   "Red Cloud, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52580,7 +50284,6 @@
   },
   "Red Cross, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -52600,7 +50303,6 @@
   },
   "Red Lake Falls, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52620,7 +50322,6 @@
   },
   "Red Lodge, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52640,7 +50341,6 @@
   },
   "Red Oak, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52660,7 +50360,6 @@
   },
   "Red Wing, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52680,7 +50379,6 @@
   },
   "Redding, CA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right", "Frequent Transit", "Bike Parking"],
     "citations": [
       {
@@ -52700,7 +50398,6 @@
   },
   "Redfield, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 19, 2024, 10:40:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52720,7 +50417,6 @@
   },
   "Redford Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 3:25:18 AM UTC",
     "requirements": ["By Right", "Other", "In Lieu Fees"],
     "citations": [
       {
@@ -52740,7 +50436,6 @@
   },
   "Redwood Falls, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 21, 2024, 2:35:11 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52760,7 +50455,6 @@
   },
   "Reedsburg, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52780,7 +50474,6 @@
   },
   "Reeseville, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52800,7 +50493,6 @@
   },
   "Regensburg, BY": {
     "reporter": "Samuel Deetz",
-    "updated": "March 7, 2024, 11:20:30 PM UTC",
     "requirements": [
       "Frequent Transit",
       "Bike Parking",
@@ -52875,7 +50567,6 @@
   },
   "Regina, SK": {
     "reporter": "Mike Cotcher",
-    "updated": "July 31, 2024, 4:54:29 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52908,7 +50599,6 @@
   },
   "Rehoboth Beach, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -52928,7 +50618,6 @@
   },
   "Reinbeck, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52948,7 +50637,6 @@
   },
   "Reno, NV": {
     "reporter": "Paul Donegan",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52968,7 +50656,6 @@
   },
   "Renville, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -52988,7 +50675,6 @@
   },
   "Reynoldsburg, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 3:57:33 PM UTC",
     "requirements": ["Other", "Frequent Transit", "Car Share", "Bike Parking"],
     "citations": [
       {
@@ -53013,7 +50699,6 @@
   },
   "Rhinelander, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53033,7 +50718,6 @@
   },
   "Rib Mountain, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 7, 2024, 5:21:58 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -53053,7 +50737,6 @@
   },
   "Rice Lake, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53073,7 +50756,6 @@
   },
   "Richfield, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Other", "Bike Parking", "Frequent Transit"],
     "citations": [
       {
@@ -53098,7 +50780,6 @@
   },
   "Richland Center, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53118,7 +50799,6 @@
   },
   "Richland City, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53138,7 +50818,6 @@
   },
   "Richland County, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 11:05:37 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -53158,7 +50837,6 @@
   },
   "Richland, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 8:08:14 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53178,7 +50856,6 @@
   },
   "Richmond, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53203,7 +50880,6 @@
   },
   "Richmond, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53223,7 +50899,6 @@
   },
   "Richmond, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 6:47:07 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53243,7 +50918,6 @@
   },
   "Richmond, VA": {
     "reporter": "Patrick Siegman",
-    "updated": "March 14, 2024, 6:47:07 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53276,7 +50950,6 @@
   },
   "Richton Park, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53296,7 +50969,6 @@
   },
   "Ridgefield, WA": {
     "reporter": "Daniel Robinson",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right", "Frequent Transit", "Bike Parking"],
     "citations": [
       {
@@ -53316,7 +50988,6 @@
   },
   "Ridgeland, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 2, 2024, 7:02:36 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -53336,7 +51007,6 @@
   },
   "Ridgely, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 10, 2024, 7:10:00 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -53356,7 +51026,6 @@
   },
   "Ridgeway, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -53376,7 +51045,6 @@
   },
   "Ridgway, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 6:16:26 PM UTC",
     "requirements": ["By Right", "Other", "In Lieu Fees"],
     "citations": [
       {
@@ -53396,7 +51064,6 @@
   },
   "Ridley Park, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 24, 2024, 3:19:04 AM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -53421,7 +51088,6 @@
   },
   "Rifle, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -53441,7 +51107,6 @@
   },
   "Riley, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53461,7 +51126,6 @@
   },
   "Rio de Janeiro, RJ": {
     "reporter": "Jacob Mason",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53481,7 +51145,6 @@
   },
   "Rising Sun, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -53501,7 +51164,6 @@
   },
   "Rittman, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 10, 2024, 4:56:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53521,7 +51183,6 @@
   },
   "River Forest, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53541,7 +51202,6 @@
   },
   "River Grove, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -53566,7 +51226,6 @@
   },
   "River Rouge, MI": {
     "reporter": "Nani Wolf",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -53586,7 +51245,6 @@
   },
   "Riverdale, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -53611,7 +51269,6 @@
   },
   "Riverside, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 20, 2024, 12:05:03 AM UTC",
     "requirements": ["ADU", "TDM", "Other", "By Right"],
     "citations": [
       {
@@ -53641,7 +51298,6 @@
   },
   "Riverside, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53661,7 +51317,6 @@
   },
   "Riverside, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -53721,7 +51376,6 @@
   },
   "Riverton, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53741,7 +51395,6 @@
   },
   "Roanoke, VA": {
     "reporter": "Chris Chittum",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53766,7 +51419,6 @@
   },
   "Robbinsdale, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 22, 2024, 12:02:40 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53791,7 +51443,6 @@
   },
   "Roberts, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 6:45:44 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -53811,7 +51462,6 @@
   },
   "Rochelle, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53831,7 +51481,6 @@
   },
   "Rochester Hills, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 3:32:06 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53851,7 +51500,6 @@
   },
   "Rochester, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 3:22:30 AM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -53871,7 +51519,6 @@
   },
   "Rochester, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "March 27, 2024, 6:49:11 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -53896,7 +51543,6 @@
   },
   "Rochester, NY": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53916,7 +51562,6 @@
   },
   "Rock Creek, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53936,7 +51581,6 @@
   },
   "Rock Creek, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53956,7 +51600,6 @@
   },
   "Rock Falls, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -53976,7 +51619,6 @@
   },
   "Rock Hill, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -54011,7 +51653,6 @@
   },
   "Rock Island County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54031,7 +51672,6 @@
   },
   "Rock Island, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54051,7 +51691,6 @@
   },
   "Rock Island, WA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -54071,7 +51710,6 @@
   },
   "Rock Rapids, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54091,7 +51729,6 @@
   },
   "Rock Valley, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54111,7 +51748,6 @@
   },
   "Rockdale, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54131,7 +51767,6 @@
   },
   "Rockford, IL": {
     "reporter": "Jake Schreiner",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -54151,7 +51786,6 @@
   },
   "Rockford, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54171,7 +51805,6 @@
   },
   "Rockville, MD": {
     "reporter": "Natasha Shangold",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54191,7 +51824,6 @@
   },
   "Rockwell City, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54211,7 +51843,6 @@
   },
   "Rockwell, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54231,7 +51862,6 @@
   },
   "Rocky River, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -54256,7 +51886,6 @@
   },
   "Rogers City, MI": {
     "reporter": "Alex Harimoto",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54276,7 +51905,6 @@
   },
   "Rogers, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54306,7 +51934,6 @@
   },
   "Rogers, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -54326,7 +51953,6 @@
   },
   "Rolla, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -54346,7 +51972,6 @@
   },
   "Rolling Meadows, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -54366,7 +51991,6 @@
   },
   "Rome City, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54386,7 +52010,6 @@
   },
   "Romeo, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 8:30:06 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -54406,7 +52029,6 @@
   },
   "Romeoville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54426,7 +52048,6 @@
   },
   "Romulus, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 6:09:30 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54446,7 +52067,6 @@
   },
   "Roscoe, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 3:29:41 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54466,7 +52086,6 @@
   },
   "Roscommon, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 24, 2024, 4:36:59 PM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -54491,7 +52110,6 @@
   },
   "Rose Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 5, 2024, 3:18:45 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54511,7 +52129,6 @@
   },
   "Roseau, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "March 27, 2024, 6:18:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54531,7 +52148,6 @@
   },
   "Roselle, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -54551,7 +52167,6 @@
   },
   "Rosemount, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54571,7 +52186,6 @@
   },
   "Rosenheim, BY": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 5:27:33 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -54591,7 +52205,6 @@
   },
   "Roseville, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 16, 2024, 8:09:05 PM UTC",
     "requirements": [
       "ADU",
       "By Right",
@@ -54622,7 +52235,6 @@
   },
   "Roseville, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 8:03:29 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -54642,7 +52254,6 @@
   },
   "Roseville, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Frequent Transit", "Other", "TDM"],
     "citations": [
       {
@@ -54667,7 +52278,6 @@
   },
   "Rossford, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 1:33:57 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54687,7 +52297,6 @@
   },
   "Rossville, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54707,7 +52316,6 @@
   },
   "Rostock, MV": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 7:30:36 PM UTC",
     "requirements": [
       "By Right",
       "In Lieu Fees",
@@ -54749,7 +52357,6 @@
   },
   "Roswell, NM": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54769,7 +52376,6 @@
   },
   "Round Lake Beach, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -54789,7 +52395,6 @@
   },
   "Round Lake Park, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -54809,7 +52414,6 @@
   },
   "Round Lake, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -54829,7 +52433,6 @@
   },
   "Roundup, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54849,7 +52452,6 @@
   },
   "Royal Oak, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 3:45:55 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54874,7 +52476,6 @@
   },
   "Royalton, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54894,7 +52495,6 @@
   },
   "Rudolph, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54914,7 +52514,6 @@
   },
   "Rush City, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54934,7 +52533,6 @@
   },
   "Rushville, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54954,7 +52552,6 @@
   },
   "Russell Springs, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -54974,7 +52571,6 @@
   },
   "Russell, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -54994,7 +52590,6 @@
   },
   "Russellville, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -55019,7 +52614,6 @@
   },
   "Russellville, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55039,7 +52633,6 @@
   },
   "Ruston, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55059,7 +52652,6 @@
   },
   "Ruthven, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55079,7 +52671,6 @@
   },
   "Sabetha, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55099,7 +52690,6 @@
   },
   "Sacramento, CA": {
     "reporter": "Ryan Dodge",
-    "updated": "April 4, 2024, 2:34:17 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55150,7 +52740,6 @@
   },
   "Saginaw Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 9, 2024, 10:32:06 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -55170,7 +52759,6 @@
   },
   "Saginaw, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 11:50:17 PM UTC",
     "requirements": ["Bike Parking"],
     "citations": [
       {
@@ -55190,7 +52778,6 @@
   },
   "Saint Marys, PA": {
     "reporter": "Matthew Pfeufer",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55210,7 +52797,6 @@
   },
   "Salaberry-de-Valleyfield, QC": {
     "reporter": "Vincent Lefebvre",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55235,7 +52821,6 @@
   },
   "Salem, MA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 22, 2024, 11:41:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55260,7 +52845,6 @@
   },
   "Salem, OR": {
     "reporter": "Tony Jordan",
-    "updated": "May 12, 2024, 3:38:10 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55306,7 +52890,6 @@
   },
   "Salem, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55326,7 +52909,6 @@
   },
   "Salida, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 4, 2024, 8:24:32 PM UTC",
     "requirements": ["In Lieu Fees", "Other"],
     "citations": [
       {
@@ -55351,7 +52933,6 @@
   },
   "Salina, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55371,7 +52952,6 @@
   },
   "Salinas, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 20, 2024, 11:33:37 PM UTC",
     "requirements": [
       "Car Share",
       "Frequent Transit",
@@ -55407,7 +52987,6 @@
   },
   "Saline, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 8:34:40 PM UTC",
     "requirements": ["By Right", "Size of Project", "In Lieu Fees"],
     "citations": [
       {
@@ -55427,7 +53006,6 @@
   },
   "Salisbury, MD": {
     "reporter": "William White",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55447,7 +53025,6 @@
   },
   "Salisbury, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55467,7 +53044,6 @@
   },
   "Salisbury, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -55492,7 +53068,6 @@
   },
   "Salix, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55512,7 +53087,6 @@
   },
   "Salt Lake City, UT": {
     "reporter": "Brittain Corbett",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -55563,7 +53137,6 @@
   },
   "San Angelo, TX": {
     "reporter": "Jon James",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55583,7 +53156,6 @@
   },
   "San Antonio, TX": {
     "reporter": "dawn hanson",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55603,7 +53175,6 @@
   },
   "San Bernardino, CA": {
     "reporter": "Maggie Kochman",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["Frequent Transit", "In Lieu Fees", "Other", "ADU"],
     "citations": [
       {
@@ -55636,7 +53207,6 @@
   },
   "San Diego, CA": {
     "reporter": "Chris McCahill",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": [
       "Frequent Transit",
       "Planned Frequent Transit",
@@ -55673,7 +53243,6 @@
   },
   "San Francisco, CA": {
     "reporter": "Tom Radulovich",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55698,7 +53267,6 @@
   },
   "San Jose, CA": {
     "reporter": "Edward Schreiner",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55718,7 +53286,6 @@
   },
   "San Juan, PR": {
     "reporter": "Samuel Deetz",
-    "updated": "April 13, 2024, 4:48:30 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55738,7 +53305,6 @@
   },
   "San Luis Obispo, CA": {
     "reporter": "Ryan Hartzell",
-    "updated": "May 17, 2024, 7:30:14 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -55773,7 +53339,6 @@
   },
   "San Marcos, TX": {
     "reporter": "Andrea Villalobos",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55793,7 +53358,6 @@
   },
   "San Pedro Garza García, NL": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 8:30:56 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55813,7 +53377,6 @@
   },
   "Sandpoint, ID": {
     "reporter": "Steve Lockwood",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["Inclusionary Housing", "Affordable Housing"],
     "citations": [
       {
@@ -55846,7 +53409,6 @@
   },
   "Sandusky, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 11, 2024, 9:36:54 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55871,7 +53433,6 @@
   },
   "Sandusky, OH": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -55891,7 +53452,6 @@
   },
   "Sandwich, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 9:23:05 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -55911,7 +53471,6 @@
   },
   "Sandy Springs, GA": {
     "reporter": "Derrick Arndt",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": [
       "By Right",
       "Affordable Housing",
@@ -55942,7 +53501,6 @@
   },
   "Santa Ana, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 11:42:34 PM UTC",
     "requirements": ["ADU", "Other"],
     "citations": [
       {
@@ -55967,7 +53525,6 @@
   },
   "Santa Barbara, CA": {
     "reporter": "Jessica Metzger",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": [
       "By Right",
       "Bike Parking",
@@ -55994,7 +53551,6 @@
   },
   "Santa Clara, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 9:36:42 PM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -56024,7 +53580,6 @@
   },
   "Santa Clarita, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 8:33:37 PM UTC",
     "requirements": ["ADU"],
     "citations": [
       {
@@ -56044,7 +53599,6 @@
   },
   "Santa Fe, NM": {
     "reporter": "Samuel Deetz",
-    "updated": "January 1, 2024, 8:26:10 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -56069,7 +53623,6 @@
   },
   "Santa Monica, CA": {
     "reporter": "Ellen Schwartz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56089,7 +53642,6 @@
   },
   "Santa Rosa, CA": {
     "reporter": "Angel York",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56109,7 +53661,6 @@
   },
   "Sapulpa, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 7:21:10 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56134,7 +53685,6 @@
   },
   "Saranac Lake, NY": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56154,7 +53704,6 @@
   },
   "Sarasota, FL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 22, 2024, 10:37:42 PM UTC",
     "requirements": ["ADU", "Other", "By Right"],
     "citations": [
       {
@@ -56204,7 +53753,6 @@
   },
   "Saratoga Springs, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 2:15:49 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56229,7 +53777,6 @@
   },
   "Saratoga, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -56254,7 +53801,6 @@
   },
   "Sardis, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 2, 2024, 10:01:25 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56274,7 +53820,6 @@
   },
   "Saskatoon, SK": {
     "reporter": "Bertrand Bartake",
-    "updated": "August 1, 2024, 6:35:18 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56312,7 +53857,6 @@
   },
   "Saugatuck Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 5, 2024, 3:27:01 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56332,7 +53876,6 @@
   },
   "Saugatuck, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 5:34:32 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56352,7 +53895,6 @@
   },
   "Sauk City, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56372,7 +53914,6 @@
   },
   "Sauk Village, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -56392,7 +53933,6 @@
   },
   "Sault Ste. Marie, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56412,7 +53952,6 @@
   },
   "Sault Ste. Marie, ON": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -56432,7 +53971,6 @@
   },
   "Savanna, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56452,7 +53990,6 @@
   },
   "Savannah, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 10:10:13 PM UTC",
     "requirements": ["By Right", "Bike Parking", "Other"],
     "citations": [
       {
@@ -56497,7 +54034,6 @@
   },
   "Savannah, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56517,7 +54053,6 @@
   },
   "Schaumburg, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Frequent Transit", "In Lieu Fees", "Other", "TDM"],
     "citations": [
       {
@@ -56542,7 +54077,6 @@
   },
   "Schenectady, NY": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56572,7 +54106,6 @@
   },
   "Schererville, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -56597,7 +54130,6 @@
   },
   "Schiller Park, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -56617,7 +54149,6 @@
   },
   "Schoolcraft, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 8:27:14 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56642,7 +54173,6 @@
   },
   "Schuyler, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56662,7 +54192,6 @@
   },
   "Scio Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 5, 2024, 3:34:00 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56682,7 +54211,6 @@
   },
   "Scotland": {
     "reporter": "Samuel Deetz",
-    "updated": "April 11, 2024, 4:00:53 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56702,7 +54230,6 @@
   },
   "Scottsbluff, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56722,7 +54249,6 @@
   },
   "Scottsdale, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 6:58:49 PM UTC",
     "requirements": ["By Right", "Other", "In Lieu Fees", "Size of Project"],
     "citations": [
       {
@@ -56752,7 +54278,6 @@
   },
   "Scranton, PA": {
     "reporter": "Craig Beavers",
-    "updated": "July 17, 2024, 3:17:14 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56785,7 +54310,6 @@
   },
   "Seabrook, NH": {
     "reporter": "Tom Morgan",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56805,7 +54329,6 @@
   },
   "Searcy, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56825,7 +54348,6 @@
   },
   "Seattle, WA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56845,7 +54367,6 @@
   },
   "Sebewaing, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 11, 2024, 9:02:27 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -56880,7 +54401,6 @@
   },
   "Sedalia, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56900,7 +54420,6 @@
   },
   "Seligman, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56920,7 +54439,6 @@
   },
   "Sellersville, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 22, 2024, 5:25:59 PM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -56945,7 +54463,6 @@
   },
   "Selma, AL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 22, 2024, 11:16:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56965,7 +54482,6 @@
   },
   "Senatobia, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 2, 2024, 9:47:02 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -56985,7 +54501,6 @@
   },
   "Seneca, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -57005,7 +54520,6 @@
   },
   "Seneca, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57025,7 +54539,6 @@
   },
   "Sergeant Bluff, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57045,7 +54558,6 @@
   },
   "Sesser, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 23, 2024, 3:27:49 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57070,7 +54582,6 @@
   },
   "Severance, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 7:48:09 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -57095,7 +54606,6 @@
   },
   "Seward, AK": {
     "reporter": "Samuel Deetz",
-    "updated": "February 15, 2024, 6:07:22 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57115,7 +54625,6 @@
   },
   "Seward, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57135,7 +54644,6 @@
   },
   "Sewickley, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 5:41:51 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -57155,7 +54663,6 @@
   },
   "Seymour, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57175,7 +54682,6 @@
   },
   "Shaker Heights, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Other", "Size of Project"],
     "citations": [
       {
@@ -57195,7 +54701,6 @@
   },
   "Shakopee, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57215,7 +54720,6 @@
   },
   "Sharon, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57235,7 +54739,6 @@
   },
   "Sharonville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57255,7 +54758,6 @@
   },
   "Shawano County, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 11:15:31 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57275,7 +54777,6 @@
   },
   "Shawano, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57295,7 +54796,6 @@
   },
   "Shawnee, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57315,7 +54815,6 @@
   },
   "Sheboygan, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57335,7 +54834,6 @@
   },
   "Sheffield Lake, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 3:51:52 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57355,7 +54853,6 @@
   },
   "Shelby County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 2:13:28 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -57375,7 +54872,6 @@
   },
   "Shelby, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57395,7 +54891,6 @@
   },
   "Shelby, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 6, 2024, 6:42:56 PM UTC",
     "requirements": ["Bike Parking", "Size of Project", "Other"],
     "citations": [
       {
@@ -57420,7 +54915,6 @@
   },
   "Shelby, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57440,7 +54934,6 @@
   },
   "Shelby, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 11, 2024, 4:59:01 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57460,7 +54953,6 @@
   },
   "Shelbyville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 23, 2024, 3:18:26 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -57480,7 +54972,6 @@
   },
   "Shelbyville, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57500,7 +54991,6 @@
   },
   "Sheldon, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57520,7 +55010,6 @@
   },
   "Shell Rock, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57540,7 +55029,6 @@
   },
   "Shenandoah, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -57560,7 +55048,6 @@
   },
   "Sherbrooke, QC": {
     "reporter": "Etienne Lefebvre",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57580,7 +55067,6 @@
   },
   "Sheridan, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -57600,7 +55086,6 @@
   },
   "Sherman, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 4:18:18 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57620,7 +55105,6 @@
   },
   "Sherman, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57640,7 +55124,6 @@
   },
   "Sherwood, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -57660,7 +55143,6 @@
   },
   "Shiocton, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57680,7 +55162,6 @@
   },
   "Shippensburg, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 19, 2024, 2:09:51 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57700,7 +55181,6 @@
   },
   "Shively, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "August 3, 2024, 3:22:43 PM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -57736,7 +55216,6 @@
   },
   "Shoreview, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Frequent Transit", "TDM", "Other"],
     "citations": [
       {
@@ -57756,7 +55235,6 @@
   },
   "Shorewood, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "December 28, 2023, 11:47:05 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57776,7 +55254,6 @@
   },
   "Shorewood, WI": {
     "reporter": "Ann McKaig",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57796,7 +55273,6 @@
   },
   "Shreveport, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 7:47:37 AM UTC",
     "requirements": [
       "Other",
       "Historic Preservation",
@@ -57836,7 +55312,6 @@
   },
   "Sidney, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57856,7 +55331,6 @@
   },
   "Sidney, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -57876,7 +55350,6 @@
   },
   "Sidney, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57896,7 +55369,6 @@
   },
   "Sidney, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 18, 2024, 2:12:51 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -57916,7 +55388,6 @@
   },
   "Sierra Vista, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 5:54:31 PM UTC",
     "requirements": ["Bike Parking", "Other"],
     "citations": [
       {
@@ -57936,7 +55407,6 @@
   },
   "Siloam Springs, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -57956,7 +55426,6 @@
   },
   "Silver City, NM": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -57981,7 +55450,6 @@
   },
   "Silver Lake, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58001,7 +55469,6 @@
   },
   "Silverthorne, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 5, 2024, 5:14:06 AM UTC",
     "requirements": [
       "Bike Parking",
       "Frequent Transit",
@@ -58032,7 +55499,6 @@
   },
   "Simi Valley, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 10:18:35 PM UTC",
     "requirements": ["ADU"],
     "citations": [
       {
@@ -58052,7 +55518,6 @@
   },
   "Sinking Spring, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 18, 2024, 6:50:12 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58072,7 +55537,6 @@
   },
   "Sioux Center, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58092,7 +55556,6 @@
   },
   "Sioux City, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58112,7 +55575,6 @@
   },
   "Sioux Falls, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["Bike Parking", "TDM", "Other"],
     "citations": [
       {
@@ -58132,7 +55594,6 @@
   },
   "Siren, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58152,7 +55613,6 @@
   },
   "Sister Bay, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -58192,7 +55652,6 @@
   },
   "Skokie, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -58233,7 +55692,6 @@
   },
   "Slayton, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -58253,7 +55711,6 @@
   },
   "Slidell, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 26, 2024, 4:33:01 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58273,7 +55730,6 @@
   },
   "Sligo, County Sligo": {
     "reporter": "Samuel Deetz",
-    "updated": "July 9, 2024, 7:31:13 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -58293,7 +55749,6 @@
   },
   "Slippery Rock, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 24, 2024, 10:37:27 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58313,7 +55768,6 @@
   },
   "Sloan, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58333,7 +55787,6 @@
   },
   "Smith Center, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58353,7 +55806,6 @@
   },
   "Smithfield, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 7:01:11 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -58373,7 +55825,6 @@
   },
   "Smithsburg, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 8:41:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58393,7 +55844,6 @@
   },
   "Smithton, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58413,7 +55863,6 @@
   },
   "Smithville, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58433,7 +55882,6 @@
   },
   "Smyrna, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58453,7 +55901,6 @@
   },
   "Snellville, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -58478,7 +55925,6 @@
   },
   "Snow Hill, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 10, 2024, 4:23:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58498,7 +55944,6 @@
   },
   "Snowmass Village, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 7:08:23 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -58523,7 +55968,6 @@
   },
   "Somerset, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58543,7 +55987,6 @@
   },
   "Somersworth, NH": {
     "reporter": "Kenneth Ferrer",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58563,7 +56006,6 @@
   },
   "Somerville, MA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Frequent Transit", "By Right"],
     "citations": [
       {
@@ -58583,7 +56025,6 @@
   },
   "Somonauk, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 12:47:14 AM UTC",
     "requirements": ["Other", "By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -58608,7 +56049,6 @@
   },
   "South Bend, IN": {
     "reporter": "Michael Divita",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58628,7 +56068,6 @@
   },
   "South Burlington, VT": {
     "reporter": "Cathyann LaRose",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58661,7 +56100,6 @@
   },
   "South Charleston, WV": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58681,7 +56119,6 @@
   },
   "South Chicago Heights, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 9:43:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58701,7 +56138,6 @@
   },
   "South Coatesville, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 30, 2024, 8:15:23 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -58726,7 +56162,6 @@
   },
   "South Elgin, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -58758,7 +56193,6 @@
   },
   "South Euclid, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 4:05:03 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58778,7 +56212,6 @@
   },
   "South Haven, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 5:39:07 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58798,7 +56231,6 @@
   },
   "South Kingstown, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 8:30:54 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58818,7 +56250,6 @@
   },
   "South Lyon, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 3:52:22 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58838,7 +56269,6 @@
   },
   "South Milwaukee, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58858,7 +56288,6 @@
   },
   "South Pekin, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58878,7 +56307,6 @@
   },
   "South Perth, WA": {
     "reporter": "Samuel Deetz",
-    "updated": "April 11, 2024, 5:16:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58898,7 +56326,6 @@
   },
   "South Rockwood, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "April 1, 2024, 5:13:58 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -58923,7 +56350,6 @@
   },
   "South St. Paul, MN": {
     "reporter": "Michael Healy",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Size of Project"],
     "citations": [
       {
@@ -58943,7 +56369,6 @@
   },
   "South Whitley, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58963,7 +56388,6 @@
   },
   "Southern View, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 24, 2024, 4:59:15 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -58983,7 +56407,6 @@
   },
   "Southfield, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 4:03:39 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59003,7 +56426,6 @@
   },
   "Sparta, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59023,7 +56445,6 @@
   },
   "Sparta, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 8:27:13 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -59043,7 +56464,6 @@
   },
   "Sparta, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59063,7 +56483,6 @@
   },
   "Spearfish, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59083,7 +56502,6 @@
   },
   "Spencer, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59103,7 +56521,6 @@
   },
   "Spencerville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 18, 2024, 3:27:25 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59123,7 +56540,6 @@
   },
   "Spicer, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59143,7 +56559,6 @@
   },
   "Spirit Lake, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59163,7 +56578,6 @@
   },
   "Spokane, WA": {
     "reporter": "Evan Manvel",
-    "updated": "August 13, 2024, 2:28:27 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -59219,7 +56633,6 @@
   },
   "Spring City, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 30, 2024, 8:24:11 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -59244,7 +56657,6 @@
   },
   "Spring Green, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59264,7 +56676,6 @@
   },
   "Spring Lake, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 9:51:03 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -59284,7 +56695,6 @@
   },
   "Spring Park, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59304,7 +56714,6 @@
   },
   "Spring Valley, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59324,7 +56733,6 @@
   },
   "Springboro, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Bike Parking", "Other"],
     "citations": [
       {
@@ -59349,7 +56757,6 @@
   },
   "Springdale, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -59369,7 +56776,6 @@
   },
   "Springdale, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59389,7 +56795,6 @@
   },
   "Springfield, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59409,7 +56814,6 @@
   },
   "Springfield, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59429,7 +56833,6 @@
   },
   "Springfield, MA": {
     "reporter": "Yarden Mach",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59449,7 +56852,6 @@
   },
   "Springfield, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59469,7 +56871,6 @@
   },
   "Springfield, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59489,7 +56890,6 @@
   },
   "Springfield, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 29, 2024, 5:30:47 AM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -59514,7 +56914,6 @@
   },
   "Springfield, OR": {
     "reporter": "Evan Manvel",
-    "updated": "May 12, 2024, 3:30:28 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59547,7 +56946,6 @@
   },
   "Springport, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 11:04:40 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -59567,7 +56965,6 @@
   },
   "St. Ansgar, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59587,7 +56984,6 @@
   },
   "St. Bernard, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59607,7 +57003,6 @@
   },
   "St. Bonifacius, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59627,7 +57022,6 @@
   },
   "St. Catharines, ON": {
     "reporter": "Tami Kitay",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59667,7 +57061,6 @@
   },
   "St. Charles, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -59687,7 +57080,6 @@
   },
   "St. Charles, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 9, 2024, 10:01:58 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -59712,7 +57104,6 @@
   },
   "St. Charles, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Bike Parking", "Other"],
     "citations": [
       {
@@ -59732,7 +57123,6 @@
   },
   "St. Clair, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 6:54:42 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -59752,7 +57142,6 @@
   },
   "St. Clair, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59772,7 +57161,6 @@
   },
   "St. Cloud, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees", "By Right", "Other"],
     "citations": [
       {
@@ -59792,7 +57180,6 @@
   },
   "St. Croix Falls, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59812,7 +57199,6 @@
   },
   "St. Francisville, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 7:31:55 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59832,7 +57218,6 @@
   },
   "St. Gabriel, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 26, 2024, 5:06:48 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59852,7 +57237,6 @@
   },
   "St. Ignace, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59872,7 +57256,6 @@
   },
   "St. James, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59892,7 +57275,6 @@
   },
   "St. John the Baptist Parish, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 6:36:20 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -59912,7 +57294,6 @@
   },
   "St. John's, NL": {
     "reporter": "Etienne Lefebvre",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59937,7 +57318,6 @@
   },
   "St. John, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59957,7 +57337,6 @@
   },
   "St. Johns, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 13, 2024, 8:15:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59977,7 +57356,6 @@
   },
   "St. Joseph Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 30, 2024, 3:29:36 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -59997,7 +57375,6 @@
   },
   "St. Joseph County, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "July 31, 2024, 8:04:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60017,7 +57394,6 @@
   },
   "St. Joseph, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 23, 2024, 3:22:27 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60042,7 +57418,6 @@
   },
   "St. Joseph, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60062,7 +57437,6 @@
   },
   "St. Louis Park, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Frequent Transit", "Other", "TDM"],
     "citations": [
       {
@@ -60097,7 +57471,6 @@
   },
   "St. Louis, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 9, 2024, 6:05:10 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -60117,7 +57490,6 @@
   },
   "St. Louis, MO": {
     "reporter": "Scott Ogilvie",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60173,7 +57545,6 @@
   },
   "St. Matthews, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "August 2, 2024, 4:33:15 AM UTC",
     "requirements": ["By Right", "Frequent Transit", "Other"],
     "citations": [
       {
@@ -60203,7 +57574,6 @@
   },
   "St. Michael, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60223,7 +57593,6 @@
   },
   "St. Michaels, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 10, 2024, 7:41:27 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -60243,7 +57612,6 @@
   },
   "St. Paul Park, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 21, 2024, 5:07:48 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60263,7 +57631,6 @@
   },
   "St. Paul, MN": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60308,7 +57675,6 @@
   },
   "St. Paul, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60328,7 +57694,6 @@
   },
   "St. Pete Beach, FL": {
     "reporter": "Anthony Close",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60348,7 +57713,6 @@
   },
   "St. Peter, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60368,7 +57732,6 @@
   },
   "St. Petersburg, FL": {
     "reporter": "Anthony Close",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60398,7 +57761,6 @@
   },
   "St. Tammany Parish, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 6:46:30 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -60418,7 +57780,6 @@
   },
   "Stallings, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "Bike Parking", "In Lieu Fees"],
     "citations": [
       {
@@ -60448,7 +57809,6 @@
   },
   "Stamford, CT": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 8:32:53 PM UTC",
     "requirements": ["Car Share", "By Right"],
     "citations": [
       {
@@ -60478,7 +57838,6 @@
   },
   "Stanfield, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -60498,7 +57857,6 @@
   },
   "Stanford, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60518,7 +57876,6 @@
   },
   "Stanley, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60538,7 +57895,6 @@
   },
   "Stanton, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 8, 2024, 11:39:41 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -60563,7 +57919,6 @@
   },
   "Stanwood, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60583,7 +57938,6 @@
   },
   "Star Prairie, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60603,7 +57957,6 @@
   },
   "Star Valley Ranch, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -60623,7 +57976,6 @@
   },
   "Starbuck, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -60643,7 +57995,6 @@
   },
   "Starkville, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Frequent Transit", "Bike Parking"],
     "citations": [
       {
@@ -60663,7 +58014,6 @@
   },
   "State Center, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60683,7 +58033,6 @@
   },
   "State College, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 25, 2024, 10:19:31 PM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -60724,7 +58073,6 @@
   },
   "Statesville, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60744,7 +58092,6 @@
   },
   "Ste. Genevieve, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60764,7 +58111,6 @@
   },
   "Steamboat Springs, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 6:07:48 PM UTC",
     "requirements": ["Frequent Transit", "Other", "In Lieu Fees"],
     "citations": [
       {
@@ -60794,7 +58140,6 @@
   },
   "Steger, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60814,7 +58159,6 @@
   },
   "Stephenson County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60834,7 +58178,6 @@
   },
   "Sterling, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60854,7 +58197,6 @@
   },
   "Sterling, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60874,7 +58216,6 @@
   },
   "Sterling, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60894,7 +58235,6 @@
   },
   "Steubenville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 12:14:52 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -60914,7 +58254,6 @@
   },
   "Stevens Point, WI": {
     "reporter": "Trevor Roark",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -60949,7 +58288,6 @@
   },
   "Stevensville, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 23, 2024, 5:30:14 AM UTC",
     "requirements": ["Other", "Bike Parking", "Size of Project"],
     "citations": [
       {
@@ -60974,7 +58312,6 @@
   },
   "Stevensville, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -60994,7 +58331,6 @@
   },
   "Stewartville, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61014,7 +58350,6 @@
   },
   "Stillwater, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 16, 2024, 6:48:13 PM UTC",
     "requirements": ["Other", "Frequent Transit", "By Right"],
     "citations": [
       {
@@ -61044,7 +58379,6 @@
   },
   "Stirling, WA": {
     "reporter": "Samuel Deetz",
-    "updated": "April 30, 2024, 7:26:47 PM UTC",
     "requirements": [
       "In Lieu Fees",
       "Frequent Transit",
@@ -61140,7 +58474,6 @@
   },
   "Stockbridge, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 8:25:59 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61160,7 +58493,6 @@
   },
   "Stockton, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 10:23:52 PM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -61207,7 +58539,6 @@
   },
   "Stonington, CT": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61227,7 +58558,6 @@
   },
   "Storm Lake, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61247,7 +58577,6 @@
   },
   "Story City, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61267,7 +58596,6 @@
   },
   "Story County, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 2, 2024, 4:39:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61287,7 +58615,6 @@
   },
   "Stoughton, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61307,7 +58634,6 @@
   },
   "Strasburg, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 12, 2024, 3:20:03 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61327,7 +58653,6 @@
   },
   "Stratford, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61347,7 +58672,6 @@
   },
   "Stratton, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61367,7 +58691,6 @@
   },
   "Streator, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61387,7 +58710,6 @@
   },
   "Stuart, FL": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["In Lieu Fees", "Historic Preservation"],
     "citations": [
       {
@@ -61417,7 +58739,6 @@
   },
   "Stuart, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61442,7 +58763,6 @@
   },
   "Sturgeon Bay, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -61462,7 +58782,6 @@
   },
   "Sturgis, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 31, 2024, 1:19:50 AM UTC",
     "requirements": ["Other", "By Right", "Size of Project"],
     "citations": [
       {
@@ -61487,7 +58806,6 @@
   },
   "Sturgis, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61507,7 +58825,6 @@
   },
   "Stuttgart, BW": {
     "reporter": "Samuel Deetz",
-    "updated": "May 3, 2024, 9:29:46 PM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -61537,7 +58854,6 @@
   },
   "Subiaco, WA": {
     "reporter": "Samuel Deetz",
-    "updated": "April 11, 2024, 5:52:00 AM UTC",
     "requirements": ["Frequent Transit", "Bike Parking", "Other", "By Right"],
     "citations": [
       {
@@ -61572,7 +58888,6 @@
   },
   "Sublette, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61592,7 +58907,6 @@
   },
   "Sudbury, ON": {
     "reporter": "Etienne Lefebvre",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61617,7 +58931,6 @@
   },
   "Sugar Creek, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61637,7 +58950,6 @@
   },
   "Sugar Grove, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -61657,7 +58969,6 @@
   },
   "Sugar Hill, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61677,7 +58988,6 @@
   },
   "Sullivan, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61697,7 +59007,6 @@
   },
   "Sullivan, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61717,7 +59026,6 @@
   },
   "Summerset, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61737,7 +59045,6 @@
   },
   "Summit, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61757,7 +59064,6 @@
   },
   "Sun Prairie, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61777,7 +59083,6 @@
   },
   "Sundance, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61797,7 +59102,6 @@
   },
   "Sunnyvale, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 20, 2024, 10:37:24 PM UTC",
     "requirements": ["Frequent Transit", "By Right", "Other", "ADU"],
     "citations": [
       {
@@ -61832,7 +59136,6 @@
   },
   "Superior Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 9:42:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61852,7 +59155,6 @@
   },
   "Superior, WI": {
     "reporter": "Jenny Van Sickle",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61879,7 +59181,6 @@
   },
   "Surfside Beach, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61899,7 +59200,6 @@
   },
   "Suring, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61919,7 +59219,6 @@
   },
   "Surprise, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "February 15, 2024, 6:42:46 PM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -61944,7 +59243,6 @@
   },
   "Surrey, BC": {
     "reporter": "Paul Hillsdon",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -61964,7 +59262,6 @@
   },
   "Suwanee, GA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -61984,7 +59281,6 @@
   },
   "Swanville, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62004,7 +59300,6 @@
   },
   "Swarthmore, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 24, 2024, 5:05:15 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62024,7 +59319,6 @@
   },
   "Swartz Creek, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 8:49:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62044,7 +59338,6 @@
   },
   "Swissvale, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 5:59:55 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -62069,7 +59362,6 @@
   },
   "Switzerland County, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -62089,7 +59381,6 @@
   },
   "Sycamore, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62109,7 +59400,6 @@
   },
   "Sykesville, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 11, 2024, 4:40:08 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -62129,7 +59419,6 @@
   },
   "Sylvania, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62149,7 +59438,6 @@
   },
   "Syracuse, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62169,7 +59457,6 @@
   },
   "Syracuse, NY": {
     "reporter": "John Bremquist",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62189,7 +59476,6 @@
   },
   "São Paulo, SP": {
     "reporter": "Jacob Mason",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62222,7 +59508,6 @@
   },
   "Tacoma, WA": {
     "reporter": "Larry Harala",
-    "updated": "January 23, 2024, 3:52:55 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62255,7 +59540,6 @@
   },
   "Tahlequah, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62275,7 +59559,6 @@
   },
   "Tallahassee, FL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 23, 2024, 12:12:03 AM UTC",
     "requirements": ["By Right", "Historic Preservation"],
     "citations": [
       {
@@ -62305,7 +59588,6 @@
   },
   "Tallmadge, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 11, 2024, 4:20:42 PM UTC",
     "requirements": ["Frequent Transit", "Other"],
     "citations": [
       {
@@ -62325,7 +59607,6 @@
   },
   "Tampa, FL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 8:10:00 PM UTC",
     "requirements": ["By Right", "Bike Parking", "Car Share", "In Lieu Fees"],
     "citations": [
       {
@@ -62360,7 +59641,6 @@
   },
   "Tampico, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62380,7 +59660,6 @@
   },
   "Taneytown, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 11, 2024, 3:50:01 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -62400,7 +59679,6 @@
   },
   "Tarentum, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 6:04:02 PM UTC",
     "requirements": ["Historic Preservation"],
     "citations": [
       {
@@ -62420,7 +59698,6 @@
   },
   "Tawas City, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 24, 2024, 5:15:09 PM UTC",
     "requirements": ["Size of Project", "Bike Parking"],
     "citations": [
       {
@@ -62440,7 +59717,6 @@
   },
   "Taylor Mill, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Other", "Bike Parking", "Car Share"],
     "citations": [
       {
@@ -62460,7 +59736,6 @@
   },
   "Taylor, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 6:31:41 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -62485,7 +59760,6 @@
   },
   "Taylor, TX": {
     "reporter": "Tony Jordan",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62510,7 +59784,6 @@
   },
   "Taylor, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62530,7 +59803,6 @@
   },
   "Taylorville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62550,7 +59822,6 @@
   },
   "Tazewell County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -62570,7 +59841,6 @@
   },
   "Tecumseh, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 31, 2024, 7:12:04 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -62595,7 +59865,6 @@
   },
   "Tecumseh, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62615,7 +59884,6 @@
   },
   "Tekamah, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62635,7 +59903,6 @@
   },
   "Tekonsha, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 22, 2024, 3:51:30 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62655,7 +59922,6 @@
   },
   "Tel Aviv, TA": {
     "reporter": "Erel Herzog",
-    "updated": "July 17, 2024, 3:53:05 AM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -62680,7 +59946,6 @@
   },
   "Temecula, CA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Size of Project"],
     "citations": [
       {
@@ -62705,7 +59970,6 @@
   },
   "Tempe, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "February 14, 2024, 6:35:08 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -62735,7 +59999,6 @@
   },
   "Temple, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 8:06:25 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62760,7 +60023,6 @@
   },
   "Templeton, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62780,7 +60042,6 @@
   },
   "Terre Haute, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62800,7 +60061,6 @@
   },
   "Texarkana, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62820,7 +60080,6 @@
   },
   "Texarkana, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "May 8, 2024, 7:44:05 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62840,7 +60099,6 @@
   },
   "The Village, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 16, 2024, 8:25:55 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -62860,7 +60118,6 @@
   },
   "Theresa, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62880,7 +60137,6 @@
   },
   "Thermopolis, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -62900,7 +60156,6 @@
   },
   "Thibodaux, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62920,7 +60175,6 @@
   },
   "Thief River Falls, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -62940,7 +60194,6 @@
   },
   "Thiensville, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -62960,7 +60213,6 @@
   },
   "Thomas Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 3:44:56 AM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -62980,7 +60232,6 @@
   },
   "Thomasboro, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 26, 2024, 8:39:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63000,7 +60251,6 @@
   },
   "Thomasville, GA": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63050,7 +60300,6 @@
   },
   "Thornapple Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 3:48:11 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63070,7 +60319,6 @@
   },
   "Thornton, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 15, 2024, 7:50:24 PM UTC",
     "requirements": ["By Right", "Frequent Transit", "Other"],
     "citations": [
       {
@@ -63095,7 +60343,6 @@
   },
   "Thousand Oaks, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 10:05:50 PM UTC",
     "requirements": [
       "Other",
       "Historic Preservation",
@@ -63121,7 +60368,6 @@
   },
   "Three Oaks, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 23, 2024, 5:42:06 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63146,7 +60392,6 @@
   },
   "Three Rivers, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 31, 2024, 1:25:24 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63166,7 +60411,6 @@
   },
   "Thunder Bay, ON": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -63211,7 +60455,6 @@
   },
   "Tiffin, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 2:15:46 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63231,7 +60474,6 @@
   },
   "Tigard, OR": {
     "reporter": "Schuyler Warren",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63251,7 +60493,6 @@
   },
   "Timmins, ON": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63271,7 +60512,6 @@
   },
   "Timnath, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "July 31, 2024, 11:23:11 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -63296,7 +60536,6 @@
   },
   "Tioga, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63316,7 +60555,6 @@
   },
   "Tionesta, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 25, 2024, 7:25:19 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63336,7 +60574,6 @@
   },
   "Tipp City, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 18, 2024, 1:47:55 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63361,7 +60598,6 @@
   },
   "Tipton, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63381,7 +60617,6 @@
   },
   "Tipton, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -63401,7 +60636,6 @@
   },
   "Tishomingo, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63421,7 +60655,6 @@
   },
   "Titonka, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63441,7 +60674,6 @@
   },
   "Titusville, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 11, 2024, 4:00:13 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -63466,7 +60698,6 @@
   },
   "Tiverton, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 4:12:22 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -63486,7 +60717,6 @@
   },
   "Toledo, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63506,7 +60736,6 @@
   },
   "Toledo, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Size of Project", "Historic Preservation"],
     "citations": [
       {
@@ -63546,7 +60775,6 @@
   },
   "Tolono, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63566,7 +60794,6 @@
   },
   "Tomahawk, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63586,7 +60813,6 @@
   },
   "Tonica, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 12:17:34 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63606,7 +60832,6 @@
   },
   "Topeka, KS": {
     "reporter": "Andy Fry",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63626,7 +60851,6 @@
   },
   "Topton, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 24, 2024, 9:46:14 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -63646,7 +60870,6 @@
   },
   "Toronto, ON": {
     "reporter": "Tony Jordan",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63691,7 +60914,6 @@
   },
   "Torrance, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 20, 2024, 10:12:11 PM UTC",
     "requirements": [
       "ADU",
       "Historic Preservation",
@@ -63717,7 +60939,6 @@
   },
   "Torrington, WY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -63737,7 +60958,6 @@
   },
   "Towanda, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 22, 2024, 4:17:09 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63757,7 +60977,6 @@
   },
   "Town of Cedarburg, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 2, 2024, 2:52:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63777,7 +60996,6 @@
   },
   "Town of Empire, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 8, 2024, 5:31:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63797,7 +61015,6 @@
   },
   "Town of Farmington, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 10, 2024, 9:58:05 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63817,7 +61034,6 @@
   },
   "Town of Lac du Flambeau, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 7, 2024, 4:29:55 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63837,7 +61053,6 @@
   },
   "Town of Ledgeview, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 2, 2024, 3:13:15 PM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -63867,7 +61082,6 @@
   },
   "Town of Lowell, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 3, 2024, 3:15:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63887,7 +61101,6 @@
   },
   "Town of Mitchell, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 8, 2024, 6:00:30 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63907,7 +61120,6 @@
   },
   "Town of Mosinee, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 7, 2024, 5:53:09 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63927,7 +61139,6 @@
   },
   "Town of Peshtigo, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 7, 2024, 4:57:16 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63947,7 +61158,6 @@
   },
   "Town of Richmond, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 7, 2024, 6:04:27 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63967,7 +61177,6 @@
   },
   "Town of Scott, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 8, 2024, 6:09:12 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -63987,7 +61196,6 @@
   },
   "Town of St. Joseph, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 10, 2024, 9:09:01 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64007,7 +61215,6 @@
   },
   "Town of Taycheedah, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 8, 2024, 5:45:57 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64027,7 +61234,6 @@
   },
   "Town of Vinland, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 2, 2024, 4:10:32 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64047,7 +61253,6 @@
   },
   "Town of Weston, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 7, 2024, 5:14:30 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64067,7 +61272,6 @@
   },
   "Travelers Rest, SC": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64087,7 +61291,6 @@
   },
   "Traverse City, MI": {
     "reporter": "Russell Soyring",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64120,7 +61323,6 @@
   },
   "Trelleborg, Scania": {
     "reporter": "Johan Kerttu",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -64145,7 +61347,6 @@
   },
   "Trempealeau, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64165,7 +61366,6 @@
   },
   "Trenton, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 22, 2024, 7:15:41 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -64185,7 +61385,6 @@
   },
   "Trenton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64205,7 +61404,6 @@
   },
   "Trinidad, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64230,7 +61428,6 @@
   },
   "Troy, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 4:23:08 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64250,7 +61447,6 @@
   },
   "Troy, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 18, 2024, 1:52:59 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64270,7 +61466,6 @@
   },
   "Trumann, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64290,7 +61485,6 @@
   },
   "Tualatin, OR": {
     "reporter": "Evan Manvel",
-    "updated": "June 11, 2024, 3:18:59 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64315,7 +61509,6 @@
   },
   "Tucson, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 8:46:34 PM UTC",
     "requirements": [
       "Other",
       "In Lieu Fees",
@@ -64373,7 +61566,6 @@
   },
   "Tulsa, OK": {
     "reporter": "Stephen Lassiter",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": [
       "By Right",
       "Bike Parking",
@@ -64412,7 +61604,6 @@
   },
   "Tupelo, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 10:22:04 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64432,7 +61623,6 @@
   },
   "Turtle Lake, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64452,7 +61642,6 @@
   },
   "Tuscaloosa, AL": {
     "reporter": "Kendall Mullenhour",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64485,7 +61674,6 @@
   },
   "Tuscola, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 12:51:59 AM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -64515,7 +61703,6 @@
   },
   "Tuttle, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 16, 2024, 5:40:16 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64535,7 +61722,6 @@
   },
   "Twin Falls, ID": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -64555,7 +61741,6 @@
   },
   "Twin Lakes, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64575,7 +61760,6 @@
   },
   "Two Harbors, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64595,7 +61779,6 @@
   },
   "Two Rivers, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64615,7 +61798,6 @@
   },
   "Tyrone, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 22, 2024, 4:09:38 PM UTC",
     "requirements": ["Size of Project", "By Right"],
     "citations": [
       {
@@ -64635,7 +61817,6 @@
   },
   "Udall, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64655,7 +61836,6 @@
   },
   "Uhrichsville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 12, 2024, 3:01:25 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64675,7 +61855,6 @@
   },
   "Ulysses, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64695,7 +61874,6 @@
   },
   "Underwood, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64715,7 +61893,6 @@
   },
   "Union Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 5, 2024, 11:40:43 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64735,7 +61912,6 @@
   },
   "Union City, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64755,7 +61931,6 @@
   },
   "Union City, TN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64775,7 +61950,6 @@
   },
   "Union, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64795,7 +61969,6 @@
   },
   "University City, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Frequent Transit"],
     "citations": [
       {
@@ -64815,7 +61988,6 @@
   },
   "University Park, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -64835,7 +62007,6 @@
   },
   "Upper Arlington, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 6:07:57 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64855,7 +62026,6 @@
   },
   "Upsala, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64875,7 +62045,6 @@
   },
   "Urbana, IL": {
     "reporter": "Kevin Garcia",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64895,7 +62064,6 @@
   },
   "Utica, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64915,7 +62083,6 @@
   },
   "Utica, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 2:08:44 AM UTC",
     "requirements": ["By Right", "In Lieu Fees", "Size of Project"],
     "citations": [
       {
@@ -64950,7 +62117,6 @@
   },
   "Uvalde, TX": {
     "reporter": "Susan Anderson",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -64970,7 +62136,6 @@
   },
   "Vail, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 4, 2024, 2:07:57 AM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -65000,7 +62165,6 @@
   },
   "Vallejo, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 22, 2024, 10:40:34 PM UTC",
     "requirements": [
       "By Right",
       "Size of Project",
@@ -65043,7 +62207,6 @@
   },
   "Valley Center, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65063,7 +62226,6 @@
   },
   "Valley Springs, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65083,7 +62245,6 @@
   },
   "Valley, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65103,7 +62264,6 @@
   },
   "Valparaiso, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -65128,7 +62288,6 @@
   },
   "Van Buren Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 3:40:51 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65148,7 +62307,6 @@
   },
   "Van Buren, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65168,7 +62326,6 @@
   },
   "Van Meter, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65188,7 +62345,6 @@
   },
   "Van Wert , OH": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65208,7 +62364,6 @@
   },
   "Vancouver, BC": {
     "reporter": "Duaa Alzouman",
-    "updated": "July 1, 2024, 3:10:12 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65267,7 +62422,6 @@
   },
   "Vancouver, WA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 12, 2024, 8:33:37 PM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -65312,7 +62466,6 @@
   },
   "Vandalia, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65332,7 +62485,6 @@
   },
   "Vassar, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 11, 2024, 6:29:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65352,7 +62504,6 @@
   },
   "Veedersburg, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -65372,7 +62523,6 @@
   },
   "Velva, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65392,7 +62542,6 @@
   },
   "Ventura, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65412,7 +62561,6 @@
   },
   "Verdigris, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 15, 2024, 3:34:08 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65432,7 +62580,6 @@
   },
   "Vermillion, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65452,7 +62599,6 @@
   },
   "Vernon Center, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65472,7 +62618,6 @@
   },
   "Verona, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 6:13:08 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -65492,7 +62637,6 @@
   },
   "Verona, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65517,7 +62661,6 @@
   },
   "Versailles, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65537,7 +62680,6 @@
   },
   "Vicksburg, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -65557,7 +62699,6 @@
   },
   "Victoria, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65577,7 +62718,6 @@
   },
   "Victoria, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65597,7 +62737,6 @@
   },
   "Vidalia, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 5, 2024, 8:15:10 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -65617,7 +62756,6 @@
   },
   "Vilas County, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 11:28:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65637,7 +62775,6 @@
   },
   "Villa Hills, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -65657,7 +62794,6 @@
   },
   "Villa Park, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["Bike Parking", "Other"],
     "citations": [
       {
@@ -65682,7 +62818,6 @@
   },
   "Village of Four Seasons, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65702,7 +62837,6 @@
   },
   "Vinita, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 5:08:00 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65722,7 +62856,6 @@
   },
   "Vinton, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65742,7 +62875,6 @@
   },
   "Vinton, VA": {
     "reporter": "Rachel Ruhlen",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65762,7 +62894,6 @@
   },
   "Virginia Beach, VA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65782,7 +62913,6 @@
   },
   "Visalia, CA": {
     "reporter": "Samuel Deetz",
-    "updated": "February 20, 2024, 10:22:29 PM UTC",
     "requirements": [
       "In Lieu Fees",
       "Frequent Transit",
@@ -65814,7 +62944,6 @@
   },
   "Vivian, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65834,7 +62963,6 @@
   },
   "Volga, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65854,7 +62982,6 @@
   },
   "Volo, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -65874,7 +63001,6 @@
   },
   "Wabash, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65894,7 +63020,6 @@
   },
   "Wabasha, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65914,7 +63039,6 @@
   },
   "Waco, TX": {
     "reporter": "Samuel Deetz",
-    "updated": "February 15, 2024, 6:32:52 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65934,7 +63058,6 @@
   },
   "Waconia, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65954,7 +63077,6 @@
   },
   "Wadena, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65974,7 +63096,6 @@
   },
   "Wadsworth, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 2:42:46 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -65994,7 +63115,6 @@
   },
   "Wagoner, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "May 16, 2024, 5:05:43 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66019,7 +63139,6 @@
   },
   "Wahoo, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -66039,7 +63158,6 @@
   },
   "Wahpeton, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66059,7 +63177,6 @@
   },
   "Walker, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 8:00:58 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -66079,7 +63196,6 @@
   },
   "Walkersville, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 9:26:40 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -66099,7 +63215,6 @@
   },
   "Walla Walla, WA": {
     "reporter": "John Gahbauer",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66119,7 +63234,6 @@
   },
   "Walnut Creek, CA": {
     "reporter": "Michael Moore",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66139,7 +63253,6 @@
   },
   "Walnut, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "April 3, 2024, 12:33:56 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66159,7 +63272,6 @@
   },
   "Walterboro, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66179,7 +63291,6 @@
   },
   "Wanamingo, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -66199,7 +63310,6 @@
   },
   "Wanatah, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -66219,7 +63329,6 @@
   },
   "Wapakoneta, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 18, 2024, 2:55:03 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66244,7 +63353,6 @@
   },
   "Wapella, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66264,7 +63372,6 @@
   },
   "Wapello, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66284,7 +63391,6 @@
   },
   "Warren, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "February 15, 2024, 7:37:13 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66304,7 +63410,6 @@
   },
   "Warren, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66324,7 +63429,6 @@
   },
   "Warren, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 5:30:17 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -66344,7 +63448,6 @@
   },
   "Warrensburg, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66364,7 +63467,6 @@
   },
   "Warrensburg, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66384,7 +63486,6 @@
   },
   "Warrensville Heights, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66404,7 +63505,6 @@
   },
   "Warsaw, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66424,7 +63524,6 @@
   },
   "Warsaw, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -66444,7 +63543,6 @@
   },
   "Warwick, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 5:47:09 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -66464,7 +63562,6 @@
   },
   "Waseca, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66484,7 +63581,6 @@
   },
   "Washburn, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66504,7 +63600,6 @@
   },
   "Washington Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 9:07:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66534,7 +63629,6 @@
   },
   "Washington County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 2:18:55 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66554,7 +63648,6 @@
   },
   "Washington Court House, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 4:48:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66579,7 +63672,6 @@
   },
   "Washington, DC": {
     "reporter": "Ryan Westrom",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66612,7 +63704,6 @@
   },
   "Washington, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66632,7 +63723,6 @@
   },
   "Washington, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 11:26:57 PM UTC",
     "requirements": ["Size of Project"],
     "citations": [
       {
@@ -66652,7 +63742,6 @@
   },
   "Washington, UT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -66672,7 +63761,6 @@
   },
   "Washington, WA": {
     "reporter": "",
-    "updated": "August 24, 2024, 4:42:32 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -66705,7 +63793,6 @@
   },
   "Waterford, County Waterford": {
     "reporter": "Samuel Deetz",
-    "updated": "July 9, 2024, 7:44:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66730,7 +63817,6 @@
   },
   "Waterloo, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66750,7 +63836,6 @@
   },
   "Waterloo, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66770,7 +63855,6 @@
   },
   "Waterman, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 4:09:40 AM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -66795,7 +63879,6 @@
   },
   "Watertown, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "January 3, 2024, 1:59:09 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66815,7 +63898,6 @@
   },
   "Watertown, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -66835,7 +63917,6 @@
   },
   "Watertown, WI": {
     "reporter": "Jacob Mass",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66855,7 +63936,6 @@
   },
   "Waterville, ME": {
     "reporter": "Jacob Lavarnway",
-    "updated": "July 23, 2024, 3:27:38 AM UTC",
     "requirements": ["ADU"],
     "citations": [
       {
@@ -66888,7 +63968,6 @@
   },
   "Waterville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66908,7 +63987,6 @@
   },
   "Watseka, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66928,7 +64006,6 @@
   },
   "Waukee, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66948,7 +64025,6 @@
   },
   "Waukegan, IL": {
     "reporter": "Jake Seid",
-    "updated": "July 25, 2024, 7:35:19 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -66973,7 +64049,6 @@
   },
   "Waukesha, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -66993,7 +64068,6 @@
   },
   "Waukon, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67013,7 +64087,6 @@
   },
   "Waupaca, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67033,7 +64106,6 @@
   },
   "Wausau, WI": {
     "reporter": "Jake Schreiner",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67053,7 +64125,6 @@
   },
   "Waverly, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 27, 2024, 6:15:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67073,7 +64144,6 @@
   },
   "Waverly, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67093,7 +64163,6 @@
   },
   "Waverly, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 5:59:15 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -67123,7 +64192,6 @@
   },
   "Waxhaw, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -67143,7 +64211,6 @@
   },
   "Wayland, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67163,7 +64230,6 @@
   },
   "Wayne, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 7:10:59 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -67188,7 +64254,6 @@
   },
   "Wayne, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67208,7 +64273,6 @@
   },
   "Waynesburg, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67228,7 +64292,6 @@
   },
   "Waynesville, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67248,7 +64311,6 @@
   },
   "Waynesville, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -67273,7 +64335,6 @@
   },
   "Weatherford, OK": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67293,7 +64354,6 @@
   },
   "Weatherford, TX": {
     "reporter": "Tim Lehrbach",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67313,7 +64373,6 @@
   },
   "Webberville, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 8:29:15 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67333,7 +64392,6 @@
   },
   "Webster City, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67353,7 +64411,6 @@
   },
   "Webster Groves, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67373,7 +64430,6 @@
   },
   "Welcome, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "August 1, 2024, 7:44:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67393,7 +64449,6 @@
   },
   "Wellington, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "February 21, 2024, 10:30:44 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -67418,7 +64473,6 @@
   },
   "Wellington, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67438,7 +64492,6 @@
   },
   "Wellington, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67458,7 +64511,6 @@
   },
   "Wells, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67478,7 +64530,6 @@
   },
   "Wellston, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 6:41:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67498,7 +64549,6 @@
   },
   "Welsh, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 5, 2024, 1:04:38 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67518,7 +64568,6 @@
   },
   "West Allis, WI": {
     "reporter": "Zac Roder",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67538,7 +64587,6 @@
   },
   "West Baton Rouge Parish, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 6:55:46 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -67558,7 +64606,6 @@
   },
   "West Bend, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67578,7 +64625,6 @@
   },
   "West Bend, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67598,7 +64644,6 @@
   },
   "West Branch, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "January 24, 2024, 4:59:51 PM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -67633,7 +64678,6 @@
   },
   "West Burlington, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67653,7 +64697,6 @@
   },
   "West Carrollton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67673,7 +64716,6 @@
   },
   "West Chester, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 30, 2024, 8:48:03 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -67703,7 +64745,6 @@
   },
   "West Chicago, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67723,7 +64764,6 @@
   },
   "West Des Moines, IA": {
     "reporter": "Orion Nauman",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67743,7 +64783,6 @@
   },
   "West Fargo, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67768,7 +64807,6 @@
   },
   "West Frankfort, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 19, 2024, 2:39:59 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67788,7 +64826,6 @@
   },
   "West Grove, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 30, 2024, 8:56:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67808,7 +64845,6 @@
   },
   "West Homestead, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 23, 2024, 9:58:59 PM UTC",
     "requirements": ["Frequent Transit"],
     "citations": [
       {
@@ -67828,7 +64864,6 @@
   },
   "West Lafayette, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67848,7 +64883,6 @@
   },
   "West Liberty, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67868,7 +64902,6 @@
   },
   "West Liberty, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 5:30:23 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -67888,7 +64921,6 @@
   },
   "West Memphis, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -67918,7 +64950,6 @@
   },
   "West Milton, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 18, 2024, 2:05:48 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67938,7 +64969,6 @@
   },
   "West Palm Beach, FL": {
     "reporter": "Jesse Bailey",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67978,7 +65008,6 @@
   },
   "West Plains, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -67998,7 +65027,6 @@
   },
   "West Reading, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 18, 2024, 7:04:03 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -68023,7 +65051,6 @@
   },
   "West Saint Paul, MN": {
     "reporter": "Morgan Kavanaugh",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68048,7 +65075,6 @@
   },
   "West Salem, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68068,7 +65094,6 @@
   },
   "West Union, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68088,7 +65113,6 @@
   },
   "West Unity, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68108,7 +65132,6 @@
   },
   "West Yellowstone, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -68128,7 +65151,6 @@
   },
   "Westchester, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 9:03:05 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -68148,7 +65170,6 @@
   },
   "Westerly, RI": {
     "reporter": "Samuel Deetz",
-    "updated": "July 17, 2024, 8:36:24 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68168,7 +65189,6 @@
   },
   "Western Springs, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68188,7 +65208,6 @@
   },
   "Westland, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 7:26:07 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -68208,7 +65227,6 @@
   },
   "Westminster, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 11, 2024, 3:46:40 PM UTC",
     "requirements": ["In Lieu Fees", "By Right"],
     "citations": [
       {
@@ -68228,7 +65246,6 @@
   },
   "Westminster, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68248,7 +65265,6 @@
   },
   "Westmont, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -68278,7 +65294,6 @@
   },
   "Weston, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68298,7 +65313,6 @@
   },
   "Weston, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68318,7 +65332,6 @@
   },
   "Weston, WV": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68338,7 +65351,6 @@
   },
   "Westover, WV": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68358,7 +65370,6 @@
   },
   "Westwood, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -68378,7 +65389,6 @@
   },
   "Wheat Ridge, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "May 7, 2024, 4:27:32 PM UTC",
     "requirements": [
       "Affordable Housing",
       "Other",
@@ -68418,7 +65428,6 @@
   },
   "Wheaton, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68438,7 +65447,6 @@
   },
   "Wheeling, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68458,7 +65466,6 @@
   },
   "White Bear Lake, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68478,7 +65485,6 @@
   },
   "White Cloud, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 6, 2024, 6:03:29 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68498,7 +65504,6 @@
   },
   "Whitefish, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68518,7 +65523,6 @@
   },
   "Whitehall, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 6:12:08 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68538,7 +65542,6 @@
   },
   "Whitehorse, YT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right", "In Lieu Fees"],
     "citations": [
       {
@@ -68563,7 +65566,6 @@
   },
   "Whitewater, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68583,7 +65585,6 @@
   },
   "Whiting, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68603,7 +65604,6 @@
   },
   "Wichita, KS": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68623,7 +65623,6 @@
   },
   "Wickenburg, AZ": {
     "reporter": "Steve Boyle",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68663,7 +65662,6 @@
   },
   "Wilder, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68683,7 +65681,6 @@
   },
   "Wilkes-Barre, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68703,7 +65700,6 @@
   },
   "Wilkinsburg, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 6:40:03 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -68723,7 +65719,6 @@
   },
   "Williams Bay, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68748,7 +65743,6 @@
   },
   "Williamsburg, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68768,7 +65762,6 @@
   },
   "Williamsport, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68788,7 +65781,6 @@
   },
   "Williamston, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 18, 2024, 8:20:15 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -68813,7 +65805,6 @@
   },
   "Williamston, SC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68833,7 +65824,6 @@
   },
   "Williamstown Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 2, 2024, 5:10:23 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68853,7 +65843,6 @@
   },
   "Williston, ND": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68873,7 +65862,6 @@
   },
   "Willmar, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 22, 2024, 1:18:34 AM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -68924,7 +65912,6 @@
   },
   "Willowbrook, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68944,7 +65931,6 @@
   },
   "Wilmerding, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "June 24, 2024, 6:43:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -68964,7 +65950,6 @@
   },
   "Wilmette, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Size of Project", "In Lieu Fees", "Other"],
     "citations": [
       {
@@ -68994,7 +65979,6 @@
   },
   "Wilmington, DE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69014,7 +65998,6 @@
   },
   "Wilmington, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69034,7 +66017,6 @@
   },
   "Wilmington, NC": {
     "reporter": "David Curtis",
-    "updated": "November 28, 2023, 7:47:48 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69067,7 +66049,6 @@
   },
   "Wilmington, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "May 28, 2024, 4:42:28 PM UTC",
     "requirements": ["Other", "In Lieu Fees"],
     "citations": [
       {
@@ -69097,7 +66078,6 @@
   },
   "Wilson, NC": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Bike Parking", "Tree Preservation", "By Right"],
     "citations": [
       {
@@ -69122,7 +66102,6 @@
   },
   "Winchester, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69142,7 +66121,6 @@
   },
   "Windom, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69162,7 +66140,6 @@
   },
   "Windsor Heights, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69182,7 +66159,6 @@
   },
   "Windsor, MO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69202,7 +66178,6 @@
   },
   "Winfield, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69222,7 +66197,6 @@
   },
   "Winfield, KS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69242,7 +66216,6 @@
   },
   "Winfield, WV": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69262,7 +66235,6 @@
   },
   "Wingate, NC": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69282,7 +66254,6 @@
   },
   "Winnebago County, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "August 7, 2024, 12:23:21 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69302,7 +66273,6 @@
   },
   "Winneconne, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69322,7 +66292,6 @@
   },
   "Winnetka, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -69342,7 +66311,6 @@
   },
   "Winnipeg, MB": {
     "reporter": "Andrew Ross",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69372,7 +66340,6 @@
   },
   "Winnsboro, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 5, 2024, 9:06:27 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69392,7 +66359,6 @@
   },
   "Winona, MN": {
     "reporter": "Luke Sims",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69417,7 +66383,6 @@
   },
   "Winston-Salem, NC": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69447,7 +66412,6 @@
   },
   "Winter Haven, FL": {
     "reporter": "Sean Martin",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69467,7 +66431,6 @@
   },
   "Winter Park, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "April 15, 2024, 5:20:55 AM UTC",
     "requirements": ["In Lieu Fees"],
     "citations": [
       {
@@ -69487,7 +66450,6 @@
   },
   "Winterset, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69507,7 +66469,6 @@
   },
   "Winthrop Harbor, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69527,7 +66488,6 @@
   },
   "Winthrop, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69547,7 +66507,6 @@
   },
   "Wisconsin Dells, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:37 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69572,7 +66531,6 @@
   },
   "Wisconsin Rapids, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Bike Parking"],
     "citations": [
       {
@@ -69592,7 +66550,6 @@
   },
   "Wittenberg, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:47 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69612,7 +66569,6 @@
   },
   "Wixom, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 20, 2024, 4:37:18 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69632,7 +66588,6 @@
   },
   "Wolf Point, MT": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -69652,7 +66607,6 @@
   },
   "Wonder Lake, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 15, 2024, 2:41:14 AM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -69677,7 +66631,6 @@
   },
   "Wood Dale, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:44 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -69697,7 +66650,6 @@
   },
   "Wood River, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "August 22, 2024, 7:20:15 PM UTC",
     "requirements": ["Other", "By Right"],
     "citations": [
       {
@@ -69717,7 +66669,6 @@
   },
   "Woodburn, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right", "Frequent Transit", "Bike Parking", "Other"],
     "citations": [
       {
@@ -69742,7 +66693,6 @@
   },
   "Woodbury, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "January 20, 2024, 9:00:01 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69762,7 +66712,6 @@
   },
   "Woodford County, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -69782,7 +66731,6 @@
   },
   "Woodford County, KY": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:51 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69802,7 +66750,6 @@
   },
   "Woodlawn, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69822,7 +66769,6 @@
   },
   "Woodsboro, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "May 9, 2024, 9:30:15 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -69842,7 +66788,6 @@
   },
   "Woodstock, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 6, 2024, 5:44:01 PM UTC",
     "requirements": ["Other"],
     "citations": [
       {
@@ -69862,7 +66807,6 @@
   },
   "Woodville, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69882,7 +66826,6 @@
   },
   "Woodward, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69902,7 +66845,6 @@
   },
   "Woonsocket, RI": {
     "reporter": "Keith Brynes",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69922,7 +66864,6 @@
   },
   "Wooster, OH": {
     "reporter": "Thomas Stikeleather",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -69942,7 +66883,6 @@
   },
   "Worcester County, MD": {
     "reporter": "Samuel Deetz",
-    "updated": "August 6, 2024, 4:37:20 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69962,7 +66902,6 @@
   },
   "Worcester, MA": {
     "reporter": "Stephen Rolle",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -69987,7 +66926,6 @@
   },
   "Wormleysburg, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "August 19, 2024, 2:17:20 AM UTC",
     "requirements": ["Other", "Bike Parking"],
     "citations": [
       {
@@ -70012,7 +66950,6 @@
   },
   "Worth, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right", "Size of Project"],
     "citations": [
       {
@@ -70032,7 +66969,6 @@
   },
   "Worthington, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:45 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70052,7 +66988,6 @@
   },
   "Worthington, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 4, 2024, 6:18:13 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70077,7 +67012,6 @@
   },
   "Wrangell, AK": {
     "reporter": "Samuel Deetz",
-    "updated": "February 15, 2024, 6:15:59 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70097,7 +67031,6 @@
   },
   "Wray, CO": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70117,7 +67050,6 @@
   },
   "Wrightstown, WI": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:46 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70137,7 +67069,6 @@
   },
   "Wyandotte, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 7:35:55 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70157,7 +67088,6 @@
   },
   "Wyoming, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 8:13:57 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70177,7 +67107,6 @@
   },
   "Wyomissing, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 18, 2024, 7:19:16 PM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -70197,7 +67126,6 @@
   },
   "Xenia, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 5, 2024, 5:08:31 AM UTC",
     "requirements": ["By Right", "Other"],
     "citations": [
       {
@@ -70217,7 +67145,6 @@
   },
   "Yakima, WA": {
     "reporter": "Joshua Hicks",
-    "updated": "November 28, 2023, 7:47:34 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70237,7 +67164,6 @@
   },
   "Yale, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 12, 2024, 6:59:21 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70257,7 +67183,6 @@
   },
   "Yankton, SD": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70277,7 +67202,6 @@
   },
   "Yazoo City, MS": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:39 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70297,7 +67221,6 @@
   },
   "Yellow Springs, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 5, 2024, 5:33:05 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70317,7 +67240,6 @@
   },
   "Yellowknife, NT": {
     "reporter": "Dustin",
-    "updated": "November 28, 2023, 7:47:36 PM UTC",
     "requirements": [""],
     "citations": [
       {
@@ -70337,7 +67259,6 @@
   },
   "Yellville, AR": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:50 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70357,7 +67278,6 @@
   },
   "Yonkers, NY": {
     "reporter": "Samuel Deetz",
-    "updated": "January 5, 2024, 5:57:23 AM UTC",
     "requirements": [
       "Historic Preservation",
       "Size of Project",
@@ -70413,7 +67333,6 @@
   },
   "York, England": {
     "reporter": "Samuel Deetz",
-    "updated": "August 25, 2024, 6:34:21 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70433,7 +67352,6 @@
   },
   "York, PA": {
     "reporter": "Skyler Yost",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70453,7 +67371,6 @@
   },
   "Yorkton, SK": {
     "reporter": "Barbara Dupuis",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["Size of Project", "In Lieu Fees"],
     "citations": [
       {
@@ -70473,7 +67390,6 @@
   },
   "Yorkville, IL": {
     "reporter": "Samuel Deetz",
-    "updated": "January 4, 2024, 9:34:08 PM UTC",
     "requirements": ["By Right", "Car Share", "Other"],
     "citations": [
       {
@@ -70498,7 +67414,6 @@
   },
   "Youngstown, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "January 2, 2024, 11:33:47 PM UTC",
     "requirements": ["By Right", "Size of Project", "Other"],
     "citations": [
       {
@@ -70528,7 +67443,6 @@
   },
   "Ypsilanti Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 9:51:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70548,7 +67462,6 @@
   },
   "Ypsilanti, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 21, 2024, 6:53:38 PM UTC",
     "requirements": [
       "By Right",
       "Frequent Transit",
@@ -70586,7 +67499,6 @@
   },
   "Yukon, OK": {
     "reporter": "",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70606,7 +67518,6 @@
   },
   "Yuma, AZ": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:38 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70626,7 +67537,6 @@
   },
   "Yutan, NE": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70646,7 +67556,6 @@
   },
   "Zachary, LA": {
     "reporter": "Samuel Deetz",
-    "updated": "March 4, 2024, 10:50:15 PM UTC",
     "requirements": ["Other", "TDM"],
     "citations": [
       {
@@ -70666,7 +67575,6 @@
   },
   "Zanesville, OH": {
     "reporter": "Matthew Schley",
-    "updated": "November 28, 2023, 7:47:35 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70686,7 +67594,6 @@
   },
   "Zearing, IA": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:42 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70706,7 +67613,6 @@
   },
   "Zeeland Charter Township, MI": {
     "reporter": "Samuel Deetz",
-    "updated": "March 14, 2024, 10:16:41 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70726,7 +67632,6 @@
   },
   "Zelienople, PA": {
     "reporter": "Samuel Deetz",
-    "updated": "July 24, 2024, 11:03:23 PM UTC",
     "requirements": ["Other", "By Right", "Size of Project", "In Lieu Fees"],
     "citations": [
       {
@@ -70756,7 +67661,6 @@
   },
   "Zionsville, IN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:49 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70776,7 +67680,6 @@
   },
   "Zoar, OH": {
     "reporter": "Samuel Deetz",
-    "updated": "June 12, 2024, 3:40:40 AM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70796,7 +67699,6 @@
   },
   "Zumbro Falls, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {
@@ -70816,7 +67718,6 @@
   },
   "Zumbrota, MN": {
     "reporter": "Samuel Deetz",
-    "updated": "November 28, 2023, 7:47:40 PM UTC",
     "requirements": ["By Right"],
     "citations": [
       {

--- a/scripts/city_detail_last_updated.txt
+++ b/scripts/city_detail_last_updated.txt
@@ -1,1 +1,1 @@
-September 1, 2024, 3:07:27 AM UTC
+September 1, 2024, 3:37:26 AM UTC

--- a/scripts/lib/data.ts
+++ b/scripts/lib/data.ts
@@ -18,7 +18,6 @@ export type Citation = {
 
 export type ExtendedEntry = {
   reporter: string | null;
-  updated: string;
   requirements: string[];
   citations: Citation[];
 };

--- a/scripts/lib/data.ts
+++ b/scripts/lib/data.ts
@@ -1,29 +1,26 @@
 import fs from "fs/promises";
 
-import { DateTime } from "luxon";
-
 import { RawEntry, PlaceId } from "../../src/js/types";
 
 export type Attachment = {
-  url: string;
   fileName: string;
   isDoc: boolean;
   outputPath: string;
 };
 
 export type Citation = {
-  idx: number;
   description: string;
   type: string;
   url: string;
   notes: string;
-  lastUpdated: DateTime<true>;
   attachments: Attachment[];
 };
 
 export type ExtendedEntry = {
   reporter: string | null;
   updated: string;
+  requirements: string[];
+  citations: Citation[];
 };
 
 export type CompleteEntry = RawEntry & ExtendedEntry;

--- a/scripts/updateCityDetail.ts
+++ b/scripts/updateCityDetail.ts
@@ -17,6 +17,7 @@ import {
 
 type Attachment = AttachmentBase & { url: string };
 export type Citation = CitationBase & {
+  idx: number;
   lastUpdated: DateTime<true>;
   attachments: Attachment[];
 };
@@ -29,8 +30,6 @@ type PlaceEntry = {
   scope: string;
   requirements: string;
   reporter: string;
-  reportLastUpdated: DateTime<true>;
-  cityLastUpdated: DateTime<true>;
   citations: Citation[];
 };
 
@@ -117,6 +116,7 @@ async function loadData(): Promise<Record<string, PlaceEntry>> {
       : 1;
 
     const citation = {
+      idx: citationIdx,
       description: row["Source Description"],
       type: row.Type,
       url: row.URL,
@@ -138,8 +138,6 @@ async function loadData(): Promise<Record<string, PlaceEntry>> {
       scope: row.Magnitude,
       requirements: row.Requirements,
       reporter: row.Reporter,
-      reportLastUpdated: parseDatetime(row["Report Last updated"]),
-      cityLastUpdated: parseDatetime(row["City Last Updated"]),
       citations: [citation],
     };
   });
@@ -223,14 +221,6 @@ async function saveExtendedDataFile(
   const prunedData = Object.fromEntries(
     Object.entries(data)
       .map(([placeId, entry]) => {
-        const lastUpdated = DateTime.max(
-          ...entry.citations.map((x) => x.lastUpdated),
-          entry.cityLastUpdated,
-          entry.reportLastUpdated,
-        )
-          .setZone("UTC")
-          .toFormat(TIME_FORMAT);
-
         const citations = entry.citations.map((citation) => ({
           description: citation.description,
           type: citation.type,
@@ -246,7 +236,6 @@ async function saveExtendedDataFile(
           placeId,
           {
             reporter: entry.reporter,
-            updated: lastUpdated,
             requirements: entry.requirements.split(", "),
             citations,
           },

--- a/scripts/updateCityDetail.ts
+++ b/scripts/updateCityDetail.ts
@@ -10,7 +10,16 @@ import Papa from "papaparse";
 import Handlebars from "handlebars";
 import { DateTime } from "luxon";
 
-import { Attachment, Citation } from "./lib/data";
+import {
+  Attachment as AttachmentBase,
+  Citation as CitationBase,
+} from "./lib/data";
+
+type Attachment = AttachmentBase & { url: string };
+export type Citation = CitationBase & {
+  lastUpdated: DateTime<true>;
+  attachments: Attachment[];
+};
 
 type PlaceEntry = {
   summary: string;
@@ -108,7 +117,6 @@ async function loadData(): Promise<Record<string, PlaceEntry>> {
       : 1;
 
     const citation = {
-      idx: citationIdx,
       description: row["Source Description"],
       type: row.Type,
       url: row.URL,

--- a/tests/scripts/updateCityDetail.test.ts
+++ b/tests/scripts/updateCityDetail.test.ts
@@ -6,8 +6,9 @@ import {
   citationsUpdated,
   normalizeAttachments,
   parseDatetime,
+  Citation,
 } from "../../scripts/updateCityDetail";
-import { readCoreData, Citation } from "../../scripts/lib/data";
+import { readCoreData } from "../../scripts/lib/data";
 
 test.describe("citationsUpdated()", () => {
   test("returns false if every citation is older than globalLastUpdated", () => {


### PR DESCRIPTION
We don't actually use `updated` in the CSV or HTML pages, so there is no need to save it in `extended.json`. We can add it back if the volunteer team wants it, but for now I want to simplify things as much as possible.

This also fixes the type hints for `ExtendedEntry`.
