### PR TITLE
Fix modeling of empty requirements

### DIFF
--- a/data/extended.json
+++ b/data/extended.json
@@ -3954,7 +3954,7 @@
   },
   "Bath Charter Township, MI": {
     "reporter": "Nick Tafelsky",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Report from City Planner",
@@ -7241,7 +7241,7 @@
   },
   "Brevard, NC": {
     "reporter": "Aaron Bland",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Municipal code off-street parking requirements section (10.3)",
@@ -8699,7 +8699,7 @@
   },
   "Calumet, MI": {
     "reporter": "Nani Wolf",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Municipal Code",
@@ -11159,7 +11159,7 @@
   },
   "Charlotte, NC": {
     "reporter": "Alan Goodwin",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Charlotte Zoning Code: CHAPTER 15. TRANSIT ORIENTED DEVELOPMENT DISTRICTS ",
@@ -16147,7 +16147,7 @@
   },
   "Dearborn, MI": {
     "reporter": null,
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Municipal code",
@@ -17377,7 +17377,7 @@
   },
   "Dover, NH": {
     "reporter": "Christopher Parker",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Site Plan Regulations Section D",
@@ -18758,7 +18758,7 @@
   },
   "Ecorse, MI": {
     "reporter": "Nani Wolf",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Ecorse City Zoning Code",
@@ -21555,7 +21555,7 @@
   },
   "Flemington, NJ": {
     "reporter": "Brian Budney",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "News article",
@@ -21634,7 +21634,7 @@
   },
   "Flint, MI": {
     "reporter": "Joel Arnold",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Municipal Code",
@@ -22985,7 +22985,7 @@
   },
   "Freeport, IL": {
     "reporter": "Samuel Deetz",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Municipal Code",
@@ -23498,7 +23498,7 @@
   },
   "Galena, IL": {
     "reporter": "Jake Schreiner",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "City Code",
@@ -27035,7 +27035,7 @@
   },
   "Hamtramck, MI": {
     "reporter": "Nani Wolf",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Municipal code",
@@ -28850,7 +28850,7 @@
   },
   "Hollandale, WI": {
     "reporter": "Samuel Deetz",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "City Zoning Code",
@@ -29235,7 +29235,7 @@
   },
   "Howell, MI": {
     "reporter": "Nani Wolf",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Municipal Code",
@@ -29627,7 +29627,7 @@
   },
   "Huntington, WV": {
     "reporter": "Shae Strait",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "1343.04 - PARKING REQUIREMENT REDUCTIONS",
@@ -32117,7 +32117,7 @@
   },
   "Keyport, NJ": {
     "reporter": "Andrew Kelsey",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Keyport City Code",
@@ -32412,7 +32412,7 @@
   },
   "Kissimmee, FL": {
     "reporter": "John Hambley",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "City Code",
@@ -34040,7 +34040,7 @@
   },
   "Lansing , MI": {
     "reporter": "Andrew Fedewa",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Reductions allowed via shared parking lots or shared vehicle programs",
@@ -34645,7 +34645,7 @@
   },
   "Leduc, AB": {
     "reporter": "Mike Norris",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Zoning Bylaw",
@@ -37286,7 +37286,7 @@
   },
   "Mancelona, MI": {
     "reporter": "Sara Kopriva",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Municipal Code",
@@ -40079,7 +40079,7 @@
   },
   "Milan, MI": {
     "reporter": "Samuel Deetz",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Milan Zoning Code",
@@ -40761,7 +40761,7 @@
   },
   "Mint Hill, NC": {
     "reporter": "Samuel Deetz",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Mint Hill Unified Development Ordinance",
@@ -40818,7 +40818,7 @@
   },
   "Missoula, MT": {
     "reporter": "Patrick Siegman",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Municipal Code",
@@ -42192,7 +42192,7 @@
   },
   "Mount Prospect, IL": {
     "reporter": null,
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Off-Street Parking Requirements Worksheet",
@@ -46051,7 +46051,7 @@
   },
   "Oakboro, NC": {
     "reporter": "Samuel Deetz",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Oakboro Unified Development Ordinance",
@@ -52943,7 +52943,7 @@
   },
   "River Rouge, MI": {
     "reporter": "Nani Wolf",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Municipal code",
@@ -53494,7 +53494,7 @@
   },
   "Rockford, IL": {
     "reporter": "Jake Schreiner",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Zoning Ordinance",
@@ -61240,7 +61240,7 @@
   },
   "Surrey, BC": {
     "reporter": "Paul Hillsdon",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Zoning By-Law",
@@ -63358,7 +63358,7 @@
   },
   "Trelleborg, Scania": {
     "reporter": "Johan Kerttu",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Description of ordinance (in Swedish)",
@@ -63776,7 +63776,7 @@
   },
   "Twin Falls, ID": {
     "reporter": null,
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Twin Falls Zoning Code",
@@ -69070,7 +69070,7 @@
   },
   "Wooster, OH": {
     "reporter": "Thomas Stikeleather",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "Municipal code",
@@ -69446,7 +69446,7 @@
   },
   "Yellowknife, NT": {
     "reporter": "Dustin",
-    "requirements": [""],
+    "requirements": [],
     "citations": [
       {
         "description": "City Bylaw",

--- a/migrations/schemas/directus.md
+++ b/migrations/schemas/directus.md
@@ -35,7 +35,7 @@ Dropped fields from Google Tables `cities` table:
 | policy_changes           | enum[]      | `type`                                                    |                                     |
 | land_uses                | enum[]      | `uses`                                                    |                                     |
 | reform_scope             | enum[]      | `magnitude`                                               |                                     |
-| requirements             | enum[]?     | `requirements`                                            |                                     |
+| requirements             | enum[]      | `requirements`                                            |                                     |
 | status                   | enum        | `status`                                                  |                                     |
 | reform_date              | string?     | `date of reform`                                          | `yyyy` or `yyyy-mm` or `yyyy-mm-dd` |
 | reporter                 | string      | the person's name; full Contacts table not used in Tables |

--- a/scripts/city_detail_last_updated.txt
+++ b/scripts/city_detail_last_updated.txt
@@ -1,1 +1,1 @@
-November 16, 2024, 5:34:07 PM UTC
+November 16, 2024, 6:07:31 PM UTC

--- a/scripts/lib/data.ts
+++ b/scripts/lib/data.ts
@@ -64,6 +64,7 @@ export function splitStringArray(
   val: string,
   transform: Record<string, string> = {},
 ): string[] {
+  if (!val) return [];
   return val.split(", ").map((v) => {
     const lowercase = v.toLowerCase();
     return transform[lowercase] ?? lowercase;

--- a/scripts/lib/directus.ts
+++ b/scripts/lib/directus.ts
@@ -63,7 +63,7 @@ type LegacyReform = {
   policy_changes: string[];
   land_uses: string[];
   reform_scope: string[];
-  requirements: string[] | null;
+  requirements: string[];
   status: ReformStatus;
   summary: string;
   reporter: string;


### PR DESCRIPTION
The Directus database is now set up to not allow `null` and instead set the default for the field to `[]`.