### PR TITLE
Fix Sass deprecation about mixin order

### DIFF
--- a/src/css/_about.scss
+++ b/src/css/_about.scss
@@ -15,10 +15,6 @@
   margin-left: spacing.$map-controls-margin-x;
   margin-right: spacing.$map-controls-margin-x;
 
-  @include breakpoints.gt-sm {
-    margin-left: 10%;
-  }
-
   min-height: 50%;
   max-height: 70%;
   min-width: 200px;
@@ -35,6 +31,10 @@
 
   overflow-y: auto;
   overflow-wrap: break-word;
+
+  @include breakpoints.gt-sm {
+    margin-left: 10%;
+  }
 
   h3 {
     margin: 0;

--- a/src/css/_counters.scss
+++ b/src/css/_counters.scss
@@ -22,6 +22,12 @@
   padding: spacing.$element-gap spacing.$container-edge-spacing;
   min-height: calc($font-size * 2 + spacing.$element-gap * 2);
   width: 260px;
+
+  background-color: colors.$white;
+  color: colors.$black;
+  border: borders.$component-border;
+  border-radius: borders.$border-radius;
+
   @include breakpoints.gt-xxs {
     width: 280px;
   }
@@ -31,11 +37,6 @@
   @include breakpoints.gt-md {
     width: 340px;
   }
-
-  background-color: colors.$white;
-  color: colors.$black;
-  border: borders.$component-border;
-  border-radius: borders.$border-radius;
 }
 
 .table-counter-container {
@@ -44,13 +45,14 @@
   width: 100%;
 
   font-size: typography.$font-size-base;
-  @include breakpoints.gt-xs {
-    font-size: typography.$font-size-md;
-  }
 
   display: flex;
   align-items: center;
   justify-content: space-betwen;
+
+  @include breakpoints.gt-xs {
+    font-size: typography.$font-size-md;
+  }
 
   #table-counter {
     margin: 0;

--- a/src/css/_logo.scss
+++ b/src/css/_logo.scss
@@ -11,16 +11,17 @@
   // `bottom` is set so high to avoid covering the attribution
   // on small screens, since it wraps to two lines.
   bottom: 30px;
+
+  width: 80px;
+  @include breakpoints.gt-xxs {
+    width: 100px;
+  }
+
   @include breakpoints.gt-xs {
     bottom: 15px;
   }
   @include breakpoints.gt-sm {
     bottom: 0px;
-  }
-
-  width: 80px;
-  @include breakpoints.gt-xxs {
-    width: 100px;
   }
 
   img {

--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -18,17 +18,18 @@
 
   padding: spacing.$container-edge-spacing;
   width: 300px;
+
+  background-color: colors.$white;
+  border: borders.$component-border;
+  border-radius: borders.$border-radius;
+  color: colors.$black;
+
   @include breakpoints.gt-xxs {
     width: 340px;
   }
   @include breakpoints.gt-xs {
     width: 400px;
   }
-
-  background-color: colors.$white;
-  border: borders.$component-border;
-  border-radius: borders.$border-radius;
-  color: colors.$black;
 
   p,
   li {

--- a/src/css/_search.scss
+++ b/src/css/_search.scss
@@ -20,14 +20,15 @@ div.choices[data-type*="select-one"] {
 
     min-height: spacing.$min-touch-target;
     width: 260px;
-    @include breakpoints.gt-xxs {
-      width: 280px;
-    }
 
     border-top-left-radius: borders.$border-radius;
     border-top-right-radius: borders.$border-radius;
     border-bottom-left-radius: 0;
     border-bottom-right-radius: 0;
+
+    @include breakpoints.gt-xxs {
+      width: 280px;
+    }
   }
 
   input.choices__input {


### PR DESCRIPTION
The breakpoint should appear after all the rules for the root selector.