### PR TITLE
Use bigger height for donate button on details page mobile

### DIFF
--- a/scripts/11ty/_includes/style.scss
+++ b/scripts/11ty/_includes/style.scss
@@ -85,13 +85,9 @@ $logo-height: 75px;
     color: hsl(0, 0%, 100%);
     text-decoration: none;
     display: flex;
-    height: $min-touch-target;
+    height: $logo-height;
     padding: 0 $spacing-element-gap;
     align-items: center;
-
-    @include breakpoints-gt-xs {
-      height: $logo-height;
-    }
 
     &:hover {
       background-color: hsl(0, 0%, 32%);

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
@@ -9,7 +9,7 @@
       integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
       crossorigin="anonymous"
     />
-    <style>main{word-break:break-word;width:calc(100% - 2rem)}.site-header{background-color:hsl(0,0%,25.88%);font-size:30px;padding:15px;display:flex;flex-direction:row;justify-content:space-between;align-items:center;border-bottom:4px solid #20c9b6}.site-header img{height:75px;cursor:pointer}.site-header-map-link{display:none}@media screen and (min-width:640px){.site-header-map-link{display:block}}.site-header-right ul{list-style:none;padding:0;margin:0;display:flex}.site-header-right a{color:#fff;text-decoration:none;display:flex;height:44px;padding:0 10px;align-items:center}@media screen and (min-width:640px){.site-header-right a{height:75px}}.site-header-right a:hover{background-color:#515151}.attachment+.attachment{margin-top:3rem}</style>
+    <style>main{word-break:break-word;width:calc(100% - 2rem)}.site-header{background-color:hsl(0,0%,25.88%);font-size:30px;padding:15px;display:flex;flex-direction:row;justify-content:space-between;align-items:center;border-bottom:4px solid #20c9b6}.site-header img{height:75px;cursor:pointer}.site-header-map-link{display:none}@media screen and (min-width:640px){.site-header-map-link{display:block}}.site-header-right ul{list-style:none;padding:0;margin:0;display:flex}.site-header-right a{color:#fff;text-decoration:none;display:flex;height:75px;padding:0 10px;align-items:center}.site-header-right a:hover{background-color:#515151}.attachment+.attachment{margin-top:3rem}</style>
     <title>Parking reforms in Abbottstown, PA | Parking Reform Network</title>
     <script
       async

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
@@ -9,7 +9,7 @@
       integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
       crossorigin="anonymous"
     />
-    <style>main{word-break:break-word;width:calc(100% - 2rem)}.site-header{background-color:hsl(0,0%,25.88%);font-size:30px;padding:15px;display:flex;flex-direction:row;justify-content:space-between;align-items:center;border-bottom:4px solid #20c9b6}.site-header img{height:75px;cursor:pointer}.site-header-map-link{display:none}@media screen and (min-width:640px){.site-header-map-link{display:block}}.site-header-right ul{list-style:none;padding:0;margin:0;display:flex}.site-header-right a{color:#fff;text-decoration:none;display:flex;height:44px;padding:0 10px;align-items:center}@media screen and (min-width:640px){.site-header-right a{height:75px}}.site-header-right a:hover{background-color:#515151}.attachment+.attachment{margin-top:3rem}</style>
+    <style>main{word-break:break-word;width:calc(100% - 2rem)}.site-header{background-color:hsl(0,0%,25.88%);font-size:30px;padding:15px;display:flex;flex-direction:row;justify-content:space-between;align-items:center;border-bottom:4px solid #20c9b6}.site-header img{height:75px;cursor:pointer}.site-header-map-link{display:none}@media screen and (min-width:640px){.site-header-map-link{display:block}}.site-header-right ul{list-style:none;padding:0;margin:0;display:flex}.site-header-right a{color:#fff;text-decoration:none;display:flex;height:75px;padding:0 10px;align-items:center}.site-header-right a:hover{background-color:#515151}.attachment+.attachment{margin-top:3rem}</style>
     <title>Parking reforms in Abilene, TX | Parking Reform Network</title>
     <script
       async

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
@@ -9,7 +9,7 @@
       integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
       crossorigin="anonymous"
     />
-    <style>main{word-break:break-word;width:calc(100% - 2rem)}.site-header{background-color:hsl(0,0%,25.88%);font-size:30px;padding:15px;display:flex;flex-direction:row;justify-content:space-between;align-items:center;border-bottom:4px solid #20c9b6}.site-header img{height:75px;cursor:pointer}.site-header-map-link{display:none}@media screen and (min-width:640px){.site-header-map-link{display:block}}.site-header-right ul{list-style:none;padding:0;margin:0;display:flex}.site-header-right a{color:#fff;text-decoration:none;display:flex;height:44px;padding:0 10px;align-items:center}@media screen and (min-width:640px){.site-header-right a{height:75px}}.site-header-right a:hover{background-color:#515151}.attachment+.attachment{margin-top:3rem}</style>
+    <style>main{word-break:break-word;width:calc(100% - 2rem)}.site-header{background-color:hsl(0,0%,25.88%);font-size:30px;padding:15px;display:flex;flex-direction:row;justify-content:space-between;align-items:center;border-bottom:4px solid #20c9b6}.site-header img{height:75px;cursor:pointer}.site-header-map-link{display:none}@media screen and (min-width:640px){.site-header-map-link{display:block}}.site-header-right ul{list-style:none;padding:0;margin:0;display:flex}.site-header-right a{color:#fff;text-decoration:none;display:flex;height:75px;padding:0 10px;align-items:center}.site-header-right a:hover{background-color:#515151}.attachment+.attachment{margin-top:3rem}</style>
     <title>Parking reforms in Basalt, CO | Parking Reform Network</title>
     <script
       async


### PR DESCRIPTION
Making the right side shorter was a holdover from an earlier iteration of the mobile header on the details pages, back when I split the header over two rows. The height should stay the same always.