### PR TITLE
Improve performance of matching places

### DIFF
--- a/src/js/FilterState.ts
+++ b/src/js/FilterState.ts
@@ -38,12 +38,12 @@ export interface FilterState {
   searchInput: string | null;
   policyTypeFilter: PolicyTypeFilter;
   allMinimumsRemovedToggle: boolean;
-  includedPolicyChanges: string[];
-  scope: string[];
-  landUse: string[];
-  status: string[];
-  country: string[];
-  year: string[];
+  includedPolicyChanges: Set<string>;
+  scope: Set<string>;
+  landUse: Set<string>;
+  status: Set<string>;
+  country: Set<string>;
+  year: Set<string>;
   populationSliderIndexes: [number, number];
 }
 
@@ -153,7 +153,7 @@ export class PlaceFilterManager {
 
   private matchesPlace(place: ProcessedPlace): boolean {
     const filterState = this.state.getValue();
-    const isCountry = filterState.country.includes(place.country);
+    const isCountry = filterState.country.has(place.country);
 
     const isAllMinimumsRepealed =
       // If the toggle is false, we don't care.
@@ -176,14 +176,10 @@ export class PlaceFilterManager {
   private matchesPolicyRecord(policyRecord: ProcessedCorePolicy): boolean {
     const filterState = this.state.getValue();
 
-    const isScope = policyRecord.scope.some((v) =>
-      filterState.scope.includes(v),
-    );
-    const isLand = policyRecord.land.some((v) =>
-      filterState.landUse.includes(v),
-    );
-    const isStatus = filterState.status.includes(policyRecord.status);
-    const isYear = filterState.year.includes(
+    const isScope = policyRecord.scope.some((v) => filterState.scope.has(v));
+    const isLand = policyRecord.land.some((v) => filterState.landUse.has(v));
+    const isStatus = filterState.status.has(policyRecord.status);
+    const isYear = filterState.year.has(
       policyRecord.date?.parsed.year.toString() || UNKNOWN_YEAR,
     );
     return isScope && isLand && isStatus && isYear;
@@ -211,7 +207,7 @@ export class PlaceFilterManager {
 
     if (filterState.policyTypeFilter === "legacy reform") {
       const isPolicyType = entry.unifiedPolicy.policy.some((v) =>
-        filterState.includedPolicyChanges.includes(v),
+        filterState.includedPolicyChanges.has(v),
       );
       return isPlace &&
         isPolicyType &&
@@ -227,7 +223,7 @@ export class PlaceFilterManager {
     if (filterState.policyTypeFilter === "any parking reform") {
       const policyTypes = determinePolicyTypes(entry);
       const isPolicyType = policyTypes.some((v) =>
-        filterState.includedPolicyChanges.includes(v),
+        filterState.includedPolicyChanges.has(v),
       );
       return isPlace && isPolicyType
         ? {

--- a/src/js/counters.ts
+++ b/src/js/counters.ts
@@ -47,7 +47,10 @@ export function determineHtml(
     // We customize the text based on which policy changes are selected.
     let suffix;
     if (state.allMinimumsRemovedToggle) {
-      suffix = isEqual(state.includedPolicyChanges, ["add parking maximums"])
+      suffix = isEqual(
+        state.includedPolicyChanges,
+        new Set(["add parking maximums"]),
+      )
         ? "both all parking minimums removed and parking maximums added"
         : "all parking minimums removed";
     } else {
@@ -56,7 +59,7 @@ export function determineHtml(
         "reduce parking minimums": "parking minimums reduced",
         "remove parking minimums": "parking minimums removed",
       };
-      const policyDescriptions = state.includedPolicyChanges
+      const policyDescriptions = Array.from(state.includedPolicyChanges)
         .map((policy) => policyDescriptionMap[policy as PolicyType])
         .sort()
         .reverse();

--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -54,9 +54,11 @@ export class FilterOptions {
     };
   }
 
-  default(groupKey: FilterGroupKey): string[] {
-    return this.options[groupKey].filter(
-      (opt) => !DESELECTED_BY_DEFAULT[groupKey].has(opt),
+  default(groupKey: FilterGroupKey): Set<string> {
+    return new Set(
+      this.options[groupKey].filter(
+        (opt) => !DESELECTED_BY_DEFAULT[groupKey].has(opt),
+      ),
     );
   }
 
@@ -308,7 +310,7 @@ function initFilterGroup(
         return params.preserveCapitalization ? text : text?.toLowerCase();
       })
       .filter((x) => x !== undefined);
-    filterManager.update({ [params.filterStateKey]: checkedLabels });
+    filterManager.update({ [params.filterStateKey]: new Set(checkedLabels) });
   });
 
   const allCheckboxes = Array.from(
@@ -321,7 +323,9 @@ function initFilterGroup(
     allCheckboxes.forEach((input) => (input.checked = true));
     updateCheckboxStats(accordionState, accordionElements.fieldSet);
     filterManager.update({
-      [params.filterStateKey]: filterOptions.all(params.filterStateKey),
+      [params.filterStateKey]: new Set(
+        filterOptions.all(params.filterStateKey),
+      ),
     });
   });
 
@@ -329,7 +333,7 @@ function initFilterGroup(
     allCheckboxes.forEach((input) => (input.checked = false));
     updateCheckboxStats(accordionState, accordionElements.fieldSet);
     filterManager.update({
-      [params.filterStateKey]: [],
+      [params.filterStateKey]: new Set(),
     });
   });
 

--- a/tests/app/FilterState.test.ts
+++ b/tests/app/FilterState.test.ts
@@ -9,16 +9,16 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
     searchInput: null,
     policyTypeFilter: "any parking reform",
     allMinimumsRemovedToggle: false,
-    includedPolicyChanges: [
+    includedPolicyChanges: new Set([
       "add parking maximums",
       "reduce parking minimums",
       "remove parking minimums",
-    ],
-    scope: ["citywide", "city center / business district"],
-    landUse: ["all uses", "commercial", "other"],
-    status: ["implemented", "passed"],
-    country: ["United States", "Brazil"],
-    year: ["2023", "2024"],
+    ]),
+    scope: new Set(["citywide", "city center / business district"]),
+    landUse: new Set(["all uses", "commercial", "other"]),
+    status: new Set(["implemented", "passed"]),
+    country: new Set(["United States", "Brazil"]),
+    year: new Set(["2023", "2024"]),
     populationSliderIndexes: [0, POPULATION_MAX_INDEX],
   };
 
@@ -105,7 +105,12 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
     });
 
     // The below filters should have no impact.
-    manager.update({ scope: [], landUse: [], status: [], year: [] });
+    manager.update({
+      scope: new Set(),
+      landUse: new Set(),
+      status: new Set(),
+      year: new Set(),
+    });
     expect(manager.matchedPolicyRecords).toEqual({
       "Place 1": { rmMinIdx: [], reduceMinIdx: [], addMaxIdx: [] },
       "Place 2": { rmMinIdx: [], reduceMinIdx: [], addMaxIdx: [] },
@@ -119,7 +124,9 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
       allMinimumsRemovedToggle: DEFAULT_STATE.allMinimumsRemovedToggle,
     });
 
-    manager.update({ includedPolicyChanges: ["reduce parking minimums"] });
+    manager.update({
+      includedPolicyChanges: new Set(["reduce parking minimums"]),
+    });
     expect(manager.matchedPolicyRecords).toEqual({
       "Place 1": { rmMinIdx: [], reduceMinIdx: [], addMaxIdx: [] },
     });
@@ -127,7 +134,7 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
       includedPolicyChanges: DEFAULT_STATE.includedPolicyChanges,
     });
 
-    manager.update({ country: ["United States"] });
+    manager.update({ country: new Set(["United States"]) });
     expect(manager.matchedPolicyRecords).toEqual({
       "Place 1": { rmMinIdx: [], reduceMinIdx: [], addMaxIdx: [] },
     });
@@ -149,25 +156,25 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
       // This option should be ignored with 'reduce parking minimums'.
       allMinimumsRemovedToggle: true,
       // Should be ignored.
-      includedPolicyChanges: [],
+      includedPolicyChanges: new Set(),
     });
     expect(manager.matchedPolicyRecords).toEqual({
       "Place 1": { rmMinIdx: [], reduceMinIdx: [0], addMaxIdx: [] },
     });
 
-    manager.update({ scope: ["city center / business district"] });
+    manager.update({ scope: new Set(["city center / business district"]) });
     expect(manager.matchedPolicyRecords).toEqual({});
     manager.update({ scope: DEFAULT_STATE.scope });
 
-    manager.update({ landUse: ["commercial"] });
+    manager.update({ landUse: new Set(["commercial"]) });
     expect(manager.matchedPolicyRecords).toEqual({});
     manager.update({ landUse: DEFAULT_STATE.landUse });
 
-    manager.update({ status: ["repealed"] });
+    manager.update({ status: new Set(["repealed"]) });
     expect(manager.matchedPolicyRecords).toEqual({});
     manager.update({ status: DEFAULT_STATE.status });
 
-    manager.update({ year: ["2023"] });
+    manager.update({ year: new Set(["2023"]) });
     expect(manager.matchedPolicyRecords).toEqual({});
     manager.update({ year: DEFAULT_STATE.year });
   });
