### PR TITLE
Include country in counter

### DIFF
--- a/src/js/counters.ts
+++ b/src/js/counters.ts
@@ -11,7 +11,16 @@ function determineHtml(state: FilterState, numPlaces: number): string {
     ? "with all parking minimums removed"
     : "with parking reforms";
   const placesWord = numPlaces === 1 ? "place" : "places";
-  return `Showing ${numPlaces} ${placesWord} ${suffix}`;
+
+  let country =
+    state.country.length === 1
+      ? state.country[0]
+      : `${state.country.length} countries`;
+  if (country === "United States" || country === "United Kingdom") {
+    country = `the ${country}`;
+  }
+
+  return `Showing ${numPlaces} ${placesWord} in ${country} ${suffix}`;
 }
 
 function setUpResetButton(


### PR DESCRIPTION
We've had a few instances of people being confused that the counter, by default, shows multiple countries. Tony requested that we say which country or countries are chosen.