### PR TITLE
Extract CSS for details to dedicated file

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,3 @@
-scripts/11ty/
 city_detail/
 
 dist/

--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -1,11 +1,18 @@
 /** Config for Eleventy to generate the details pages. */
 
+// @ts-ignore
+import CleanCSS from "clean-css";
+
 import { readProcessedCompleteData } from "./scripts/lib/data.js";
 import { escapePlaceId } from "./src/js/data.js";
 
 export default async function (eleventyConfig: any) {
   eleventyConfig.setLiquidOptions({
     jsTruthy: true,
+  });
+
+  eleventyConfig.addFilter("cssmin", function (code: any) {
+    return new CleanCSS({}).minify(code).styles;
   });
 
   const completeData = await readProcessedCompleteData();

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "@types/tabulator-tables": "^6.2.3",
         "@typescript-eslint/eslint-plugin": "^7.18.0",
         "@typescript-eslint/parser": "^7.18.0",
+        "clean-css": "^5.3.3",
         "eslint": "^8.57.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-config-prettier": "^9.1.0",
@@ -14948,6 +14949,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.0"
+      }
+    },
+    "node_modules/clean-css": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/clean-css/-/clean-css-5.3.3.tgz",
+      "integrity": "sha512-D5J+kHaVb/wKSFcyyV75uCn8fiY4sV38XJoe4CUyGQ+mOU/fMVYUdH1hJC+CJQ5uY3EnW27SbJYS4X8BiLrAFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "~0.6.0"
+      },
+      "engines": {
+        "node": ">= 10.0"
       }
     },
     "node_modules/cli-progress": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@types/tabulator-tables": "^6.2.3",
     "@typescript-eslint/eslint-plugin": "^7.18.0",
     "@typescript-eslint/parser": "^7.18.0",
+    "clean-css": "^5.3.3",
     "eslint": "^8.57.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-config-prettier": "^9.1.0",

--- a/scripts/11ty/_includes/style.css
+++ b/scripts/11ty/_includes/style.css
@@ -1,0 +1,45 @@
+body {
+  background-color: #20c9c9;
+  background-image: url("bg-photo.jpg");
+  background-position: center center;
+  background-repeat: no-repeat;
+  background-attachment: fixed;
+  background-size: cover;
+}
+
+main {
+  word-break: break-word;
+  width: calc(100% - 2rem);
+  background-color: white;
+}
+
+.site-header {
+  background-color: #4d4d4d;
+  color: white;
+}
+
+.all-caps-link {
+  display: inline-block;
+  text-transform: uppercase;
+  text-decoration-line: none;
+  color: unset;
+}
+
+.all-caps-link:hover {
+  color: unset;
+}
+
+.attachment + .attachment {
+  margin-top: 3rem;
+}
+
+.button {
+  background-color: #21ccb9;
+  border: none;
+  color: white;
+  padding: 7px 16px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  font-size: 16px;
+}

--- a/scripts/11ty/template.liquid
+++ b/scripts/11ty/template.liquid
@@ -16,18 +16,8 @@ permalink: "{{ entry.escapedPlaceId }}.html"
       integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
       crossorigin="anonymous"
     />
-    <style>
-      body { background-color: #20c9c9; background-image: url("bg-photo.jpg");
-      background-position: center center; background-repeat: no-repeat;
-      background-attachment: fixed; background-size: cover; } main { word-break:
-      break-word; width: calc(100% - 2rem); background-color: white; }
-      .site-header { background-color: #4d4d4d; color: white; } .all-caps-link {
-      display: inline-block; text-transform: uppercase; text-decoration-line:
-      none; color: unset; } .all-caps-link:hover { color: unset; } .attachment +
-      .attachment { margin-top: 3rem; } .button { background-color: #21ccb9;
-      border: none; color: white; padding: 7px 16px; text-align: center;
-      text-decoration: none; display: inline-block; font-size: 16px; }
-    </style>
+    {% capture css -%} {% render "style.css" %} {%- endcapture -%}
+    <style>{{ css | cssmin }}</style>
     <title>Parking Reform Network - Reforms in {{ entry.placeId }}</title>
     <script
       async

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
@@ -9,18 +9,7 @@
       integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
       crossorigin="anonymous"
     />
