### PR TITLE
Add bare-bones select for policy type

### DIFF
--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -395,11 +395,53 @@ function initAllMinimumsToggle(filterManager: PlaceFilterManager): void {
   );
 }
 
+function initPolicyTypeFilterDropdown(filterManager: PlaceFilterManager): void {
+  // Hide the dropdown if on the legacy app.
+  if (filterManager.getState().policyTypeFilter === "legacy reform") return;
+
+  const id = "filter-policy-type-dropdown";
+
+  const container = document.createElement("div");
+
+  const label = document.createElement("label");
+  label.htmlFor = id;
+  label.textContent = "Policy type:";
+
+  const select = document.createElement("select");
+  select.id = id;
+  select.name = id;
+
+  const options: PolicyTypeFilter[] = [
+    "any parking reform",
+    "add parking maximums",
+    "reduce parking minimums",
+    "remove parking minimums",
+  ];
+  options.forEach((option) => {
+    const element = document.createElement("option");
+    element.value = option;
+    element.textContent = capitalize(option);
+    select.append(element);
+  });
+
+  select.addEventListener("change", () => {
+    const policyTypeFilter = select.value as PolicyTypeFilter;
+    filterManager.update({ policyTypeFilter });
+  });
+
+  const filterPopup = document.getElementById("filter-popup");
+  if (!filterPopup) return;
+  container.append(label);
+  container.append(select);
+  filterPopup.prepend(container);
+}
+
 export function initFilterOptions(
   filterManager: PlaceFilterManager,
   filterOptions: FilterOptions,
 ): void {
   initAllMinimumsToggle(filterManager);
+  initPolicyTypeFilterDropdown(filterManager);
 
   initFilterGroup(filterManager, filterOptions, {
     htmlName: "policy-change",

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -8,27 +8,16 @@ import initScorecard from "./scorecard";
 import { initPopulationSlider, POPULATION_MAX_INDEX } from "./populationSlider";
 import { FilterOptions, initFilterOptions } from "./filterOptions";
 import initFilterPopup from "./filterPopup";
-import { PlaceFilterManager, PolicyTypeFilter } from "./FilterState";
+import { PlaceFilterManager } from "./FilterState";
 import initCounters from "./counters";
 import { initViewToggle, addViewToggleSubscribers } from "./viewToggle";
 import initTable from "./table";
 import subscribeSnapToPlace from "./mapPosition";
 import readData from "./data";
 
-function policyTypeFilterFromUrl(): PolicyTypeFilter {
-  const typeParam = new URLSearchParams(window.location.search).get("type");
-  switch (typeParam) {
-    case "any":
-      return "any parking reform";
-    case "max":
-      return "add parking maximums";
-    case "rm":
-      return "remove parking minimums";
-    case "reduce":
-      return "reduce parking minimums";
-    default:
-      return "legacy reform";
-  }
+function isRevampEnabled(): boolean {
+  const param = new URLSearchParams(window.location.search).get("revamp");
+  return param !== null;
 }
 
 export default async function initApp(): Promise<void> {
@@ -37,20 +26,20 @@ export default async function initApp(): Promise<void> {
   initAbout();
   const filterPopupIsVisible = initFilterPopup();
 
-  const policyTypeFilter = policyTypeFilterFromUrl();
+  const revampEnabled = isRevampEnabled();
 
   const viewToggle = initViewToggle();
 
   const map = createMap();
   const data = await readData({
-    includeMultipleReforms: policyTypeFilter !== "legacy reform",
+    includeMultipleReforms: revampEnabled,
   });
 
   const filterOptions = new FilterOptions(Object.values(data));
 
   const filterManager = new PlaceFilterManager(data, {
     searchInput: null,
-    policyTypeFilter,
+    policyTypeFilter: revampEnabled ? "any parking reform" : "legacy reform",
     allMinimumsRemovedToggle: true,
     includedPolicyChanges: filterOptions.default("includedPolicyChanges"),
     scope: filterOptions.default("scope"),


### PR DESCRIPTION
You can now add `?revamp` to the URL for the filter to default to "any parking reform" & have a bare-bones dropdown to change the policy type.

<img width="330" alt="Screenshot 2024-12-17 at 8 16 18 PM" src="https://github.com/user-attachments/assets/13c482ca-750d-4d99-af93-77c448a9581b" />
<img width="271" alt="Screenshot 2024-12-17 at 8 16 31 PM" src="https://github.com/user-attachments/assets/1bc7d6a3-eaf9-4855-a21e-70b63f1a77d0" />

A follow up will style this element. This PR sets up all the filter logic.