### PR TITLE
Change test strategy for HTML pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ We write our code in TypeScript. The types are ignored when starting the server 
 ❯ npm test
 ```
 
-If the tests are taking a long time to start, run `rm -rf .parcel-cache` and try the tests again.
+If the tests are taking a long time to start or have unexpected failures, run `rm -rf .parcel-cache` and try the tests again.
 
 ### Autoformat code
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "parcel",
     "build": "rm -rf dist; parcel build --detailed-report",
-    "test": "playwright test",
+    "test": "npm run gen-html; playwright test",
     "check": "tsc --noEmit",
     "fmt": "prettier --write .",
     "fix": "prettier --write .; eslint --fix scripts/  tests/",

--- a/tests/scripts/generateHtmlPages.test.ts
+++ b/tests/scripts/generateHtmlPages.test.ts
@@ -1,10 +1,6 @@
-import { expect, test } from "@playwright/test";
+import { readFile } from "fs/promises";
 
-import {
-  loadTemplate,
-  renderHandlebars,
-} from "../../scripts/generateHtmlPages";
-import { Date } from "../../src/js/types";
+import { expect, test } from "@playwright/test";
 
 // This test uses snapshot testing (https://jestjs.io/docs/snapshot-testing#updating-snapshots). If the tests fail and the changes
 // are valid, run `npm test -- --updateSnapshot`.
@@ -16,64 +12,13 @@ test("generate html page", async ({}, testInfo) => {
   // eslint-disable-next-line no-param-reassign
   testInfo.snapshotSuffix = "";
 
-  const template = await loadTemplate();
-  const result = renderHandlebars(
-    "My City, NY",
-    {
-      place: {
-        name: "My City",
-        state: "NY",
-        country: "US",
-        repeal: true,
-        pop: 24104,
-        coord: [44.23, 14.23],
-        url: "https://parkingreform.org/my-city-details.html",
-      },
-      unifiedPolicy: {
-        summary: "No parking mandates for the win!",
-        status: "passed",
-        policy: ["reduce parking minimums", "add parking maximums"],
-        scope: ["citywide"],
-        land: ["commercial", "other"],
-        date: new Date("2018-03-27"),
-        reporter: "Parking God",
-        requirements: ["by right"],
-        citations: [
-          {
-            description: "Zoning Code",
-            type: "city code",
-            url: "https://parkingreform.org/some-url.pdf",
-            notes: "Here's a note",
-            attachments: [
-              {
-                fileName: "MyCity_NY_1_1.png",
-                directusId: "abc-af-ac",
-                isDoc: false,
-              },
-            ],
-          },
-          {
-            description: "News article",
-            type: "media report",
-            url: "https://parkingreform.org/some-other-url.pdf",
-            notes: "",
-            attachments: [
-              {
-                fileName: "MyCity_NY_2_1.png",
-                directusId: "abc-af-ac",
-                isDoc: false,
-              },
-              {
-                fileName: "MyCity_NY_2_2.pdf",
-                directusId: "abc-af-ac",
-                isDoc: true,
-              },
-            ],
-          },
-        ],
-      },
-    },
-    template,
-  );
-  expect(result).toMatchSnapshot("page.html");
+  const assertPlace = async (normalizedPlaceId: string): Promise<void> => {
+    const content = await readFile(`city_detail/${normalizedPlaceId}.html`);
+    const snapshotName = normalizedPlaceId.toLowerCase().replace("_", "-")
+    expect(content).toMatchSnapshot(`${snapshotName}.html`);
+  };
+
+  await assertPlace("Abilene_TX");
+  await assertPlace("Abbottstown_PA");
+  await assertPlace("Basalt_CO");
 });

--- a/tests/scripts/generateHtmlPages.test.ts
+++ b/tests/scripts/generateHtmlPages.test.ts
@@ -14,7 +14,7 @@ test("generate html page", async ({}, testInfo) => {
 
   const assertPlace = async (normalizedPlaceId: string): Promise<void> => {
     const content = await readFile(`city_detail/${normalizedPlaceId}.html`);
-    const snapshotName = normalizedPlaceId.toLowerCase().replace("_", "-")
+    const snapshotName = normalizedPlaceId.toLowerCase().replace("_", "-");
     expect(content).toMatchSnapshot(`${snapshotName}.html`);
   };
 

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
+      crossorigin="anonymous"
+    />
+    <style>
+      body { background-color: #20c9c9; background-image: url("bg-photo.jpg");
+      background-position: center center; background-repeat: no-repeat;
+      background-attachment: fixed; background-size: cover; } main { word-break:
+      break-word; width: calc(100% - 2rem); background-color: white; }
+      .site-header { background-color: #4d4d4d; color: white; } .all-caps-link {
+      display: inline-block; text-transform: uppercase; text-decoration-line:
+      none; color: unset; } .all-caps-link:hover { color: unset; } .attachment +
+      .attachment { margin-top: 3rem; } .button { background-color: #21ccb9;
+      border: none; color: white; padding: 7px 16px; text-align: center;
+      text-decoration: none; display: inline-block; font-size: 16px; }
+    </style>
+    <title>Parking Reform Network - Reforms in Abbottstown, PA</title>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-5MFS4ZVMY3"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || []; function
+      gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config',
+      'G-5MFS4ZVMY3');
+    </script>
+  </head>
+  <body>
+    <header class="site-header container-fluid">
+      <h1 class="p-2">
+        <a class="p-1 all-caps-link" href="https://parkingreform.org">
+          Parking Reform Network
+        </a>
+      </h1>
+    </header>
+    <main class="container-md p-3 p-sm-4 mt-3 mt-sm-4 mt-md-5 col-11 col-md-9">
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-sm-8">
+            <header>
+              <h1 class="display-3">Abbottstown, PA</h1>
+            </header>
+          </div>
+          <div class="col-sm-4" align="center">
+            <span class="display-8">Support this project with a donation</span>
+            <script
+            >gl=document.createElement('script');gl.src='https://secure.givelively.org/widgets/simple_donation/parking-reform-network.js?show_suggested_amount_buttons=false&show_in_honor_of=false&address_required=false&has_required_custom_question=null&prefilled_donation_amount=25';document.getElementsByTagName('head')[0].appendChild(gl);</script><div
+              id="give-lively-widget"
+              class="gl-simple-donation-widget"
+            ></div>
+          </div>
+        </div>
+      </div>
+      <hr />
+      <h2>Summary</h2>
+      <p class="lead">Parking requirements may be reduced through on-street parking, public parking and proximity to transit. Parking maximums are set at 110% of the minimums for nonresidential uses.</p>
+      <hr />
+      <dl class="row">
+        <dt class="col-12 col-sm-4 col-lg-3">Implementation status</dt>
+        <dd class="col-12 col-sm-8 col-lg-9">implemented</dd>
+        <dt class="col-12 col-sm-4 col-lg-3">Reform type</dt>
+        <dd class="col-12 col-sm-8 col-lg-9">add parking maximums; reduce parking minimums</dd>
+        <dt class="col-12 col-sm-4 col-lg-3">Land uses</dt>
+        <dd class="col-12 col-sm-8 col-lg-9">all uses; commercial; industrial; other; residential, multi-family</dd>
+        <dt class="col-12 col-sm-4 col-lg-3">Scope of reform</dt>
+        <dd class="col-12 col-sm-8 col-lg-9">citywide</dd>
+        <dt class="col-12 col-sm-4 col-lg-3">Requirements</dt>
+        <dd class="col-12 col-sm-8 col-lg-9">frequent transit; other</dd>
+        <dt class="col-12 col-sm-4 col-lg-3">Reporter</dt>
+        <dd class="col-12 col-sm-8 col-lg-9">Samuel Deetz</dd>
+      </dl>
+        <section class="my-3">
+          <header>
+            <h2>Citation 1</h2>
+          </header>
+          <dl class="row">
+            <dt class="col-12 col-sm-4 col-lg-3">Source description</dt>
+            <dd class="col-12 col-sm-8 col-lg-9">Abbottstown Zoning Code</dd>
+            <dt class="col-12 col-sm-4 col-lg-3">Type</dt>
+            <dd class="col-12 col-sm-8 col-lg-9">city code</dd>
+            <dt class="col-12 col-sm-4 col-lg-3">URL</dt>
+            <dd class="col-12 col-sm-8 col-lg-9"><a
+                target="_blank"
+                href="https://ecode360.com/33754474#33754521"
+              >https://ecode360.com/33754474#33754521</a></dd>
+            <dt class="col-12 col-sm-4 col-lg-3">Notes</dt>
+            <dd class="col-12 col-sm-8 col-lg-9">§ 204-49Maximum number of parking spaces.
+§ 204-50Parking space reductions.</dd>
+          </dl>
+            <h3>Attachments and screenshots</h3>
+            <ul class="mt-4 list-unstyled">
+                <li class="attachment">
+                    <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/09f7dee6-0d7e-4c17-9dbc-eba33fa75c23/Abbottstown_PA_1_1.png" />
+                </li>
+                <li class="attachment">
+                    <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/3cd722d2-bedb-4660-99c4-fc851b126c80/Abbottstown_PA_1_2.png" />
+                </li>
+            </ul>
+        </section>
+    </main>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ"
+      crossorigin="anonymous"
+    ></script>
+  </body>
+</html>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
+      crossorigin="anonymous"
+    />
+    <style>
+      body { background-color: #20c9c9; background-image: url("bg-photo.jpg");
+      background-position: center center; background-repeat: no-repeat;
+      background-attachment: fixed; background-size: cover; } main { word-break:
+      break-word; width: calc(100% - 2rem); background-color: white; }
+      .site-header { background-color: #4d4d4d; color: white; } .all-caps-link {
+      display: inline-block; text-transform: uppercase; text-decoration-line:
+      none; color: unset; } .all-caps-link:hover { color: unset; } .attachment +
+      .attachment { margin-top: 3rem; } .button { background-color: #21ccb9;
+      border: none; color: white; padding: 7px 16px; text-align: center;
+      text-decoration: none; display: inline-block; font-size: 16px; }
+    </style>
+    <title>Parking Reform Network - Reforms in Abilene, TX</title>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-5MFS4ZVMY3"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || []; function
+      gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config',
+      'G-5MFS4ZVMY3');
+    </script>
+  </head>
+  <body>
+    <header class="site-header container-fluid">
+      <h1 class="p-2">
+        <a class="p-1 all-caps-link" href="https://parkingreform.org">
+          Parking Reform Network
+        </a>
+      </h1>
+    </header>
+    <main class="container-md p-3 p-sm-4 mt-3 mt-sm-4 mt-md-5 col-11 col-md-9">
+      <div class="container-fluid">
+        <div class="row">
+          <div class="col-sm-8">
+            <header>
+              <h1 class="display-3">Abilene, TX</h1>
+            </header>
+          </div>
+          <div class="col-sm-4" align="center">
+            <span class="display-8">Support this project with a donation</span>
+            <script
+            >gl=document.createElement('script');gl.src='https://secure.givelively.org/widgets/simple_donation/parking-reform-network.js?show_suggested_amount_buttons=false&show_in_honor_of=false&address_required=false&has_required_custom_question=null&prefilled_donation_amount=25';document.getElementsByTagName('head')[0].appendChild(gl);</script><div
+              id="give-lively-widget"
+              class="gl-simple-donation-widget"
+            ></div>
+          </div>
+        </div>
+      </div>
+      <hr />
+      <h2>Summary</h2>
+      <p class="lead">Existing buildings within the Central Business (CB) district are exempt from parking requirements. On-street parking may count towards minimums for new development in the district.</p>
+      <hr />
+      <dl class="row">
+        <dt class="col-12 col-sm-4 col-lg-3">Implementation status</dt>
+        <dd class="col-12 col-sm-8 col-lg-9">implemented</dd>
+        <dt class="col-12 col-sm-4 col-lg-3">Reform type</dt>
+        <dd class="col-12 col-sm-8 col-lg-9">reduce parking minimums</dd>
+        <dt class="col-12 col-sm-4 col-lg-3">Land uses</dt>
+        <dd class="col-12 col-sm-8 col-lg-9">all uses</dd>
+        <dt class="col-12 col-sm-4 col-lg-3">Scope of reform</dt>
+        <dd class="col-12 col-sm-8 col-lg-9">city center / business district</dd>
+        <dt class="col-12 col-sm-4 col-lg-3">Requirements</dt>
+        <dd class="col-12 col-sm-8 col-lg-9">other</dd>
+        <dt class="col-12 col-sm-4 col-lg-3">Reporter</dt>
+        <dd class="col-12 col-sm-8 col-lg-9">Samuel Deetz</dd>
+      </dl>
+        <section class="my-3">
+          <header>
+            <h2>Citation 1</h2>
+          </header>
+          <dl class="row">
+            <dt class="col-12 col-sm-4 col-lg-3">Source description</dt>
+            <dd class="col-12 col-sm-8 col-lg-9">Abilene Land Development Code</dd>
+            <dt class="col-12 col-sm-4 col-lg-3">Type</dt>
+            <dd class="col-12 col-sm-8 col-lg-9">city code</dd>
+            <dt class="col-12 col-sm-4 col-lg-3">URL</dt>
+            <dd class="col-12 col-sm-8 col-lg-9"><a
+                target="_blank"
+                href="https://library.municode.com/tx/abilene/codes/code_of_ordinances?nodeId&#x3D;PTIIIAPANDECO_CH4SIDERE_ART2DEST_DIV1PASTLO_S4.2.1.2GEPALORE"
+              >https://library.municode.com/tx/abilene/codes/code_of_ordinances?nodeId&#x3D;PTIIIAPANDECO_CH4SIDERE_ART2DEST_DIV1PASTLO_S4.2.1.2GEPALORE</a></dd>
+            <dt class="col-12 col-sm-4 col-lg-3">Notes</dt>
+            <dd class="col-12 col-sm-8 col-lg-9">CHAPTER 4: - SITE DEVELOPMENT REGULATIONS
+ARTICLE 2. - DEVELOPMENT STANDARDS
+DIVISION 1. - PARKING, STACKING AND LOADING
+Section 4.2.1.2 - General Parking and Loading Requirements
+(c)</dd>
+          </dl>
+            <h3>Attachments and screenshots</h3>
+            <ul class="mt-4 list-unstyled">
+                <li class="attachment">
+                    <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/73ca3464-9cb3-4c0c-b7be-1328f2376620/Abilene_TX_1_1.png" />
+                </li>
+            </ul>
+        </section>
+    </main>
+    <script
+      src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
+      integrity="sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ"
+      crossorigin="anonymous"
+    ></script>
+  </body>
+</html>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
@@ -21,7 +21,7 @@
       border: none; color: white; padding: 7px 16px; text-align: center;
       text-decoration: none; display: inline-block; font-size: 16px; }
     </style>
-    <title>Parking Reform Network - Reforms in My City, NY</title>
+    <title>Parking Reform Network - Reforms in Basalt, CO</title>
     <script
       async
       src="https://www.googletagmanager.com/gtag/js?id=G-5MFS4ZVMY3"
@@ -45,7 +45,7 @@
         <div class="row">
           <div class="col-sm-8">
             <header>
-              <h1 class="display-3">My City, NY</h1>
+              <h1 class="display-3">Basalt, CO</h1>
             </header>
           </div>
           <div class="col-sm-4" align="center">
@@ -60,21 +60,21 @@
       </div>
       <hr />
       <h2>Summary</h2>
-      <p class="lead">No parking mandates for the win!</p>
+      <p class="lead">Within the Downtown Parking Area, a fee in lieu of require parking may be provided for commercial or mixed-use developments. Within the CSC District, parking requirements are reduced and on-street parking may be used to satisfy requirements, while surface parking is prohibited in certain areas. Uses designated as landmarks have reduced parking requirements citywide.</p>
       <hr />
       <dl class="row">
         <dt class="col-12 col-sm-4 col-lg-3">Implementation status</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">passed</dd>
+        <dd class="col-12 col-sm-8 col-lg-9">implemented</dd>
         <dt class="col-12 col-sm-4 col-lg-3">Reform type</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">reduce parking minimums; add parking maximums</dd>
+        <dd class="col-12 col-sm-8 col-lg-9">add parking maximums; reduce parking minimums</dd>
         <dt class="col-12 col-sm-4 col-lg-3">Land uses</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">commercial; other</dd>
+        <dd class="col-12 col-sm-8 col-lg-9">commercial; other; residential, all uses</dd>
         <dt class="col-12 col-sm-4 col-lg-3">Scope of reform</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">citywide</dd>
+        <dd class="col-12 col-sm-8 col-lg-9">city center / business district; citywide</dd>
         <dt class="col-12 col-sm-4 col-lg-3">Requirements</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">by right</dd>
+        <dd class="col-12 col-sm-8 col-lg-9">by right; historic preservation; in-lieu fees; other</dd>
         <dt class="col-12 col-sm-4 col-lg-3">Reporter</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">Parking God</dd>
+        <dd class="col-12 col-sm-8 col-lg-9">Samuel Deetz</dd>
       </dl>
         <section class="my-3">
           <header>
@@ -82,48 +82,41 @@
           </header>
           <dl class="row">
             <dt class="col-12 col-sm-4 col-lg-3">Source description</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">Zoning Code</dd>
+            <dd class="col-12 col-sm-8 col-lg-9">Basalt Zoning Code</dd>
             <dt class="col-12 col-sm-4 col-lg-3">Type</dt>
             <dd class="col-12 col-sm-8 col-lg-9">city code</dd>
             <dt class="col-12 col-sm-4 col-lg-3">URL</dt>
             <dd class="col-12 col-sm-8 col-lg-9"><a
                 target="_blank"
-                href="https://parkingreform.org/some-url.pdf"
-              >https://parkingreform.org/some-url.pdf</a></dd>
+                href="https://library.municode.com/co/basalt/codes/municipal_code?nodeId&#x3D;CH16ZO_ARTVOREPALO_S16-94OTEPA"
+              >https://library.municode.com/co/basalt/codes/municipal_code?nodeId&#x3D;CH16ZO_ARTVOREPALO_S16-94OTEPA</a></dd>
             <dt class="col-12 col-sm-4 col-lg-3">Notes</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">Here&#x27;s a note</dd>
+            <dd class="col-12 col-sm-8 col-lg-9">ARTICLE II - District Regulations	
+  Sec. 16-30. - CSC Zone District.	
+    (e)(4)a.
+    (e)(4)b.
+    (e)(4)d.2.
+ARTICLE V - Off-Street Parking and Loading	
+  Sec. 16-94. - Off-site parking.	
+    (3)
+    (4)
+ARTICLE XVIII - Historic Preservation
+  Sec. 16-394. - Incentives.	
+    (a)</dd>
           </dl>
             <h3>Attachments and screenshots</h3>
             <ul class="mt-4 list-unstyled">
                 <li class="attachment">
-                    <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/abc-af-ac/MyCity_NY_1_1.png" />
-                </li>
-            </ul>
-        </section>
-        <section class="my-3">
-          <header>
-            <h2>Citation 2</h2>
-          </header>
-          <dl class="row">
-            <dt class="col-12 col-sm-4 col-lg-3">Source description</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">News article</dd>
-            <dt class="col-12 col-sm-4 col-lg-3">Type</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">media report</dd>
-            <dt class="col-12 col-sm-4 col-lg-3">URL</dt>
-            <dd class="col-12 col-sm-8 col-lg-9"><a
-                target="_blank"
-                href="https://parkingreform.org/some-other-url.pdf"
-              >https://parkingreform.org/some-other-url.pdf</a></dd>
-            <dt class="col-12 col-sm-4 col-lg-3">Notes</dt>
-            <dd class="col-12 col-sm-8 col-lg-9"></dd>
-          </dl>
-            <h3>Attachments and screenshots</h3>
-            <ul class="mt-4 list-unstyled">
-                <li class="attachment">
-                    <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/abc-af-ac/MyCity_NY_2_1.png" />
+                    <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/ec7446e9-8f65-4b86-a50f-ddadf0f95bd3/Basalt_CO_1_1.png" />
                 </li>
                 <li class="attachment">
-                    <a target="_blank" download="MyCity_NY_2_2.pdf" href="https://mandates-map.directus.app/assets/abc-af-ac/MyCity_NY_2_2.pdf?download">MyCity_NY_2_2.pdf</a>
+                    <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/71e17373-9617-4267-808c-cbec6c819c21/Basalt_CO_1_2.png" />
+                </li>
+                <li class="attachment">
+                    <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/3eb59336-56c1-4ca3-b01b-7064150b31ee/Basalt_CO_1_3.png" />
+                </li>
+                <li class="attachment">
+                    <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/b7ec147f-ad03-42bc-bf0e-c261f0cb0865/Basalt_CO_1_4.png" />
                 </li>
             </ul>
         </section>


### PR DESCRIPTION
We're migrating to Eleventy for HTML page generation rather than the custom script. Eleventy doesn't have a good way to generate based on test data, so we need to switch to testing actual pages.

Now that we test on real data, we need to use `npm run gen-html` before `npm test`. I considered splitting up a different `test-gen-html` command, but I think it's too complex and not worth it given that HTML page generation is really fast.