### PR TITLE
Make table and map updates lazy based on view

### DIFF
--- a/src/js/filterPopup.ts
+++ b/src/js/filterPopup.ts
@@ -12,7 +12,7 @@ function updateFilterPopupUI(isVisible: boolean): void {
 
 export default function initFilterPopup(): FilterPopupVisibleObservable {
   const isVisible = new Observable<boolean>("filter popup", false);
-  isVisible.subscribe(updateFilterPopupUI);
+  isVisible.subscribe(updateFilterPopupUI, "toggle filter popup");
 
   const popup = document.querySelector(".filter-popup");
   const icon = document.querySelector(".header-filter-icon-container");

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -10,7 +10,7 @@ import { FilterOptions, initFilterOptions } from "./filterOptions";
 import initFilterPopup from "./filterPopup";
 import { PlaceFilterManager, PolicyTypeFilter } from "./FilterState";
 import initCounters from "./counters";
-import initViewToggle from "./viewToggle";
+import { initViewToggle, addViewToggleSubscribers } from "./viewToggle";
 import initTable from "./table";
 import subscribeSnapToPlace from "./mapPosition";
 import readData from "./data";
@@ -39,6 +39,8 @@ export default async function initApp(): Promise<void> {
 
   const policyTypeFilter = policyTypeFilterFromUrl();
 
+  const viewToggle = initViewToggle();
+
   const map = createMap();
   const data = await readData({
     includeMultipleReforms: policyTypeFilter !== "legacy reform",
@@ -59,15 +61,15 @@ export default async function initApp(): Promise<void> {
     populationSliderIndexes: [0, POPULATION_MAX_INDEX],
   });
 
-  const markerGroup = initPlaceMarkers(filterManager, map);
+  const markerGroup = initPlaceMarkers(filterManager, map, viewToggle);
   subscribeSnapToPlace(filterManager, map);
   initCounters(filterManager);
   initSearch(filterManager);
   initFilterOptions(filterManager, filterOptions);
   initPopulationSlider(filterManager, filterPopupIsVisible);
 
-  const table = initTable(filterManager);
-  const viewToggle = initViewToggle(table);
+  const table = initTable(filterManager, viewToggle);
+  addViewToggleSubscribers(viewToggle, table);
 
   initScorecard(filterManager, viewToggle, markerGroup, data);
 

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -98,7 +98,7 @@ export function initPopulationSlider(
     if (isVisible) {
       updateSlidersUI(filterManager.getState());
     }
-  });
+  }, "render population slider");
 
   // Also update UI when values change, but only if the filter popup is open.
   filterManager.subscribe("update population sliders", (state) => {

--- a/src/js/viewToggle.ts
+++ b/src/js/viewToggle.ts
@@ -57,9 +57,15 @@ function updateOnIconClick(observable: ViewStateObservable): void {
   mapIcon.addEventListener("click", () => observable.setValue("map"));
 }
 
-export default function initViewToggle(table: Tabulator): ViewStateObservable {
+export function initViewToggle(): ViewStateObservable {
   const viewToggle = new Observable<ViewState>("view toggle", "map");
-  viewToggle.subscribe((state) => updateUI(table, state));
   updateOnIconClick(viewToggle);
   return viewToggle;
+}
+
+export function addViewToggleSubscribers(
+  observable: ViewStateObservable,
+  table: Tabulator,
+): void {
+  observable.subscribe((state) => updateUI(table, state), "switch app view");
 }


### PR DESCRIPTION
Makes major progress on https://github.com/ParkingReformNetwork/reform-map/issues/593. Now we only update the map and table if they are in view; else, we queue up the change.