### PR TITLE
Move population to an accordion

### DIFF
--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -8,7 +8,6 @@ import {
   UNKNOWN_YEAR,
 } from "./FilterState";
 import Observable from "./Observable";
-import { FilterPopupVisibleObservable } from "./filterPopup";
 import { initPopulationSlider } from "./populationSlider";
 
 // Keep in alignment with FilterState.
@@ -102,7 +101,7 @@ export interface AccordionState {
   supplementalTitle?: string;
 }
 
-function updateAccordionUI(
+export function updateAccordionUI(
   elements: BaseAccordionElements,
   title: string,
   state: AccordionState,
@@ -215,6 +214,7 @@ export function generateAccordion(htmlName: string): BaseAccordionElements {
   contentContainer.id = contentId;
   contentContainer.className = "filter-accordion-content";
   contentContainer.setAttribute("aria-describedby", titleId);
+  outerContainer.appendChild(contentContainer);
 
   return {
     outerContainer,
@@ -232,6 +232,7 @@ function generateAccordionForFilterGroup(
 
   const fieldSet = document.createElement("fieldset");
   fieldSet.className = `filter-${params.htmlName}`;
+  baseElements.contentContainer.appendChild(fieldSet);
 
   const groupSelectorButtons = document.createElement("div");
   groupSelectorButtons.className = "filter-group-selectors-container";
@@ -268,9 +269,6 @@ function generateAccordionForFilterGroup(
     );
     filterOptionsContainer.appendChild(label);
   });
-
-  baseElements.contentContainer.appendChild(fieldSet);
-  baseElements.outerContainer.appendChild(baseElements.contentContainer);
 
   const elements = {
     ...baseElements,
@@ -447,7 +445,6 @@ function initPolicyTypeFilterDropdown(
 export function initFilterOptions(
   filterManager: PlaceFilterManager,
   filterOptions: FilterOptions,
-  filterPopupIsVisible: FilterPopupVisibleObservable,
 ): void {
   // Note that the order of this function determines the order of the filter.
   const filterPopup = document.querySelector<HTMLFormElement>("#filter-popup");
@@ -455,7 +452,7 @@ export function initFilterOptions(
 
   initPolicyTypeFilterDropdown(filterManager, filterPopup);
   initAllMinimumsToggle(filterManager, filterPopup);
-  initPopulationSlider(filterManager, filterPopupIsVisible, filterPopup);
+  initPopulationSlider(filterManager, filterPopup);
 
   initFilterGroup(filterManager, filterOptions, filterPopup, {
     htmlName: "policy-change",

--- a/src/js/filterPopup.ts
+++ b/src/js/filterPopup.ts
@@ -1,7 +1,5 @@
 import Observable from "./Observable";
 
-export type FilterPopupVisibleObservable = Observable<boolean>;
-
 function updateFilterPopupUI(isVisible: boolean): void {
   const popup = document.querySelector<HTMLElement>(".filter-popup");
   const icon = document.querySelector(".header-filter-icon-container");
@@ -10,7 +8,7 @@ function updateFilterPopupUI(isVisible: boolean): void {
   icon.ariaExpanded = isVisible.toString();
 }
 
-export default function initFilterPopup(): FilterPopupVisibleObservable {
+export default function initFilterPopup(): void {
   const isVisible = new Observable<boolean>("filter popup", false);
   isVisible.subscribe(updateFilterPopupUI, "toggle filter popup");
 
@@ -34,5 +32,5 @@ export default function initFilterPopup(): FilterPopupVisibleObservable {
     }
   });
 
-  return isVisible;
+  isVisible.initialize();
 }

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -24,7 +24,7 @@ export default async function initApp(): Promise<void> {
   initIcons();
   maybeDisableFullScreenIcon();
   initAbout();
-  const filterPopupIsVisible = initFilterPopup();
+  initFilterPopup();
 
   const revampEnabled = isRevampEnabled();
 
@@ -54,7 +54,7 @@ export default async function initApp(): Promise<void> {
   subscribeSnapToPlace(filterManager, map);
   initCounters(filterManager);
   initSearch(filterManager);
-  initFilterOptions(filterManager, filterOptions, filterPopupIsVisible);
+  initFilterOptions(filterManager, filterOptions);
 
   const table = initTable(filterManager, viewToggle);
   addViewToggleSubscribers(viewToggle, table);
@@ -62,6 +62,5 @@ export default async function initApp(): Promise<void> {
   initScorecard(filterManager, viewToggle, markerGroup, data);
 
   viewToggle.initialize();
-  filterPopupIsVisible.initialize();
   filterManager.initialize();
 }

--- a/src/js/populationSlider.ts
+++ b/src/js/populationSlider.ts
@@ -1,5 +1,10 @@
-import { FilterPopupVisibleObservable } from "./filterPopup";
+import {
+  AccordionState,
+  generateAccordion,
+  updateAccordionUI,
+} from "./filterOptions";
 import { PlaceFilterManager, POPULATION_INTERVALS } from "./FilterState";
+import Observable from "./Observable";
 
 const THUMBSIZE = 24;
 export const POPULATION_MAX_INDEX = POPULATION_INTERVALS.length - 1;
@@ -11,7 +16,21 @@ interface Sliders {
   readonly right: HTMLInputElement;
 }
 
-function generateSliders(filterPopup: HTMLFormElement): Sliders {
+function determineAccordionDescription(
+  populationSliderIndexes: [number, number],
+): string {
+  const [leftIndex, rightIndex] = populationSliderIndexes;
+  const leftLabel = POPULATION_INTERVALS[leftIndex][0];
+  const rightLabel = POPULATION_INTERVALS[rightIndex][0];
+  return ` (${leftLabel}-${rightLabel})`;
+}
+
+function generateSliders(
+  initialPopulationSliderIndexes: [number, number],
+  filterPopup: HTMLFormElement,
+): [Sliders, Observable<AccordionState>] {
+  const accordionElements = generateAccordion("population-slider");
+
   const container = document.createElement("div");
   container.className = "population-slider-container";
 
@@ -42,14 +61,40 @@ function generateSliders(filterPopup: HTMLFormElement): Sliders {
   right.min = "0";
   controls.append(right);
 
-  filterPopup.append(container);
+  // const populationSliderIndexes = filterMa
+  const accordionState = new Observable<AccordionState>(
+    `filter accordion population`,
+    {
+      hidden: false,
+      expanded: false,
+      supplementalTitle: determineAccordionDescription(
+        initialPopulationSliderIndexes,
+      ),
+    },
+  );
+  accordionState.subscribe((state) =>
+    updateAccordionUI(accordionElements, "Population", state),
+  );
+  accordionElements.accordionButton.addEventListener("click", () => {
+    const priorState = accordionState.getValue();
+    accordionState.setValue({
+      ...priorState,
+      expanded: !priorState.expanded,
+    });
+  });
 
-  return {
-    controls,
-    label,
-    left,
-    right,
-  };
+  accordionElements.contentContainer.append(container);
+  filterPopup.append(accordionElements.outerContainer);
+
+  return [
+    {
+      controls,
+      label,
+      left,
+      right,
+    },
+    accordionState,
+  ];
 }
 
 function updateSlidersUI(
@@ -90,15 +135,17 @@ function updateSlidersUI(
 
 export function initPopulationSlider(
   filterManager: PlaceFilterManager,
-  filterPopupIsVisible: FilterPopupVisibleObservable,
   filterPopup: HTMLFormElement,
 ): void {
-  const sliders = generateSliders(filterPopup);
+  const populationSliderIndexes =
+    filterManager.getState().populationSliderIndexes;
+  const [sliders, accordionStateObservable] = generateSliders(
+    populationSliderIndexes,
+    filterPopup,
+  );
 
   // Set initial state.
-  const maxIndex = filterManager
-    .getState()
-    .populationSliderIndexes[1].toString();
+  const maxIndex = populationSliderIndexes[1].toString();
   sliders.left.setAttribute("max", maxIndex);
   sliders.right.setAttribute("max", maxIndex);
   sliders.right.setAttribute("value", maxIndex);
@@ -112,10 +159,10 @@ export function initPopulationSlider(
   sliders.left.addEventListener("input", onChange);
   sliders.right.addEventListener("input", onChange);
 
-  // Update UI whenever filter popup is visible. Note that
-  // the popup must be visible for the width calculations to work.
-  filterPopupIsVisible.subscribe((isVisible) => {
-    if (isVisible) {
+  // Update UI whenever accordion is expanded. Note that the accordion
+  // must be visible for the width calculations to work.
+  accordionStateObservable.subscribe(({ hidden }) => {
+    if (!hidden) {
       updateSlidersUI(
         filterManager.getState().populationSliderIndexes,
         sliders,
@@ -123,9 +170,20 @@ export function initPopulationSlider(
     }
   }, "render population slider");
 
-  // Also update UI when values change, but only if the filter popup is open.
+  // Also update UI when values change
   filterManager.subscribe("update population sliders", (state) => {
-    if (!filterPopupIsVisible.getValue()) return;
-    updateSlidersUI(state.populationSliderIndexes, sliders);
+    const accordionPriorState = accordionStateObservable.getValue();
+    accordionStateObservable.setValue({
+      ...accordionPriorState,
+      supplementalTitle: determineAccordionDescription(
+        state.populationSliderIndexes,
+      ),
+    });
+
+    if (!accordionStateObservable.getValue().hidden) {
+      updateSlidersUI(state.populationSliderIndexes, sliders);
+    }
   });
+
+  accordionStateObservable.initialize();
 }

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -139,6 +139,7 @@ for (const edgeCase of TESTS) {
 
     if (edgeCase.populationIntervals !== undefined) {
       const [leftInterval, rightInterval] = edgeCase.populationIntervals;
+      await page.locator("#filter-accordion-toggle-population-slider").click();
       await page
         .locator(".population-slider-left")
         .fill(leftInterval.toString());


### PR DESCRIPTION
This creates much better information hierarchy with the revamp of the app. The top two inputs dramatically change how the entire app works (reflected in the counters), whereas everything underneath it is secondary.

<img width="340" alt="Screenshot 2024-12-18 at 8 45 29 AM" src="https://github.com/user-attachments/assets/90556526-d6bb-48a9-adc8-d9bc4c1b1a8f" />
<img width="323" alt="Screenshot 2024-12-18 at 8 45 52 AM" src="https://github.com/user-attachments/assets/bbd715b3-d29f-469f-98b9-a6b17ee017de" />

A follow-up will reorder the options.

This also simplifies `FilterPopupVisibleObservable` - we no longer need to track globally if the entire filter popup is visible because we can simply track if the accordion is visible. On initial load, the accordion can only be opened up the first time when the filter popup is open. After the initial load, the population slider values can only change when the accordion is visible, meaning the filter popup is visible. 