### PR TITLE
Fix test-dist to not test scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "sync-directus": "tsx scripts/syncDirectus.ts",
     "broken-links": "tsx scripts/brokenLinks.ts",
     "serve-dist": "cd dist; http-server",
-    "test-dist": "PORT=8080 playwright test"
+    "test-dist": "PORT=8080 playwright test tests/app"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",


### PR DESCRIPTION
https://github.com/ParkingReformNetwork/reform-map/pull/644 broke `npm run test-dist` because the HTML pages were not being generated. It makes more sense to skip entirely testing the scripts folder.