### PR TITLE
Optimize Leaflet map markers

### DIFF
--- a/src/js/mapMarkers.ts
+++ b/src/js/mapMarkers.ts
@@ -43,16 +43,15 @@ export default function initPlaceMarkers(
   const placesToMarkers: Record<string, CircleMarker> = Object.entries(
     filterManager.entries,
   ).reduce((acc: Record<string, CircleMarker>, [placeId, entry]) => {
+    const [long, lat] = entry.place.coord;
     const isPrimary = entry.place.repeal;
     const style = isPrimary ? PRIMARY_MARKER_STYLE : SECONDARY_MARKER_STYLE;
-
-    const [long, lat] = entry.place.coord;
     const marker = new CircleMarker([lat, long], {
       ...style,
       radius: radiusGivenZoom({ zoom: map.getZoom(), isPrimary }),
     });
-
     marker.bindTooltip(placeId);
+
     acc[placeId] = marker;
     return acc;
   }, {});


### PR DESCRIPTION
Part of https://github.com/ParkingReformNetwork/reform-map/issues/593. DOM operations are expensive with Leaflet, so only add and remove entries when it's absolutely necessary.

Before:

[Debug] mapMarkers: 21.648ms (localhost, line 38737)
[Debug] mapMarkers: 11.689ms (localhost, line 38737)
[Debug] mapMarkers: 310.842ms (localhost, line 38737)
[Debug] mapMarkers: 28.006ms (localhost, line 38737)
[Debug] mapMarkers: 320.170ms (localhost, line 38737)
[Debug] mapMarkers: 23.577ms (localhost, line 38737)
[Debug] mapMarkers: 304.805ms (localhost, line 38737)
[Debug] mapMarkers: 19.426ms (localhost, line 38737)

After:

[Debug] mapMarkers: 4.816ms (localhost, line 38739)
[Debug] mapMarkers: 0.016ms (localhost, line 38739)
[Debug] mapMarkers: 64.560ms (localhost, line 38739)
[Debug] mapMarkers: 15.234ms (localhost, line 38739)
[Debug] mapMarkers: 49.887ms (localhost, line 38739)
[Debug] mapMarkers: 11.549ms (localhost, line 38739)
[Debug] mapMarkers: 42.215ms (localhost, line 38739)
