### PR TITLE
Fix horizontal scroll in filter

### DIFF
--- a/src/css/_filter.scss
+++ b/src/css/_filter.scss
@@ -6,14 +6,17 @@
 @use "theme/zindex";
 @use "header";
 
-$filter-width: 310px;
+$filter-total-width: 310px;
+$filter-inner-width: calc(
+  $filter-total-width - (borders.$border-thickness * 2)
+);
 
 .filter-popup {
   position: fixed;
   right: spacing.$map-controls-margin-x;
   top: calc(header.$header-height + spacing.$map-controls-margin-top);
   z-index: zindex.$filter-popup;
-  width: $filter-width;
+  width: $filter-total-width;
 
   max-height: min(600px, 75vh);
   overflow-y: auto;

--- a/src/css/_population-slider.scss
+++ b/src/css/_population-slider.scss
@@ -17,8 +17,10 @@ $thumbsize: icons.$icon-size-md;
   flex-direction: column;
   align-items: center;
 
-  // `width` must be hardcoded for the calculations in populationSlider.tss to work.
-  width: calc(filter.$filter-width - (spacing.$container-edge-spacing * 2));
+  // `width` must be hardcoded for the calculations in populationSlider.ts to work.
+  width: calc(
+    filter.$filter-inner-width - (spacing.$container-edge-spacing * 2)
+  );
   margin: spacing.$element-gap spacing.$container-edge-spacing;
 }
 


### PR DESCRIPTION
On Chrome, there was horizontal scroll because the population slider was 2px too wide due to not accounting for the filter border.