@@ -177,29 +184,29 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
       ...DEFAULT_STATE,
       policyTypeFilter: "add parking maximums",
       // Should be ignored.
-      includedPolicyChanges: [],
+      includedPolicyChanges: new Set(),
     });
     expect(manager.matchedPolicyRecords).toEqual({
       "Place 2": { rmMinIdx: [], reduceMinIdx: [], addMaxIdx: [0, 1] },
     });
 
-    manager.update({ scope: ["city center / business district"] });
+    manager.update({ scope: new Set(["city center / business district"]) });
     expect(manager.matchedPolicyRecords).toEqual({
       "Place 2": { rmMinIdx: [], reduceMinIdx: [], addMaxIdx: [0] },
     });
     manager.update({ scope: DEFAULT_STATE.scope });
 
-    manager.update({ landUse: ["commercial"] });
+    manager.update({ landUse: new Set(["commercial"]) });
     expect(manager.matchedPolicyRecords).toEqual({
       "Place 2": { rmMinIdx: [], reduceMinIdx: [], addMaxIdx: [0] },
     });
     manager.update({ landUse: DEFAULT_STATE.landUse });
 
-    manager.update({ status: ["repealed"] });
+    manager.update({ status: new Set(["repealed"]) });
     expect(manager.matchedPolicyRecords).toEqual({});
     manager.update({ status: DEFAULT_STATE.status });
 
