### PR TITLE
Refactor raw vs processed entries

### DIFF
--- a/scripts/brokenLinks.ts
+++ b/scripts/brokenLinks.ts
@@ -4,12 +4,12 @@
 
 import fetch from "node-fetch";
 
-import { readCompleteData } from "./lib/data";
+import { readRawExtendedData } from "./lib/data";
 
 export async function mapPlaceToCitationLinks(): Promise<
   Record<string, string[]>
 > {
-  const data = await readCompleteData();
+  const data = await readRawExtendedData();
   return Object.fromEntries(
     Object.entries(data).map(([placeId, entry]) => [
       placeId,

--- a/scripts/generateCsv.ts
+++ b/scripts/generateCsv.ts
@@ -5,8 +5,7 @@ import fs from "fs/promises";
 
 import Papa from "papaparse";
 
-import { readCompleteData } from "./lib/data";
-import { placeIdToUrl } from "../src/js/data";
+import { readProcessedCompleteData } from "./lib/data";
 
 function assertExpectedNumEntries(jsonKeys: string[], csv: string): void {
   const numJson = jsonKeys.length;
@@ -17,23 +16,23 @@ function assertExpectedNumEntries(jsonKeys: string[], csv: string): void {
 }
 
 async function main(): Promise<void> {
-  const completeData = await readCompleteData();
-  const data = Object.entries(completeData).map(([placeId, entry]) => ({
+  const completeData = await readProcessedCompleteData();
+  const data = Object.values(completeData).map((entry) => ({
     place: entry.place.name,
     state: entry.place.state,
     country: entry.place.country,
     all_minimums_repealed: entry.place.repeal ? "TRUE" : "FALSE",
-    status: entry.legacy.status,
-    policy_change: entry.legacy.policy,
-    scope: entry.legacy.scope,
-    land_uses: entry.legacy.land,
-    reform_date: entry.legacy.date,
+    status: entry.unifiedPolicy.status,
+    policy_change: entry.unifiedPolicy.policy,
+    scope: entry.unifiedPolicy.scope,
+    land_uses: entry.unifiedPolicy.land,
+    reform_date: entry.unifiedPolicy.date,
     population: entry.place.pop,
     lat: entry.place.coord[1],
     long: entry.place.coord[0],
-    url: placeIdToUrl(placeId),
-    reporter: entry.legacy.reporter,
-    summary: entry.legacy.summary,
+    url: entry.place.url,
+    reporter: entry.unifiedPolicy.reporter,
+    summary: entry.unifiedPolicy.summary,
   }));
   const csv = Papa.unparse(Object.values(data));
   assertExpectedNumEntries(Object.keys(completeData), csv);

--- a/scripts/lib/data.ts
+++ b/scripts/lib/data.ts
@@ -83,17 +83,15 @@ export async function readProcessedCompleteData(): Promise<
 > {
   const raw = await readRawCompleteData();
   return Object.fromEntries(
-    Object.entries(raw).map(([placeId, entry]) => {
-      return [
-        placeId,
-        {
-          place: { ...entry.place, url: placeIdToUrl(placeId) },
-          unifiedPolicy: {
-            ...entry.legacy,
-            date: Date.fromNullable(entry.legacy.date),
-          },
+    Object.entries(raw).map(([placeId, entry]) => [
+      placeId,
+      {
+        place: { ...entry.place, url: placeIdToUrl(placeId) },
+        unifiedPolicy: {
+          ...entry.legacy,
+          date: Date.fromNullable(entry.legacy.date),
         },
-      ];
-    }),
+      },
+    ]),
   );
 }

--- a/scripts/lib/data.ts
+++ b/scripts/lib/data.ts
@@ -1,6 +1,14 @@
 import fs from "fs/promises";
 
-import { RawEntry, PlaceId } from "../../src/js/types";
+import {
+  RawCoreEntry,
+  PlaceId,
+  ProcessedCoreEntry,
+  Place,
+  RawLegacyReform,
+  Date,
+} from "../../src/js/types";
+import { placeIdToUrl } from "../../src/js/data";
 
 export type Attachment = {
   fileName: string;
@@ -10,50 +18,82 @@ export type Attachment = {
 
 export type CitationType = "city code" | "media report" | "other";
 
-export type Citation = {
+export interface Citation {
   description: string;
   type: CitationType;
   url: string | null;
   notes: string | null;
   attachments: Attachment[];
+}
+
+export interface ExtendedPolicy {
+  reporter: string | null;
+  requirements: string[];
+  citations: Citation[];
+}
+
+export type RawExtendedEntry = {
+  legacy: ExtendedPolicy;
 };
+export interface RawCompleteEntry {
+  place: Place;
+  legacy: RawLegacyReform & ExtendedPolicy;
+}
 
-export type ExtendedEntry = {
-  legacy: {
-    reporter: string | null;
-    requirements: string[];
-    citations: Citation[];
-  };
-};
+export interface ProcessedExtendedEntry {
+  unifiedPolicy: ExtendedPolicy;
+}
+export type ProcessedCompleteEntry = ProcessedCoreEntry &
+  ProcessedExtendedEntry;
 
-export type CompleteEntry = RawEntry & ExtendedEntry;
-
-export async function readCoreData(): Promise<Record<PlaceId, RawEntry>> {
+export async function readRawCoreData(): Promise<
+  Record<PlaceId, RawCoreEntry>
+> {
   const raw = await fs.readFile("data/core.json", "utf8");
   return JSON.parse(raw);
 }
 
-export async function readExtendedData(): Promise<
-  Record<PlaceId, ExtendedEntry>
+export async function readRawExtendedData(): Promise<
+  Record<PlaceId, RawExtendedEntry>
 > {
   const raw = await fs.readFile("data/extended.json", "utf8");
   return JSON.parse(raw);
 }
 
-export async function readCompleteData(): Promise<
-  Record<PlaceId, CompleteEntry>
+export async function readRawCompleteData(): Promise<
+  Record<PlaceId, RawCompleteEntry>
 > {
   const [coreData, extendedData] = await Promise.all([
-    readCoreData(),
-    readExtendedData(),
+    readRawCoreData(),
+    readRawExtendedData(),
   ]);
   return Object.fromEntries(
-    Object.entries(coreData).map(([placeId, core]) => [
+    Object.entries(coreData).map(([placeId, entry]) => [
       placeId,
       {
-        place: core.place,
-        legacy: { ...core.legacy, ...extendedData[placeId].legacy },
+        place: entry.place,
+        legacy: { ...entry.legacy, ...extendedData[placeId].legacy },
       },
     ]),
+  );
+}
+
+export async function readProcessedCompleteData(): Promise<
+  Record<PlaceId, ProcessedCompleteEntry>
+> {
+  const raw = await readRawCompleteData();
+  return Object.fromEntries(
+    Object.entries(raw).map(([placeId, entry]) => {
+      return [
+        placeId,
+        {
+          place: { ...entry.place, url: placeIdToUrl(placeId) },
+          unifiedPolicy: {
+            ...entry.legacy,
+            date: Date.fromNullable(entry.legacy.date),
+          },
+        },
+      ];
+    }),
   );
 }

--- a/scripts/lib/directus.ts
+++ b/scripts/lib/directus.ts
@@ -2,6 +2,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable no-console */
 /* eslint-disable no-await-in-loop */
+/* eslint-disable no-constant-condition */
 
 import {
   createDirectus,

--- a/scripts/lib/directus.ts
+++ b/scripts/lib/directus.ts
@@ -18,7 +18,7 @@ import {
   DirectusFile,
 } from "@directus/sdk";
 
-import { ReformStatus } from "../../src/js/types.js";
+import { PolicyType, ReformStatus } from "../../src/js/types.js";
 import { CitationType } from "../../scripts/lib/data.js";
 
 export const CITATIONS_FILES_FOLDER = "f085de08-b747-4251-973d-1752ccc29649";
@@ -75,7 +75,7 @@ export type Citation = {
 export type LegacyReform = {
   place: number;
   last_verified_at: string | null;
-  policy_changes: string[];
+  policy_changes: PolicyType[];
   land_uses: string[];
   reform_scope: string[];
   requirements: string[];

--- a/scripts/syncDirectus.ts
+++ b/scripts/syncDirectus.ts
@@ -18,7 +18,7 @@ import {
 } from "./lib/directus";
 import { PlaceId as PlaceStringId } from "../src/js/types";
 import { getLongLat, initGeocoder } from "./lib/geocoder";
-import { Attachment, Citation, CompleteEntry } from "./lib/data";
+import { Attachment, Citation, RawCompleteEntry } from "./lib/data";
 import { escapePlaceId } from "../src/js/data";
 
 // --------------------------------------------------------------------------
@@ -213,7 +213,7 @@ function combineData(
   legacyReforms: Record<PlaceStringId, Partial<LegacyReform>>,
   citationsByLegacyReformJunctionId: Record<number, Partial<DirectusCitation>>,
   filesByAttachmentJunctionId: Record<number, FileMetadata>,
-): Record<PlaceStringId, CompleteEntry> {
+): Record<PlaceStringId, RawCompleteEntry> {
   return Object.fromEntries(
     Object.entries(places)
       // Skip unverified reforms.
@@ -239,7 +239,7 @@ function combineData(
             };
           },
         );
-        const result: CompleteEntry = {
+        const result: RawCompleteEntry = {
           place: {
             name: place.name!,
             state: place.state!,
@@ -271,7 +271,7 @@ function combineData(
 // --------------------------------------------------------------------------
 
 async function saveCoreData(
-  result: Record<PlaceStringId, CompleteEntry>,
+  result: Record<PlaceStringId, RawCompleteEntry>,
 ): Promise<void> {
   const pruned = Object.fromEntries(
     Object.entries(result).map(([placeId, entry]) => [
@@ -302,7 +302,7 @@ async function saveCoreData(
 }
 
 async function saveExtendedData(
-  result: Record<PlaceStringId, CompleteEntry>,
+  result: Record<PlaceStringId, RawCompleteEntry>,
 ): Promise<void> {
   const pruned = Object.fromEntries(
     Object.entries(result).map(([placeId, entry]) => [

--- a/src/js/FilterState.ts
+++ b/src/js/FilterState.ts
@@ -1,5 +1,5 @@
 import { isEqual } from "lodash-es";
-import { PlaceId, PlaceEntry } from "./types";
+import { PlaceId, ProcessedCoreEntry } from "./types";
 import Observable from "./Observable";
 import { UNKNOWN_YEAR } from "./filterOptions";
 
@@ -34,11 +34,14 @@ interface CacheEntry {
 export class PlaceFilterManager {
   private readonly state: Observable<FilterState>;
 
-  readonly entries: Record<PlaceId, PlaceEntry>;
+  readonly entries: Record<PlaceId, ProcessedCoreEntry>;
 
   private cache: CacheEntry | null = null;
 
-  constructor(entries: Record<PlaceId, PlaceEntry>, initialState: FilterState) {
+  constructor(
+    entries: Record<PlaceId, ProcessedCoreEntry>,
+    initialState: FilterState,
+  ) {
     this.entries = entries;
     this.state = new Observable(initialState);
   }

--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -1,6 +1,6 @@
 import { capitalize } from "lodash-es";
 
-import { PlaceEntry } from "./types";
+import { ProcessedCoreEntry } from "./types";
 import { PlaceFilterManager } from "./FilterState";
 import Observable from "./Observable";
 
@@ -26,7 +26,7 @@ const DESELECTED_BY_DEFAULT: Record<FilterGroupKey, Set<string>> = {
 export class FilterOptions {
   readonly options: Record<FilterGroupKey, string[]>;
 
-  constructor(entries: PlaceEntry[]) {
+  constructor(entries: ProcessedCoreEntry[]) {
     const policy = new Set<string>();
     const scope = new Set<string>();
     const landUse = new Set<string>();

--- a/src/js/mapPosition.ts
+++ b/src/js/mapPosition.ts
@@ -8,8 +8,7 @@ export default function subscribeSnapToPlace(
 ): void {
   manager.subscribe(({ searchInput }) => {
     if (searchInput) {
-      const entry = manager.entries[searchInput];
-      const [long, lat] = entry.place.coord;
+      const [long, lat] = manager.entries[searchInput].place.coord;
       map.setView([lat, long], 6);
     }
   });

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -1,11 +1,14 @@
 import type { FeatureGroup } from "leaflet";
 
-import type { PlaceEntry, PlaceId } from "./types";
+import type { ProcessedCoreEntry, PlaceId } from "./types";
 import Observable from "./Observable";
 import { PlaceFilterManager } from "./FilterState";
 import { ViewStateObservable } from "./viewToggle";
 
-function generateScorecard(entry: PlaceEntry, placeId: PlaceId): string {
+function generateScorecard(
+  entry: ProcessedCoreEntry,
+  placeId: PlaceId,
+): string {
   const dateOfReform = entry.unifiedPolicy.date
     ? `<li>Reformed ${entry.unifiedPolicy.date.preposition()} ${entry.unifiedPolicy.date.format()}</li>`
     : "";
@@ -33,7 +36,7 @@ function generateScorecard(entry: PlaceEntry, placeId: PlaceId): string {
 
 type ScorecardState =
   | { type: "hidden" }
-  | { type: "visible"; entry: PlaceEntry; placeId: PlaceId };
+  | { type: "visible"; entry: ProcessedCoreEntry; placeId: PlaceId };
 
 function updateScorecardUI(state: ScorecardState): void {
   const scorecardContainer = document.querySelector<HTMLElement>(
@@ -61,7 +64,7 @@ export default function initScorecard(
   filterManager: PlaceFilterManager,
   viewToggle: ViewStateObservable,
   markerGroup: FeatureGroup,
-  data: Record<PlaceId, PlaceEntry>,
+  data: Record<PlaceId, ProcessedCoreEntry>,
 ): void {
   const scorecardState = new Observable<ScorecardState>({ type: "hidden" });
   scorecardState.subscribe(updateScorecardUI);

--- a/src/js/types.ts
+++ b/src/js/types.ts
@@ -13,6 +13,10 @@ export class Date {
     this.parsed = parsed;
   }
 
+  static fromNullable(dateStr?: string | null): Date | null {
+    return dateStr ? new this(dateStr) : null;
+  }
+
   format(): string {
     if (this.raw.length === 4) return this.raw;
     if (this.raw.length === 7) return this.parsed.toFormat("LLL yyyy");
@@ -26,13 +30,6 @@ export class Date {
 
 export type PlaceId = string;
 
-export type ReformStatus =
-  | "implemented"
-  | "passed"
-  | "planned"
-  | "proposed"
-  | "repealed";
-
 export interface Place {
   // Full name of the town, city, county, province, state, or country.
   name: string;
@@ -45,20 +42,34 @@ export interface Place {
   repeal: boolean;
 }
 
+export type PolicyType =
+  | "reduce parking minimums"
+  | "remove parking minimums"
+  | "add parking maximums";
+
+export type ReformStatus =
+  | "implemented"
+  | "passed"
+  | "planned"
+  | "proposed"
+  | "repealed";
+
 interface BaseLegacyReform {
   summary: string;
   status: ReformStatus;
-  policy: string[];
+  policy: PolicyType[];
   scope: string[];
   land: string[];
 }
+export type RawLegacyReform = BaseLegacyReform & { date: string | null };
+export type ProcessedLegacyReform = BaseLegacyReform & { date: Date | null };
 
-export interface RawEntry {
+export interface RawCoreEntry {
   place: Place;
-  legacy: BaseLegacyReform & { date: string | null };
+  legacy: RawLegacyReform;
 }
 
-export interface PlaceEntry {
+export interface ProcessedCoreEntry {
   place: Place & { url: string };
-  unifiedPolicy: BaseLegacyReform & { date: Date | null };
+  unifiedPolicy: ProcessedLegacyReform;
 }

--- a/tests/app/utils.ts
+++ b/tests/app/utils.ts
@@ -1,7 +1,7 @@
 import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
 
-import { readCoreData } from "../../scripts/lib/data";
+import { readRawCoreData } from "../../scripts/lib/data";
 
 const PLACE_MARKER = "path.leaflet-interactive";
 export const DEFAULT_PLACE_RANGE: [number, number] = [3000, 4000];
@@ -13,7 +13,7 @@ export const loadMap = async (page: Page): Promise<void> => {
 };
 
 export async function getTotalNumPlaces(): Promise<number> {
-  const data = await readCoreData();
+  const data = await readRawCoreData();
   return Object.keys(data).length;
 }
 

--- a/tests/scripts/data.test.ts
+++ b/tests/scripts/data.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from "@playwright/test";
 
 import {
-  readCompleteData,
-  readCoreData,
-  readExtendedData,
+  readRawCompleteData,
+  readRawCoreData,
+  readRawExtendedData,
 } from "../../scripts/lib/data";
 
 test("JSON files have enough entries", async () => {
-  const core = await readCoreData();
-  const extended = await readExtendedData();
-  const complete = await readCompleteData();
+  const core = await readRawCoreData();
+  const extended = await readRawExtendedData();
+  const complete = await readRawCompleteData();
   const numCore = Object.keys(core).length;
   const numExtended = Object.keys(extended).length;
   const numComplete = Object.keys(complete).length;
@@ -21,7 +21,7 @@ test("JSON files have enough entries", async () => {
 });
 
 test("every attachment has a Directus ID", async () => {
-  const extendedData = await readExtendedData();
+  const extendedData = await readRawExtendedData();
   const missingFileNames = Object.values(extendedData).flatMap((entry) =>
     entry.legacy.citations.flatMap((citation) =>
       citation.attachments

--- a/tests/scripts/generateHtmlPages.test.ts
+++ b/tests/scripts/generateHtmlPages.test.ts
@@ -4,6 +4,7 @@ import {
   loadTemplate,
   renderHandlebars,
 } from "../../scripts/generateHtmlPages";
+import { Date } from "../../src/js/types";
 
 // This test uses snapshot testing (https://jestjs.io/docs/snapshot-testing#updating-snapshots). If the tests fail and the changes
 // are valid, run `npm test -- --updateSnapshot`.
@@ -26,14 +27,15 @@ test("generate html page", async ({}, testInfo) => {
         repeal: true,
         pop: 24104,
         coord: [44.23, 14.23],
+        url: "https://parkingreform.org/my-city-details.html",
       },
-      legacy: {
+      unifiedPolicy: {
         summary: "No parking mandates for the win!",
         status: "passed",
         policy: ["reduce parking minimums", "add parking maximums"],
         scope: ["citywide"],
         land: ["commercial", "other"],
-        date: "Mar 27, 2018",
+        date: new Date("2018-03-27"),
         reporter: "Parking God",
         requirements: ["by right"],
         citations: [


### PR DESCRIPTION
Follow up to https://github.com/ParkingReformNetwork/reform-map/pull/559 and more prep work for allowing multiple policy records on an entry.

* Use new naming `RawX` and `ProcessedX`
* Make `PolicyType` an enum
* Update `scripts/` to use the correct data format so that there will be minimal changes needed with the new API.