-    <style>
-      body { background-color: #20c9c9; background-image: url("bg-photo.jpg");
-      background-position: center center; background-repeat: no-repeat;
-      background-attachment: fixed; background-size: cover; } main { word-break:
-      break-word; width: calc(100% - 2rem); background-color: white; }
-      .site-header { background-color: #4d4d4d; color: white; } .all-caps-link {
-      display: inline-block; text-transform: uppercase; text-decoration-line:
-      none; color: unset; } .all-caps-link:hover { color: unset; } .attachment +
-      .attachment { margin-top: 3rem; } .button { background-color: #21ccb9;
-      border: none; color: white; padding: 7px 16px; text-align: center;
-      text-decoration: none; display: inline-block; font-size: 16px; }
-    </style>
+    <style>body{background-color:#20c9c9;background-image:url("bg-photo.jpg");background-position:center center;background-repeat:no-repeat;background-attachment:fixed;background-size:cover}main{word-break:break-word;width:calc(100% - 2rem);background-color:#fff}.site-header{background-color:#4d4d4d;color:#fff}.all-caps-link{display:inline-block;text-transform:uppercase;text-decoration-line:none;color:unset}.all-caps-link:hover{color:unset}.attachment+.attachment{margin-top:3rem}.button{background-color:#21ccb9;border:none;color:#fff;padding:7px 16px;text-align:center;text-decoration:none;display:inline-block;font-size:16px}</style>
     <title>Parking Reform Network - Reforms in Abbottstown, PA</title>
     <script
       async

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
@@ -9,18 +9,7 @@
       integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
       crossorigin="anonymous"
     />
-    <style>
-      body { background-color: #20c9c9; background-image: url("bg-photo.jpg");
-      background-position: center center; background-repeat: no-repeat;
-      background-attachment: fixed; background-size: cover; } main { word-break:
-      break-word; width: calc(100% - 2rem); background-color: white; }
-      .site-header { background-color: #4d4d4d; color: white; } .all-caps-link {
-      display: inline-block; text-transform: uppercase; text-decoration-line:
-      none; color: unset; } .all-caps-link:hover { color: unset; } .attachment +
-      .attachment { margin-top: 3rem; } .button { background-color: #21ccb9;
-      border: none; color: white; padding: 7px 16px; text-align: center;
-      text-decoration: none; display: inline-block; font-size: 16px; }
-    </style>
+    <style>body{background-color:#20c9c9;background-image:url("bg-photo.jpg");background-position:center center;background-repeat:no-repeat;background-attachment:fixed;background-size:cover}main{word-break:break-word;width:calc(100% - 2rem);background-color:#fff}.site-header{background-color:#4d4d4d;color:#fff}.all-caps-link{display:inline-block;text-transform:uppercase;text-decoration-line:none;color:unset}.all-caps-link:hover{color:unset}.attachment+.attachment{margin-top:3rem}.button{background-color:#21ccb9;border:none;color:#fff;padding:7px 16px;text-align:center;text-decoration:none;display:inline-block;font-size:16px}</style>
     <title>Parking Reform Network - Reforms in Abilene, TX</title>
     <script
       async

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
@@ -9,18 +9,7 @@
       integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
       crossorigin="anonymous"
     />
-    <style>
-      body { background-color: #20c9c9; background-image: url("bg-photo.jpg");
-      background-position: center center; background-repeat: no-repeat;
-      background-attachment: fixed; background-size: cover; } main { word-break:
-      break-word; width: calc(100% - 2rem); background-color: white; }
-      .site-header { background-color: #4d4d4d; color: white; } .all-caps-link {
-      display: inline-block; text-transform: uppercase; text-decoration-line:
-      none; color: unset; } .all-caps-link:hover { color: unset; } .attachment +
-      .attachment { margin-top: 3rem; } .button { background-color: #21ccb9;
-      border: none; color: white; padding: 7px 16px; text-align: center;
-      text-decoration: none; display: inline-block; font-size: 16px; }
-    </style>
+    <style>body{background-color:#20c9c9;background-image:url("bg-photo.jpg");background-position:center center;background-repeat:no-repeat;background-attachment:fixed;background-size:cover}main{word-break:break-word;width:calc(100% - 2rem);background-color:#fff}.site-header{background-color:#4d4d4d;color:#fff}.all-caps-link{display:inline-block;text-transform:uppercase;text-decoration-line:none;color:unset}.all-caps-link:hover{color:unset}.attachment+.attachment{margin-top:3rem}.button{background-color:#21ccb9;border:none;color:#fff;padding:7px 16px;text-align:center;text-decoration:none;display:inline-block;font-size:16px}</style>
     <title>Parking Reform Network - Reforms in Basalt, CO</title>
     <script
       async


### PR DESCRIPTION
Uses this technique: https://www.11ty.dev/docs/quicktips/inline-css/. This allows us to have 1+ normal CSS files outside of the HTML page, while still inlining it in the final result. The inlining is useful for performance and to avoid any caching issues that the CSS file was cached incorrectly by the browser, given that we don't use a build tool like Parcel for the details pages.

The CSS file gets minified by `clean-css`, so we don't need to worry about using whitespace and comments in the source code.