-    manager.update({ year: ["2024"] });
+    manager.update({ year: new Set(["2024"]) });
     expect(manager.matchedPolicyRecords).toEqual({});
     manager.update({ year: DEFAULT_STATE.year });
 
@@ -218,25 +225,25 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
       ...DEFAULT_STATE,
       policyTypeFilter: "remove parking minimums",
       // Should be ignored.
-      includedPolicyChanges: [],
+      includedPolicyChanges: new Set(),
     });
     expect(manager.matchedPolicyRecords).toEqual({
       "Place 2": { rmMinIdx: [0], reduceMinIdx: [], addMaxIdx: [] },
     });
 
-    manager.update({ scope: ["city center / business district"] });
+    manager.update({ scope: new Set(["city center / business district"]) });
     expect(manager.matchedPolicyRecords).toEqual({});
     manager.update({ scope: DEFAULT_STATE.scope });
 
-    manager.update({ landUse: ["commercial"] });
+    manager.update({ landUse: new Set(["commercial"]) });
     expect(manager.matchedPolicyRecords).toEqual({});
     manager.update({ landUse: DEFAULT_STATE.landUse });
 
-    manager.update({ status: ["repealed"] });
+    manager.update({ status: new Set(["repealed"]) });
     expect(manager.matchedPolicyRecords).toEqual({});
     manager.update({ status: DEFAULT_STATE.status });
 
-    manager.update({ year: ["2024"] });
+    manager.update({ year: new Set(["2024"]) });
     expect(manager.matchedPolicyRecords).toEqual({});
     manager.update({ year: DEFAULT_STATE.year });
 
@@ -254,7 +261,7 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
     // Start with a state that does not match anything to prove that search overrides filters.
     const manager = new PlaceFilterManager(DEFAULT_ENTRIES, {
       ...DEFAULT_STATE,
-      country: [],
+      country: new Set(),
     });
     expect(manager.matchedPolicyRecords).toEqual({});
 

