### PR TITLE
Fix bug with unknown year

### DIFF
--- a/src/js/FilterState.ts
+++ b/src/js/FilterState.ts
@@ -9,7 +9,7 @@ import {
 import Observable from "./Observable";
 import { determinePolicyTypes, getFilteredIndexes } from "./data";
 
-export const UNKNOWN_YEAR = "Unknown";
+export const UNKNOWN_YEAR = "unknown";
 
 export const POPULATION_INTERVALS: Array<[string, number]> = [
   ["100", 100],


### PR DESCRIPTION
This broke because of `preserveCapitalization` behavior: we were setting the data in `FilterState.ts` to be `Unknown` but `filterOptions.ts` had the value as `unknown`.