### PR TITLE
Filter out unverified policies directly in database

### DIFF
--- a/scripts/lib/directus.ts
+++ b/scripts/lib/directus.ts
@@ -17,6 +17,8 @@ import {
   readFiles,
   ReadFileOutput,
   DirectusFile,
+  IfAny,
+  QueryFilter,
 } from "@directus/sdk";
 
 import { PolicyType, ReformStatus } from "../../src/js/types.js";
@@ -129,6 +131,13 @@ export async function readItemsBatched<
   collection: Collection,
   fields: Fields,
   batchSize: number = 100,
+  filter:
+    | IfAny<
+        Schema,
+        Record<string, any>, // eslint-disable-line @typescript-eslint/no-explicit-any
+        QueryFilter<Schema, CollectionType<Schema, Collection>>
+      >
+    | undefined = undefined,
 ): Promise<ReadItemOutput<Schema, Collection, { fields: Fields }>[]> {
   const allItems = [];
   let offset = 0;
@@ -141,6 +150,7 @@ export async function readItemsBatched<
         fields,
         limit: batchSize,
         offset,
+        filter,
       }),
     );
 

--- a/scripts/syncDirectus.ts
+++ b/scripts/syncDirectus.ts
@@ -83,20 +83,26 @@ async function readLegacyReforms(
   client: DirectusClient,
   placeDirectusIdToStringId: Record<number, PlaceStringId>,
 ): Promise<Record<PlaceStringId, Partial<LegacyReform>>> {
-  const records = await readItemsBatched(client, "legacy_reforms", [
-    "id",
-    "place",
-    "last_verified_at",
-    "policy_changes",
-    "land_uses",
-    "reform_scope",
-    "requirements",
-    "status",
-    "summary",
-    "reporter",
-    "reform_date",
-    "citations",
-  ]);
+  const records = await readItemsBatched(
+    client,
+    "legacy_reforms",
+    [
+      "id",
+      "place",
+      "last_verified_at",
+      "policy_changes",
+      "land_uses",
+      "reform_scope",
+      "requirements",
+      "status",
+      "summary",
+      "reporter",
+      "reform_date",
+      "citations",
+    ],
+    100,
+    { last_verified_at: { _nnull: true } },
+  );
   return Object.fromEntries(
     records.map((record) => [placeDirectusIdToStringId[record.place], record]),
   );
@@ -216,8 +222,7 @@ function combineData(
 ): Record<PlaceStringId, RawCompleteEntry> {
   return Object.fromEntries(
     Object.entries(places)
-      // Skip unverified reforms.
-      .filter(([placeId]) => legacyReforms[placeId].last_verified_at !== null)
+      .filter(([placeId]) => legacyReforms[placeId] !== undefined)
       .map(([placeId, place]) => {
         const reform = legacyReforms[placeId];
         const citations = reform.citations!.map(


### PR DESCRIPTION
This reduces database queries. We're going to have a lot of unverified policies with the migration. We will also have an `archived` field soon.