--- a/tests/app/counters.test.ts
+++ b/tests/app/counters.test.ts
@@ -8,16 +8,16 @@ test.describe("determineHtml", () => {
     searchInput: null,
     policyTypeFilter: "any parking reform",
     allMinimumsRemovedToggle: false,
-    includedPolicyChanges: [
+    includedPolicyChanges: new Set([
       "add parking maximums",
       "remove parking minimums",
       "reduce parking minimums",
-    ],
-    scope: [],
-    landUse: [],
-    status: [],
-    country: [],
-    year: [],
+    ]),
+    scope: new Set(),
+    landUse: new Set(),
+    status: new Set(),
+    country: new Set(),
+    year: new Set(),
     populationSliderIndexes: [0, 0],
   };
 
@@ -60,23 +60,32 @@ test.describe("determineHtml", () => {
     assertMapAndTable(
       {
         ...DEFAULT_STATE,
-        includedPolicyChanges: [
+        includedPolicyChanges: new Set([
           "reduce parking minimums",
           "remove parking minimums",
-        ],
+        ]),
       },
       "Showing 5 places in Mexico with parking minimums removed or parking minimums reduced",
     );
     assertMapAndTable(
-      { ...DEFAULT_STATE, includedPolicyChanges: ["remove parking minimums"] },
+      {
+        ...DEFAULT_STATE,
+        includedPolicyChanges: new Set(["remove parking minimums"]),
+      },
       "Showing 5 places in Mexico with parking minimums removed",
     );
     assertMapAndTable(
-      { ...DEFAULT_STATE, includedPolicyChanges: ["reduce parking minimums"] },
+      {
+        ...DEFAULT_STATE,
+        includedPolicyChanges: new Set(["reduce parking minimums"]),
+      },
       "Showing 5 places in Mexico with parking minimums reduced",
     );
     assertMapAndTable(
-      { ...DEFAULT_STATE, includedPolicyChanges: ["add parking maximums"] },
+      {
+        ...DEFAULT_STATE,
+        includedPolicyChanges: new Set(["add parking maximums"]),
+      },
       "Showing 5 places in Mexico with parking maximums added",
     );
 
@@ -91,7 +100,7 @@ test.describe("determineHtml", () => {
       {
         ...DEFAULT_STATE,
         allMinimumsRemovedToggle: true,
-        includedPolicyChanges: ["add parking maximums"],
+        includedPolicyChanges: new Set(["add parking maximums"]),
       },
       "Showing 5 places in Mexico with both all parking minimums removed and parking maximums added",
     );


### PR DESCRIPTION
Part of https://github.com/ParkingReformNetwork/reform-map/issues/593. This makes solid improvements to the speed of `PlaceFilterManager.ensureCache`.

However, note that the times were already pretty small to begin with. We need to diagnose what is causing the main slowdown in 593.

## Benchmark

Used this diff:

```diff
diff --git a/src/js/FilterState.ts b/src/js/FilterState.ts
index 90ce96a1..b4223b62 100644
--- a/src/js/FilterState.ts
+++ b/src/js/FilterState.ts
@@ -131,6 +131,7 @@ export class PlaceFilterManager {
     const matchedPolicyRecords: Record<PlaceId, MatchedPolicyRecords> = {};
     const matchedCountries = new Set<string>();
     let numMatchedPolicyRecords = 0;
+    console.time('ensureCache')
     for (const placeId in this.entries) {
       const matchedRecords = this.getMatchingPolicyRecords(placeId);
       if (!matchedRecords) continue;
@@ -141,6 +142,7 @@ export class PlaceFilterManager {
         matchedRecords.reduceMinIdx.length +
         matchedRecords.rmMinIdx.length;
     }
+    console.timeEnd('ensureCache')
 
     this.cache = {
       state: currentState,
```

Before:

[Debug] ensureCache: 1.724ms (localhost, line 44452)
[Debug] ensureCache: 12.185ms (localhost, line 44452)
[Debug] ensureCache: 6.808ms (localhost, line 44452)
[Debug] ensureCache: 12.381ms (localhost, line 44452)
[Debug] ensureCache: 6.007ms (localhost, line 44452)
[Debug] ensureCache: 10.614ms (localhost, line 44452)

After:

[Debug] ensureCache: 1.192ms (localhost, line 44452)
[Debug] ensureCache: 5.217ms (localhost, line 44452)
[Debug] ensureCache: 0.617ms (localhost, line 44452)
[Debug] ensureCache: 10.342ms (localhost, line 44452)
[Debug] ensureCache: 3.109ms (localhost, line 44452)
[Debug] ensureCache: 3.724ms (localhost, line 44452)
[Debug] ensureCache: 3.961ms (localhost, line 44452)
[Debug] ensureCache: 3.750ms (localhost, line 44452)
