### PR TITLE
Write missing coordinates to Directus

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "sync-core-data": "tsx scripts/syncCoreData.ts",
     "sync-extended-data": "tsx scripts/syncExtendedData.ts",
     "sync-lat-lng": "tsx scripts/syncLatLng.ts",
+    "sync-directus": "tsx scripts/syncDirectus.ts",
     "broken-links": "tsx scripts/brokenLinks.ts",
     "serve-dist": "cd dist; http-server",
     "test-dist": "PORT=8080 playwright test"

--- a/scripts/lib/directus.ts
+++ b/scripts/lib/directus.ts
@@ -58,7 +58,7 @@ export type Citation = {
   source_description: string;
   notes: string | null;
   url: string | null;
-  attachments: number[] | CitationsFileJunction[];
+  attachments: number[];
 } & Metadata;
 
 export type LegacyReform = {
@@ -73,7 +73,7 @@ export type LegacyReform = {
   reporter: string | null;
   reform_date: string | null;
   complete_minimums_repeal: boolean;
-  citations: number[] | LegacyReformCitationJunction[];
+  citations: number[];
 } & Metadata;
 
 export interface CitationsFileJunction {

--- a/scripts/lib/geocoder.ts
+++ b/scripts/lib/geocoder.ts
@@ -1,3 +1,6 @@
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-await-in-loop */
+
 import nodeFetch from "node-fetch";
 import NodeGeocoder from "node-geocoder";
 
@@ -18,14 +21,12 @@ export function initGeocoder(): NodeGeocoder.Geocoder {
 export async function getLongLat(
   placeName: string,
   state: string | null,
-  country_code: string,
+  countryCode: string,
   geocoder: NodeGeocoder.Geocoder,
 ): Promise<[number, number] | null> {
   const stateQuery = state ? `${state}, ` : "";
   // We try the most precise query first, then fall back to less precise queries.
-  const locationMethods = [
-    () => `${placeName}, ${stateQuery}, ${country_code}`,
-  ];
+  const locationMethods = [() => `${placeName}, ${stateQuery}, ${countryCode}`];
   if (stateQuery) {
     locationMethods.push(() => `${placeName}, ${stateQuery}`);
   }

--- a/scripts/lib/geocoder.ts
+++ b/scripts/lib/geocoder.ts
@@ -1,0 +1,45 @@
+import nodeFetch from "node-fetch";
+import NodeGeocoder from "node-geocoder";
+
+export async function fetch(
+  url: nodeFetch.RequestInfo,
+  options: nodeFetch.RequestInit = {},
+): Promise<nodeFetch.Response> {
+  return nodeFetch(url, {
+    ...options,
+    headers: { "User-Agent": "prn-update-map-data" },
+  });
+}
+
+export function initGeocoder(): NodeGeocoder.Geocoder {
+  return NodeGeocoder({ provider: "openstreetmap", fetch });
+}
+
+export async function getLongLat(
+  placeName: string,
+  state: string | null,
+  country_code: string,
+  geocoder: NodeGeocoder.Geocoder,
+): Promise<[number, number] | null> {
+  const stateQuery = state ? `${state}, ` : "";
+  // We try the most precise query first, then fall back to less precise queries.
+  const locationMethods = [
+    () => `${placeName}, ${stateQuery}, ${country_code}`,
+  ];
+  if (stateQuery) {
+    locationMethods.push(() => `${placeName}, ${stateQuery}`);
+  }
+  locationMethods.push(() => `${placeName}`);
+
+  for (const getLocationString of locationMethods) {
+    const locationString = getLocationString();
+    const geocodeResults = await geocoder.geocode(locationString);
+    if (geocodeResults.length > 0) {
+      const lat = geocodeResults[0].latitude;
+      const long = geocodeResults[0].longitude;
+      if (!lat || !long) continue;
+      return [long, lat];
+    }
+  }
+  return null;
+}

--- a/scripts/syncCoreData.ts
+++ b/scripts/syncCoreData.ts
@@ -4,7 +4,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
 import nodeFetch from "node-fetch";
-import NodeGeocoder from "node-geocoder";
 import Papa from "papaparse";
 
 import { initGeocoder, getLongLat } from "./lib/geocoder";

--- a/scripts/syncCoreData.ts
+++ b/scripts/syncCoreData.ts
@@ -7,6 +7,7 @@ import nodeFetch from "node-fetch";
 import NodeGeocoder from "node-geocoder";
 import Papa from "papaparse";
 
+import { initGeocoder, getLongLat } from "./lib/geocoder";
 import { readCoreData, saveCoreData, splitStringArray } from "./lib/data";
 import { PlaceId, RawEntry } from "../src/js/types";
 
@@ -135,49 +136,23 @@ function addCachedLatLng(
 // Geocoding
 // -------------------------------------------------------------
 
-async function ensureRowLatLng(
-  entry: RawEntry,
-  geocoder: NodeGeocoder.Geocoder,
-): Promise<RawEntry> {
-  if (entry.coord !== null) {
-    return entry;
-  }
-
-  const stateQuery = entry.state ? `${entry.state}, ` : "";
-  // We try the most precise query first, then fall back to less precise queries.
-  const locationMethods = [
-    () => `${entry.place}, ${stateQuery}, ${entry.country}`,
-    () => `${entry.place}, ${stateQuery}`,
-  ];
-  if (stateQuery) {
-    locationMethods.push(() => `${entry.place}`);
-  }
-
-  for (const getLocationString of locationMethods) {
-    const locationString = getLocationString();
-    const geocodeResults = await geocoder.geocode(locationString);
-    if (geocodeResults.length > 0) {
-      const lat = geocodeResults[0].latitude;
-      const long = geocodeResults[0].longitude;
-      if (!lat || !long) continue;
-      return {
-        ...entry,
-        coord: [long, lat],
-      };
-    }
-  }
-  return entry;
-}
-
 async function addMissingLatLng(
   data: Record<PlaceId, RawEntry>,
 ): Promise<Record<PlaceId, RawEntry>> {
-  const geocoder = NodeGeocoder({ provider: "openstreetmap", fetch });
+  const geocoder = initGeocoder();
 
   // We use a for loop to avoid making too many network calls -> rate limiting.
   const result: Record<PlaceId, RawEntry> = {};
   for (const [placeId, entry] of Object.entries(data)) {
-    result[placeId] = await ensureRowLatLng(entry, geocoder);
+    if (entry.coord) continue;
+    const longLat = await getLongLat(
+      entry.place,
+      entry.state,
+      entry.country,
+      geocoder,
+    );
+    if (!longLat) throw new Error(`Could not get lat long for ${placeId}`);
+    result[placeId] = { ...entry, coord: longLat };
   }
   return result;
 }

--- a/scripts/syncDirectus.ts
+++ b/scripts/syncDirectus.ts
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+/* eslint-disable import/no-extraneous-dependencies */
+/* eslint-disable no-await-in-loop */
 
 import { readItems, updateItem } from "@directus/sdk";
 import NodeGeocoder from "node-geocoder";
@@ -10,15 +12,6 @@ import {
 } from "./lib/directus";
 import { PlaceId as PlaceStringId } from "../src/js/types";
 import { getLongLat, initGeocoder } from "./lib/geocoder";
-
-async function main(): Promise<void> {
-  const client = await initDirectus();
-  const geocoder = initGeocoder();
-
-  const places = await readPlacesAndEnsureCoordinates(client, geocoder);
-  console.log(JSON.stringify(places));
-  process.exit(0);
-}
 
 async function readPlacesAndEnsureCoordinates(
   client: DirectusClient,
@@ -76,6 +69,15 @@ async function readPlacesAndEnsureCoordinates(
     directusIdToStringId,
     stringIdToPlace,
   };
+}
+
+async function main(): Promise<void> {
+  const client = await initDirectus();
+  const geocoder = initGeocoder();
+
+  const places = await readPlacesAndEnsureCoordinates(client, geocoder);
+  console.log(JSON.stringify(places));
+  process.exit(0);
 }
 
 main().catch((error) => {

--- a/scripts/syncDirectus.ts
+++ b/scripts/syncDirectus.ts
@@ -15,12 +15,12 @@ async function main(): Promise<void> {
   const client = await initDirectus();
   const geocoder = initGeocoder();
 
-  const places = await readPlaces(client, geocoder);
+  const places = await readPlacesAndEnsureCoordinates(client, geocoder);
   console.log(JSON.stringify(places));
   process.exit(0);
 }
 
-async function readPlaces(
+async function readPlacesAndEnsureCoordinates(
   client: DirectusClient,
   geocoder: NodeGeocoder.Geocoder,
 ): Promise<{

--- a/scripts/syncDirectus.ts
+++ b/scripts/syncDirectus.ts
@@ -1,20 +1,33 @@
 /* eslint-disable no-console */
 
-import { readItems, readFiles } from "@directus/sdk";
+import { readItems, updateItem } from "@directus/sdk";
+import NodeGeocoder from "node-geocoder";
 
-import { Attachment, Citation } from "./lib/data";
 import {
-  CITATIONS_FILES_FOLDER,
   initDirectus,
-  Citation as DirectusCitation,
+  DirectusClient,
+  Place as DirectusPlace,
 } from "./lib/directus";
+import { PlaceId as PlaceStringId } from "../src/js/types";
+import { getLongLat, initGeocoder } from "./lib/geocoder";
 
 async function main(): Promise<void> {
   const client = await initDirectus();
-  // Idea: map
-  //   1. placeStringId -> record
-  //   2. id (number) -> placeStringId
-  const places = await client.request(
+  const geocoder = initGeocoder();
+
+  const places = await readPlaces(client, geocoder);
+  console.log(JSON.stringify(places));
+  process.exit(0);
+}
+
+async function readPlaces(
+  client: DirectusClient,
+  geocoder: NodeGeocoder.Geocoder,
+): Promise<{
+  directusIdToStringId: Record<number, PlaceStringId>;
+  stringIdToPlace: Record<PlaceStringId, Partial<DirectusPlace>>;
+}> {
+  const records = await client.request(
     readItems("places", {
       fields: [
         "id",
@@ -27,120 +40,42 @@ async function main(): Promise<void> {
       limit: -1,
     }),
   );
-  const legacyReforms = await client.request(
-    readItems("legacy_reforms", {
-      fields: [
-        "id",
-        "place",
-        "policy_changes",
-        "land_uses",
-        "reform_scope",
-        "requirements",
-        "status",
-        "summary",
-        "reporter",
-        "reform_date",
-        "complete_minimums_repeal",
-        "citations",
-      ],
-      limit: -1,
-    }),
-  );
-  const citations = await client.request(
-    readItems("citations", {
-      fields: [
-        "id",
-        "type",
-        "source_description",
-        "notes",
-        "url",
-        "attachments",
-      ],
-      limit: -1,
-    }),
-  );
+  const directusIdToStringId: Record<number, PlaceStringId> = {};
+  const stringIdToPlace: Record<PlaceStringId, Partial<DirectusPlace>> = {};
+  for (const record of records) {
+    const stringId = record.state
+      ? `${record.name}, ${record.state}`
+      : record.name;
 
-  const rawFiles = await client.request(
-    readFiles({
-      filter: { folder: { _eq: CITATIONS_FILES_FOLDER } },
-      fields: ["id", "type"],
-      limit: -1,
-    }),
-  );
-  const fileTypesById = Object.fromEntries(
-    rawFiles.map((record) => [record.id, record.type]),
-  );
-
-  const legacyReformsCitationsJunctions = await client.request(
-    readItems("legacy_reforms_citations", {
-      fields: ["id", "citations_id"],
-      limit: -1,
-    }),
-  );
-
-  const rawCitationFileJunctions = await client.request(
-    readItems("citations_files", {
-      fields: ["id", "directus_files_id"],
-      limit: -1,
-    }),
-  );
-  const fileIdsByCitationJunctionId = Object.fromEntries(
-    rawCitationFileJunctions.map((record) => [
-      record.id,
-      record.directus_files_id,
-    ]),
-  );
-
-  const normalizedCitations = computeCitations(
-    citations,
-    fileIdsByCitationJunctionId,
-    fileTypesById,
-  );
-
-  // TODO: maybe invert this because we need the place ID to compute attachment filename
-  // 1. Set up every citation by populating attachment data
-  // 2. Associate citations to legacyReforms
-  // 3. Associate legacyReforms to Places
-  // 4. Record the CompleteEntry with PlaceId as the key
-
-  // TODO: deal with missing coordinates. Set up geocoder.ts file to compute coordinates.
-  // Get every Place and if the value is missing, update Directus one-by-one (log it)
-
-  console.log(JSON.stringify(normalizedCitations));
-  process.exit(0);
-}
-
-function computeCitations(
-  citations: Array<Partial<DirectusCitation>>,
-  fileIdsByCitationJunctionId: Record<number, string>,
-  fileTypesById: Record<string, string | null>,
-): Record<number, Citation> {
-  return Object.fromEntries(
-    citations.map((citation) => {
-      const attachments: Attachment[] = citation.attachments!.map(
-        (citationsFileJunction) => {
-          const fileId = fileIdsByCitationJunctionId[citationsFileJunction];
-          return {
-            directusId: fileId,
-            // TODO by using fileTypesById
-            isDoc: false,
-            // TODO: can't actually compute this without the place ID
-            fileName: "TODO",
-          };
-        },
+    if (!record.coordinates) {
+      console.log(`Getting coordinates for ${stringId}`);
+      const longLat = await getLongLat(
+        record.name,
+        record.state,
+        record.country_code,
+        geocoder,
       );
-      return [
-        citation.id!,
-        {
-          description: citation.source_description!,
-          type: citation.type!,
-          url: citation.url!,
-          notes: citation.notes!,
-          attachments: attachments,
-        },
-      ];
-    }),
-  );
+      if (!longLat) {
+        throw new Error(
+          `Failed to get coordinates for ${stringId} (place ID ${record.id}). You can manually add the coordinates to Directus and try the sync again.`,
+        );
+      }
+      const coordinates = { type: "Point" as const, coordinates: longLat };
+      record.coordinates = coordinates;
+      await client.request(
+        updateItem("places", record.id, {
+          coordinates,
+        }),
+      );
+    }
+
+    directusIdToStringId[record.id] = stringId;
+    stringIdToPlace[stringId] = record;
+  }
+  return {
+    directusIdToStringId,
+    stringIdToPlace,
+  };
 }
 
 main().catch((error) => {

--- a/scripts/syncDirectus.ts
+++ b/scripts/syncDirectus.ts
@@ -1,0 +1,149 @@
+/* eslint-disable no-console */
+
+import { readItems, readFiles } from "@directus/sdk";
+
+import { Attachment, Citation } from "./lib/data";
+import {
+  CITATIONS_FILES_FOLDER,
+  initDirectus,
+  Citation as DirectusCitation,
+} from "./lib/directus";
+
+async function main(): Promise<void> {
+  const client = await initDirectus();
+  // Idea: map
+  //   1. placeStringId -> record
+  //   2. id (number) -> placeStringId
+  const places = await client.request(
+    readItems("places", {
+      fields: [
+        "id",
+        "name",
+        "state",
+        "country_code",
+        "population",
+        "coordinates",
+      ],
+      limit: -1,
+    }),
+  );
+  const legacyReforms = await client.request(
+    readItems("legacy_reforms", {
+      fields: [
+        "id",
+        "place",
+        "policy_changes",
+        "land_uses",
+        "reform_scope",
+        "requirements",
+        "status",
+        "summary",
+        "reporter",
+        "reform_date",
+        "complete_minimums_repeal",
+        "citations",
+      ],
+      limit: -1,
+    }),
+  );
+  const citations = await client.request(
+    readItems("citations", {
+      fields: [
+        "id",
+        "type",
+        "source_description",
+        "notes",
+        "url",
+        "attachments",
+      ],
+      limit: -1,
+    }),
+  );
+
+  const rawFiles = await client.request(
+    readFiles({
+      filter: { folder: { _eq: CITATIONS_FILES_FOLDER } },
+      fields: ["id", "type"],
+      limit: -1,
+    }),
+  );
+  const fileTypesById = Object.fromEntries(
+    rawFiles.map((record) => [record.id, record.type]),
+  );
+
+  const legacyReformsCitationsJunctions = await client.request(
+    readItems("legacy_reforms_citations", {
+      fields: ["id", "citations_id"],
+      limit: -1,
+    }),
+  );
+
+  const rawCitationFileJunctions = await client.request(
+    readItems("citations_files", {
+      fields: ["id", "directus_files_id"],
+      limit: -1,
+    }),
+  );
+  const fileIdsByCitationJunctionId = Object.fromEntries(
+    rawCitationFileJunctions.map((record) => [
+      record.id,
+      record.directus_files_id,
+    ]),
+  );
+
+  const normalizedCitations = computeCitations(
+    citations,
+    fileIdsByCitationJunctionId,
+    fileTypesById,
+  );
+
+  // TODO: maybe invert this because we need the place ID to compute attachment filename
+  // 1. Set up every citation by populating attachment data
+  // 2. Associate citations to legacyReforms
+  // 3. Associate legacyReforms to Places
+  // 4. Record the CompleteEntry with PlaceId as the key
+
+  // TODO: deal with missing coordinates. Set up geocoder.ts file to compute coordinates.
+  // Get every Place and if the value is missing, update Directus one-by-one (log it)
+
+  console.log(JSON.stringify(normalizedCitations));
+  process.exit(0);
+}
+
+function computeCitations(
+  citations: Array<Partial<DirectusCitation>>,
+  fileIdsByCitationJunctionId: Record<number, string>,
+  fileTypesById: Record<string, string | null>,
+): Record<number, Citation> {
+  return Object.fromEntries(
+    citations.map((citation) => {
+      const attachments: Attachment[] = citation.attachments!.map(
+        (citationsFileJunction) => {
+          const fileId = fileIdsByCitationJunctionId[citationsFileJunction];
+          return {
+            directusId: fileId,
+            // TODO by using fileTypesById
+            isDoc: false,
+            // TODO: can't actually compute this without the place ID
+            fileName: "TODO",
+          };
+        },
+      );
+      return [
+        citation.id!,
+        {
+          description: citation.source_description!,
+          type: citation.type!,
+          url: citation.url!,
+          notes: citation.notes!,
+          attachments: attachments,
+        },
+      ];
+    }),
+  );
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});


### PR DESCRIPTION
We will continue to find the coordinates automatically through reverse geocoding. It's not easy to set that up in Directus, so we'll write to Directus any missing coordinates during the nightly sync.

This also sets up the basic skeleton for `npm run sync-directus` by reading the Places table. Directus operates in terms of a numeric ID for places, but our JSON files expect a string `PlaceId`. So this new function returns a helpful mapping between those two key types.