### PR TITLE
Hide all minimums toggle when reduce is chosen

### DIFF
--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -366,23 +366,33 @@ function initFilterGroup(
 }
 
 function initAllMinimumsToggle(filterManager: PlaceFilterManager): void {
+  const outerContainer = document.createElement("div");
+
   const [label, input] = generateCheckbox(
     "filter-all-minimums-toggle",
     "filter-all-minimums-toggle",
     filterManager.getState().allMinimumsRemovedToggle,
     "Only places with all parking minimums removed",
   );
-  label.id = "filter-all-minimums-toggle-container";
+  label.id = "filter-all-minimums-toggle-label";
+  outerContainer.append(label);
 
   const filterPopup = document.getElementById("filter-popup");
   if (!filterPopup) return;
-  filterPopup.prepend(label);
+  filterPopup.prepend(outerContainer);
 
   input.addEventListener("change", () => {
     filterManager.update({
       allMinimumsRemovedToggle: input.checked,
     });
   });
+
+  filterManager.subscribe(
+    `possibly hide all minimums toggle`,
+    ({ policyTypeFilter }) => {
+      outerContainer.hidden = policyTypeFilter === "reduce parking minimums";
+    },
+  );
 }
 
 export function initFilterOptions(

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -127,7 +127,7 @@ for (const edgeCase of TESTS) {
     await deselectToggle(page);
 
     if (edgeCase.allMinimumsRemoved !== undefined) {
-      await page.locator("#filter-all-minimums-toggle-container").click();
+      await page.locator("#filter-all-minimums-toggle-label").click();
     }
 
     await selectIfSet(page, "scope", edgeCase.scope);

--- a/tests/app/utils.ts
+++ b/tests/app/utils.ts
@@ -39,5 +39,5 @@ export const assertNumPlaces = async (
 export const deselectToggle = async (page: Page): Promise<void> => {
   // Default has requirement toggle on, so first de-select it by opening filter pop-up and clicking toggle.
   await page.locator(".header-filter-icon-container").click();
-  await page.locator("#filter-all-minimums-toggle-container").click();
+  await page.locator("#filter-all-minimums-toggle-label").click();
 };


### PR DESCRIPTION
When the policy chosen is "reduce parking minimums", there is no point in showing the button "only places with all parking minimums repealed"

 
<img width="343" alt="Screenshot 2024-12-17 at 6 25 03 PM" src="https://github.com/user-attachments/assets/7f3b9407-1242-4194-954f-ba36a8ea5799" />
