### PR TITLE
Fix height of year checkbox

### DIFF
--- a/src/css/_filter.scss
+++ b/src/css/_filter.scss
@@ -176,6 +176,10 @@ $filter-inner-width: calc(
   .filter-checkbox {
     min-width: calc(50% - spacing.$element-gap / 2);
     margin: 0;
+
+    &:nth-last-child(2) {
+      margin-bottom: spacing.$container-edge-spacing;
+    }
   }
 }
 


### PR DESCRIPTION
Without this, the height was 59px rather than 44px for the left column's last checkbox in two column layouts.