### PR TITLE
Replace bootstrap with custom styling

### DIFF
--- a/scripts/11ty/_includes/style.scss
+++ b/scripts/11ty/_includes/style.scss
@@ -1,3 +1,68 @@
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap");
+
+// -------------------------------------------------------------------------
+// Theme: resets
+// -------------------------------------------------------------------------
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  height: 100%;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+button {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+}
+
+p {
+  margin: 0 0 10px;
+}
+
+ul,
+ol,
+dl {
+  margin-top: 0;
+  margin-bottom: 10px;
+  padding: 0;
+  padding-inline-start: 20px; // Default is 40px
+}
+
+p,
+li,
+a {
+  line-height: 1.3;
+}
+
+// -------------------------------------------------------------------------
+// Theme: colors
+// -------------------------------------------------------------------------
+
+$teal: hsl(173, 72%, 46%);
+$white: hsl(0, 0%, 100%);
+$black: hsl(0, 0%, 0%);
+$gray: hsl(0, 0%, 25.88%);
+$gray-light: hsl(0, 0%, 80%);
+
+$black-translucent: hsla(0, 0%, 0%, 0.4);
+
+$hover-white: hsl(0, 0%, 96%);
+$hover-gray: hsl(0, 0%, 32%);
+
 // -------------------------------------------------------------------------
 // Theme: breakpoints
 // -------------------------------------------------------------------------
@@ -24,21 +89,47 @@ $spacing-container-edge-spacing: 15px;
 // Theme: typography
 // -------------------------------------------------------------------------
 
-$font-size-xs: 12px;
-$font-size-sm: 14px;
-$font-size-base: 16px;
-$font-size-md: 18px;
-$font-size-lg: 20px;
-$font-size-xl: 24px;
-$font-size-2xl: 30px;
+// Scale is different than map apps because the project constraints are different.
+
+$font-size-base: 18px;
+$font-size-md: 20px;
+$font-size-lg: 24px;
+$font-size-xl: 28px;
+$font-size-2xl: 36px;
+
+h1 {
+  font-size: $font-size-2xl;
+  margin-bottom: $spacing-element-gap;
+  font-weight: 500;
+  line-height: 1.1;
+}
+h2 {
+  font-size: $font-size-xl;
+  margin-bottom: $spacing-element-gap;
+  font-weight: 500;
+  line-height: 1.15;
+}
+h3 {
+  font-size: $font-size-lg;
+  margin-bottom: $spacing-element-gap;
+  font-weight: 500;
+  line-height: 1.2;
+}
 
 // -------------------------------------------------------------------------
 // main
 // -------------------------------------------------------------------------
 
+body {
+  font-family: Poppins, Helvetica, Arial, sans-serif;
+  font-size: $font-size-base;
+}
+
 main {
   word-break: break-word;
-  width: calc(100% - 2rem);
+  max-width: min(1000px, 100%);
+  margin: 0 auto;
+  padding: 0 $spacing-container-edge-spacing;
 }
 
 // -------------------------------------------------------------------------
@@ -48,8 +139,8 @@ main {
 $logo-height: 75px;
 
 .site-header {
-  background-color: hsl(0, 0%, 25.88%);
-  font-size: $font-size-2xl;
+  background-color: $gray;
+  font-size: $font-size-lg;
   padding: $spacing-container-edge-spacing;
 
   display: flex;
@@ -57,7 +148,7 @@ $logo-height: 75px;
   justify-content: space-between;
   align-items: center;
 
-  border-bottom: 4px solid hsl(173, 72%, 46%);
+  border-bottom: 4px solid $teal;
 
   img {
     height: $logo-height;
@@ -82,7 +173,7 @@ $logo-height: 75px;
   }
 
   a {
-    color: hsl(0, 0%, 100%);
+    color: $white;
     text-decoration: none;
     display: flex;
     height: $logo-height;
@@ -90,14 +181,59 @@ $logo-height: 75px;
     align-items: center;
 
     &:hover {
-      background-color: hsl(0, 0%, 32%);
+      background-color: $hover-gray;
     }
   }
 }
 
 // -------------------------------------------------------------------------
+// Summary
+// -------------------------------------------------------------------------
+
+.summary {
+  font-size: $font-size-md;
+  margin-bottom: $spacing-container-edge-spacing;
+}
+
+// -------------------------------------------------------------------------
+// Metadata list
+// -------------------------------------------------------------------------
+
+dl {
+  display: grid;
+  grid-template-columns: 1fr;
+  column-gap: calc($spacing-container-edge-spacing + $spacing-element-gap);
+  align-items: start;
+  padding-left: 0;
+
+  @include breakpoints-gt-xs() {
+    grid-template-columns: auto 1fr;
+  }
+}
+
+dt {
+  font-weight: 500;
+}
+
+dd {
+  margin-left: 0;
+  margin-bottom: $spacing-element-gap;
+}
+
+// -------------------------------------------------------------------------
 // Attachments
 // -------------------------------------------------------------------------
+
+main img {
+  width: 100%;
+  border: 1px solid $black-translucent;
+  border-radius: 5px;
+}
+
+.attachments {
+  list-style: none;
+  padding-left: 0;
+}
 
 .attachment + .attachment {
   margin-top: 3rem;

--- a/scripts/11ty/template.liquid
+++ b/scripts/11ty/template.liquid
@@ -10,12 +10,6 @@ permalink: "{{ entry.escapedPlaceId }}.html"
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
-      crossorigin="anonymous"
-    />
     {% capture scss -%} {% render "style.scss" %} {%- endcapture -%}
     <style>{{ scss | scss_compile | cssmin }}</style>
     <title>Parking reforms in {{ entry.placeId }} | Parking Reform Network</title>
@@ -31,52 +25,47 @@ permalink: "{{ entry.escapedPlaceId }}.html"
   </head>
   <body>
     {% render "header" %}
-    <main class="container-md p-3 p-sm-4 mt-3 mt-sm-4 mt-md-5 col-11 col-md-9">
+    <main>
       <header>
-        <h1 class="display-3">Parking reforms in {{ entry.placeId }}</h1>
+        <h1>Parking reforms in {{ entry.placeId }}</h1>
       </header>
-      <hr />
-      <h2>Summary</h2>
-      <p class="lead">{{ entry.summary }}</p>
-      <hr />
-      <dl class="row">
-        <dt class="col-12 col-sm-4 col-lg-3">Implementation status</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">{{ entry.status }}</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Reform type</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">{{ entry.policyChange }}</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Land uses</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">{{ entry.landUse }}</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Scope of reform</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">{{ entry.scope }}</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Requirements</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">{{ entry.requirements }}</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Reporter</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">{{ entry.reporter }}</dd>
+      <p class="summary">{{ entry.summary }}</p>
+      <dl>
+        <dt>Reform type</dt>
+        <dd>{{ entry.policyChange }}</dd>
+        <dt>Reform status</dt>
+        <dd>{{ entry.status }}</dd>
+        <dt>Affected land uses</dt>
+        <dd>{{ entry.landUse }}</dd>
+        <dt>Reform scope</dt>
+        <dd>{{ entry.scope }}</dd>
+        <dt>Requirements</dt>
+        <dd>{{ entry.requirements }}</dd>
+        <dt>Reporter</dt>
+        <dd>{{ entry.reporter }}</dd>
       </dl>
       {% for citation in entry.citations -%}
-        <section class="my-3">
-          <header>
-            <h2>Citation {{ forloop.index }}</h2>
-          </header>
-          <dl class="row">
-            <dt class="col-12 col-sm-4 col-lg-3">Source description</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">{{ citation.description }}</dd>
-            <dt class="col-12 col-sm-4 col-lg-3">Type</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">{{ citation.type }}</dd>
-            <dt class="col-12 col-sm-4 col-lg-3">URL</dt>
-            <dd class="col-12 col-sm-8 col-lg-9"><a target="_blank" href="{{ citation.url }}">{{ citation.url }}</a></dd>
-            <dt class="col-12 col-sm-4 col-lg-3">Notes</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">{{ citation.notes }}</dd>
+        <section>
+          <h2>Citation {{ forloop.index }}</h2>
+          <dl>
+            <dt>Source</dt>
+            <dd>{{ citation.description }}</dd>
+            <dt>Type</dt>
+            <dd>{{ citation.type }}</dd>
+            <dt>Notes</dt>
+            <dd>{{ citation.notes }}</dd>
+            <dt>URL</dt>
+            <dd><a target="_blank" href="{{ citation.url }}">{{ citation.url }}</a></dd>
           </dl>
           {% if citation.attachments -%}
             <h3>Attachments and screenshots</h3>
-            <ul class="mt-4 list-unstyled">
+            <ul class="attachments">
               {% for attachment in citation.attachments -%}
-                <li class="attachment">
+                <li>
                   {% if attachment.isDoc -%}
                     <a target="_blank" download="{{ attachment.fileName }}" href="https://mandates-map.directus.app/assets/{{ attachment.directusId }}/{{ attachment.fileName }}?download">{{ attachment.fileName }}</a>
                   {%- else -%}
-                    <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/{{ attachment.directusId }}/{{ attachment.fileName }}" />
+                    <img src="https://mandates-map.directus.app/assets/{{ attachment.directusId }}/{{ attachment.fileName }}" />
                   {%- endif %}
                 </li>
               {%- endfor %}
@@ -85,10 +74,5 @@ permalink: "{{ entry.escapedPlaceId }}.html"
         </section>
       {%- endfor %}
     </main>
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ"
-      crossorigin="anonymous"
-    ></script>
   </body>
 </html>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
@@ -3,13 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
-      crossorigin="anonymous"
-    />
-    <style>main{word-break:break-word;width:calc(100% - 2rem)}.site-header{background-color:hsl(0,0%,25.88%);font-size:30px;padding:15px;display:flex;flex-direction:row;justify-content:space-between;align-items:center;border-bottom:4px solid #20c9b6}.site-header img{height:75px;cursor:pointer}.site-header-map-link{display:none}@media screen and (min-width:640px){.site-header-map-link{display:block}}.site-header-right ul{list-style:none;padding:0;margin:0;display:flex}.site-header-right a{color:#fff;text-decoration:none;display:flex;height:75px;padding:0 10px;align-items:center}.site-header-right a:hover{background-color:#515151}.attachment+.attachment{margin-top:3rem}</style>
+    <style>@import url(https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap);*,::after,::before{box-sizing:border-box}body,html{padding:0;margin:0;height:100%;width:100%;display:flex;flex-direction:column}button{background-color:transparent;border:none;padding:0;font:inherit;color:inherit;cursor:pointer}p{margin:0 0 10px}dl,ol,ul{margin-top:0;margin-bottom:10px;padding:0;padding-inline-start:20px}a,li,p{line-height:1.3}h1{font-size:36px;margin-bottom:10px;font-weight:500;line-height:1.1}h2{font-size:28px;margin-bottom:10px;font-weight:500;line-height:1.15}h3{font-size:24px;margin-bottom:10px;font-weight:500;line-height:1.2}body{font-family:Poppins,Helvetica,Arial,sans-serif;font-size:18px}main{word-break:break-word;max-width:min(1000px,100%);margin:0 auto;padding:0 15px}.site-header{background-color:hsl(0,0%,25.88%);font-size:24px;padding:15px;display:flex;flex-direction:row;justify-content:space-between;align-items:center;border-bottom:4px solid #20c9b6}.site-header img{height:75px;cursor:pointer}.site-header-map-link{display:none}@media screen and (min-width:640px){.site-header-map-link{display:block}}.site-header-right ul{list-style:none;padding:0;margin:0;display:flex}.site-header-right a{color:#fff;text-decoration:none;display:flex;height:75px;padding:0 10px;align-items:center}.site-header-right a:hover{background-color:#515151}.summary{font-size:20px;margin-bottom:15px}dl{display:grid;grid-template-columns:1fr;column-gap:25px;align-items:start;padding-left:0}@media screen and (min-width:640px){dl{grid-template-columns:auto 1fr}}dt{font-weight:500}dd{margin-left:0;margin-bottom:10px}main img{width:100%;border:1px solid hsla(0,0%,0%,.4);border-radius:5px}.attachments{list-style:none;padding-left:0}.attachment+.attachment{margin-top:3rem}</style>
     <title>Parking reforms in Abbottstown, PA | Parking Reform Network</title>
     <script
       async
@@ -41,57 +35,47 @@
   </div>
 </header>
 
-    <main class="container-md p-3 p-sm-4 mt-3 mt-sm-4 mt-md-5 col-11 col-md-9">
+    <main>
       <header>
-        <h1 class="display-3">Parking reforms in Abbottstown, PA</h1>
+        <h1>Parking reforms in Abbottstown, PA</h1>
       </header>
-      <hr />
-      <h2>Summary</h2>
-      <p class="lead">Parking requirements may be reduced through on-street parking, public parking and proximity to transit. Parking maximums are set at 110% of the minimums for nonresidential uses.</p>
-      <hr />
-      <dl class="row">
-        <dt class="col-12 col-sm-4 col-lg-3">Implementation status</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">implemented</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Reform type</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">add parking maximums; reduce parking minimums</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Land uses</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">all uses; commercial; industrial; other; residential, multi-family</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Scope of reform</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">citywide</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Requirements</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">frequent transit; other</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Reporter</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">Samuel Deetz</dd>
+      <p class="summary">Parking requirements may be reduced through on-street parking, public parking and proximity to transit. Parking maximums are set at 110% of the minimums for nonresidential uses.</p>
+      <dl>
+        <dt>Reform type</dt>
+        <dd>add parking maximums; reduce parking minimums</dd>
+        <dt>Reform status</dt>
+        <dd>implemented</dd>
+        <dt>Affected land uses</dt>
+        <dd>all uses; commercial; industrial; other; residential, multi-family</dd>
+        <dt>Reform scope</dt>
+        <dd>citywide</dd>
+        <dt>Requirements</dt>
+        <dd>frequent transit; other</dd>
+        <dt>Reporter</dt>
+        <dd>Samuel Deetz</dd>
       </dl>
-      <section class="my-3">
-          <header>
-            <h2>Citation 1</h2>
-          </header>
-          <dl class="row">
-            <dt class="col-12 col-sm-4 col-lg-3">Source description</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">Abbottstown Zoning Code</dd>
-            <dt class="col-12 col-sm-4 col-lg-3">Type</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">city code</dd>
-            <dt class="col-12 col-sm-4 col-lg-3">URL</dt>
-            <dd class="col-12 col-sm-8 col-lg-9"><a target="_blank" href="https://ecode360.com/33754474#33754521">https://ecode360.com/33754474#33754521</a></dd>
-            <dt class="col-12 col-sm-4 col-lg-3">Notes</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">§ 204-49Maximum number of parking spaces.
+      <section>
+          <h2>Citation 1</h2>
+          <dl>
+            <dt>Source</dt>
+            <dd>Abbottstown Zoning Code</dd>
+            <dt>Type</dt>
+            <dd>city code</dd>
+            <dt>Notes</dt>
+            <dd>§ 204-49Maximum number of parking spaces.
 § 204-50Parking space reductions.</dd>
+            <dt>URL</dt>
+            <dd><a target="_blank" href="https://ecode360.com/33754474#33754521">https://ecode360.com/33754474#33754521</a></dd>
           </dl>
           <h3>Attachments and screenshots</h3>
-            <ul class="mt-4 list-unstyled">
-              <li class="attachment">
-                  <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/09f7dee6-0d7e-4c17-9dbc-eba33fa75c23/Abbottstown_PA_1_1.png" />
-                </li><li class="attachment">
-                  <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/3cd722d2-bedb-4660-99c4-fc851b126c80/Abbottstown_PA_1_2.png" />
+            <ul class="attachments">
+              <li>
+                  <img src="https://mandates-map.directus.app/assets/09f7dee6-0d7e-4c17-9dbc-eba33fa75c23/Abbottstown_PA_1_1.png" />
+                </li><li>
+                  <img src="https://mandates-map.directus.app/assets/3cd722d2-bedb-4660-99c4-fc851b126c80/Abbottstown_PA_1_2.png" />
                 </li>
             </ul>
         </section>
     </main>
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ"
-      crossorigin="anonymous"
-    ></script>
   </body>
 </html>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
@@ -3,13 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
-      crossorigin="anonymous"
-    />
-    <style>main{word-break:break-word;width:calc(100% - 2rem)}.site-header{background-color:hsl(0,0%,25.88%);font-size:30px;padding:15px;display:flex;flex-direction:row;justify-content:space-between;align-items:center;border-bottom:4px solid #20c9b6}.site-header img{height:75px;cursor:pointer}.site-header-map-link{display:none}@media screen and (min-width:640px){.site-header-map-link{display:block}}.site-header-right ul{list-style:none;padding:0;margin:0;display:flex}.site-header-right a{color:#fff;text-decoration:none;display:flex;height:75px;padding:0 10px;align-items:center}.site-header-right a:hover{background-color:#515151}.attachment+.attachment{margin-top:3rem}</style>
+    <style>@import url(https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap);*,::after,::before{box-sizing:border-box}body,html{padding:0;margin:0;height:100%;width:100%;display:flex;flex-direction:column}button{background-color:transparent;border:none;padding:0;font:inherit;color:inherit;cursor:pointer}p{margin:0 0 10px}dl,ol,ul{margin-top:0;margin-bottom:10px;padding:0;padding-inline-start:20px}a,li,p{line-height:1.3}h1{font-size:36px;margin-bottom:10px;font-weight:500;line-height:1.1}h2{font-size:28px;margin-bottom:10px;font-weight:500;line-height:1.15}h3{font-size:24px;margin-bottom:10px;font-weight:500;line-height:1.2}body{font-family:Poppins,Helvetica,Arial,sans-serif;font-size:18px}main{word-break:break-word;max-width:min(1000px,100%);margin:0 auto;padding:0 15px}.site-header{background-color:hsl(0,0%,25.88%);font-size:24px;padding:15px;display:flex;flex-direction:row;justify-content:space-between;align-items:center;border-bottom:4px solid #20c9b6}.site-header img{height:75px;cursor:pointer}.site-header-map-link{display:none}@media screen and (min-width:640px){.site-header-map-link{display:block}}.site-header-right ul{list-style:none;padding:0;margin:0;display:flex}.site-header-right a{color:#fff;text-decoration:none;display:flex;height:75px;padding:0 10px;align-items:center}.site-header-right a:hover{background-color:#515151}.summary{font-size:20px;margin-bottom:15px}dl{display:grid;grid-template-columns:1fr;column-gap:25px;align-items:start;padding-left:0}@media screen and (min-width:640px){dl{grid-template-columns:auto 1fr}}dt{font-weight:500}dd{margin-left:0;margin-bottom:10px}main img{width:100%;border:1px solid hsla(0,0%,0%,.4);border-radius:5px}.attachments{list-style:none;padding-left:0}.attachment+.attachment{margin-top:3rem}</style>
     <title>Parking reforms in Abilene, TX | Parking Reform Network</title>
     <script
       async
@@ -41,58 +35,48 @@
   </div>
 </header>
 
-    <main class="container-md p-3 p-sm-4 mt-3 mt-sm-4 mt-md-5 col-11 col-md-9">
+    <main>
       <header>
-        <h1 class="display-3">Parking reforms in Abilene, TX</h1>
+        <h1>Parking reforms in Abilene, TX</h1>
       </header>
-      <hr />
-      <h2>Summary</h2>
-      <p class="lead">Existing buildings within the Central Business (CB) district are exempt from parking requirements. On-street parking may count towards minimums for new development in the district.</p>
-      <hr />
-      <dl class="row">
-        <dt class="col-12 col-sm-4 col-lg-3">Implementation status</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">implemented</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Reform type</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">reduce parking minimums</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Land uses</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">all uses</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Scope of reform</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">city center / business district</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Requirements</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">other</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Reporter</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">Samuel Deetz</dd>
+      <p class="summary">Existing buildings within the Central Business (CB) district are exempt from parking requirements. On-street parking may count towards minimums for new development in the district.</p>
+      <dl>
+        <dt>Reform type</dt>
+        <dd>reduce parking minimums</dd>
+        <dt>Reform status</dt>
+        <dd>implemented</dd>
+        <dt>Affected land uses</dt>
+        <dd>all uses</dd>
+        <dt>Reform scope</dt>
+        <dd>city center / business district</dd>
+        <dt>Requirements</dt>
+        <dd>other</dd>
+        <dt>Reporter</dt>
+        <dd>Samuel Deetz</dd>
       </dl>
-      <section class="my-3">
-          <header>
-            <h2>Citation 1</h2>
-          </header>
-          <dl class="row">
-            <dt class="col-12 col-sm-4 col-lg-3">Source description</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">Abilene Land Development Code</dd>
-            <dt class="col-12 col-sm-4 col-lg-3">Type</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">city code</dd>
-            <dt class="col-12 col-sm-4 col-lg-3">URL</dt>
-            <dd class="col-12 col-sm-8 col-lg-9"><a target="_blank" href="https://library.municode.com/tx/abilene/codes/code_of_ordinances?nodeId=PTIIIAPANDECO_CH4SIDERE_ART2DEST_DIV1PASTLO_S4.2.1.2GEPALORE">https://library.municode.com/tx/abilene/codes/code_of_ordinances?nodeId=PTIIIAPANDECO_CH4SIDERE_ART2DEST_DIV1PASTLO_S4.2.1.2GEPALORE</a></dd>
-            <dt class="col-12 col-sm-4 col-lg-3">Notes</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">CHAPTER 4: - SITE DEVELOPMENT REGULATIONS
+      <section>
+          <h2>Citation 1</h2>
+          <dl>
+            <dt>Source</dt>
+            <dd>Abilene Land Development Code</dd>
+            <dt>Type</dt>
+            <dd>city code</dd>
+            <dt>Notes</dt>
+            <dd>CHAPTER 4: - SITE DEVELOPMENT REGULATIONS
 ARTICLE 2. - DEVELOPMENT STANDARDS
 DIVISION 1. - PARKING, STACKING AND LOADING
 Section 4.2.1.2 - General Parking and Loading Requirements
 (c)</dd>
+            <dt>URL</dt>
+            <dd><a target="_blank" href="https://library.municode.com/tx/abilene/codes/code_of_ordinances?nodeId=PTIIIAPANDECO_CH4SIDERE_ART2DEST_DIV1PASTLO_S4.2.1.2GEPALORE">https://library.municode.com/tx/abilene/codes/code_of_ordinances?nodeId=PTIIIAPANDECO_CH4SIDERE_ART2DEST_DIV1PASTLO_S4.2.1.2GEPALORE</a></dd>
           </dl>
           <h3>Attachments and screenshots</h3>
-            <ul class="mt-4 list-unstyled">
-              <li class="attachment">
-                  <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/73ca3464-9cb3-4c0c-b7be-1328f2376620/Abilene_TX_1_1.png" />
+            <ul class="attachments">
+              <li>
+                  <img src="https://mandates-map.directus.app/assets/73ca3464-9cb3-4c0c-b7be-1328f2376620/Abilene_TX_1_1.png" />
                 </li>
             </ul>
         </section>
     </main>
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ"
-      crossorigin="anonymous"
-    ></script>
   </body>
 </html>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
@@ -3,13 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <link
-      href="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/css/bootstrap.min.css"
-      rel="stylesheet"
-      integrity="sha384-F3w7mX95PdgyTmZZMECAngseQB83DfGTowi0iMjiWaeVhAn4FJkqJByhZMI3AhiU"
-      crossorigin="anonymous"
-    />
-    <style>main{word-break:break-word;width:calc(100% - 2rem)}.site-header{background-color:hsl(0,0%,25.88%);font-size:30px;padding:15px;display:flex;flex-direction:row;justify-content:space-between;align-items:center;border-bottom:4px solid #20c9b6}.site-header img{height:75px;cursor:pointer}.site-header-map-link{display:none}@media screen and (min-width:640px){.site-header-map-link{display:block}}.site-header-right ul{list-style:none;padding:0;margin:0;display:flex}.site-header-right a{color:#fff;text-decoration:none;display:flex;height:75px;padding:0 10px;align-items:center}.site-header-right a:hover{background-color:#515151}.attachment+.attachment{margin-top:3rem}</style>
+    <style>@import url(https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap);*,::after,::before{box-sizing:border-box}body,html{padding:0;margin:0;height:100%;width:100%;display:flex;flex-direction:column}button{background-color:transparent;border:none;padding:0;font:inherit;color:inherit;cursor:pointer}p{margin:0 0 10px}dl,ol,ul{margin-top:0;margin-bottom:10px;padding:0;padding-inline-start:20px}a,li,p{line-height:1.3}h1{font-size:36px;margin-bottom:10px;font-weight:500;line-height:1.1}h2{font-size:28px;margin-bottom:10px;font-weight:500;line-height:1.15}h3{font-size:24px;margin-bottom:10px;font-weight:500;line-height:1.2}body{font-family:Poppins,Helvetica,Arial,sans-serif;font-size:18px}main{word-break:break-word;max-width:min(1000px,100%);margin:0 auto;padding:0 15px}.site-header{background-color:hsl(0,0%,25.88%);font-size:24px;padding:15px;display:flex;flex-direction:row;justify-content:space-between;align-items:center;border-bottom:4px solid #20c9b6}.site-header img{height:75px;cursor:pointer}.site-header-map-link{display:none}@media screen and (min-width:640px){.site-header-map-link{display:block}}.site-header-right ul{list-style:none;padding:0;margin:0;display:flex}.site-header-right a{color:#fff;text-decoration:none;display:flex;height:75px;padding:0 10px;align-items:center}.site-header-right a:hover{background-color:#515151}.summary{font-size:20px;margin-bottom:15px}dl{display:grid;grid-template-columns:1fr;column-gap:25px;align-items:start;padding-left:0}@media screen and (min-width:640px){dl{grid-template-columns:auto 1fr}}dt{font-weight:500}dd{margin-left:0;margin-bottom:10px}main img{width:100%;border:1px solid hsla(0,0%,0%,.4);border-radius:5px}.attachments{list-style:none;padding-left:0}.attachment+.attachment{margin-top:3rem}</style>
     <title>Parking reforms in Basalt, CO | Parking Reform Network</title>
     <script
       async
@@ -41,41 +35,34 @@
   </div>
 </header>
 
-    <main class="container-md p-3 p-sm-4 mt-3 mt-sm-4 mt-md-5 col-11 col-md-9">
+    <main>
       <header>
-        <h1 class="display-3">Parking reforms in Basalt, CO</h1>
+        <h1>Parking reforms in Basalt, CO</h1>
       </header>
-      <hr />
-      <h2>Summary</h2>
-      <p class="lead">Within the Downtown Parking Area, a fee in lieu of require parking may be provided for commercial or mixed-use developments. Within the CSC District, parking requirements are reduced and on-street parking may be used to satisfy requirements, while surface parking is prohibited in certain areas. Uses designated as landmarks have reduced parking requirements citywide.</p>
-      <hr />
-      <dl class="row">
-        <dt class="col-12 col-sm-4 col-lg-3">Implementation status</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">implemented</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Reform type</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">add parking maximums; reduce parking minimums</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Land uses</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">commercial; other; residential, all uses</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Scope of reform</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">city center / business district; citywide</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Requirements</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">by right; historic preservation; in-lieu fees; other</dd>
-        <dt class="col-12 col-sm-4 col-lg-3">Reporter</dt>
-        <dd class="col-12 col-sm-8 col-lg-9">Samuel Deetz</dd>
+      <p class="summary">Within the Downtown Parking Area, a fee in lieu of require parking may be provided for commercial or mixed-use developments. Within the CSC District, parking requirements are reduced and on-street parking may be used to satisfy requirements, while surface parking is prohibited in certain areas. Uses designated as landmarks have reduced parking requirements citywide.</p>
+      <dl>
+        <dt>Reform type</dt>
+        <dd>add parking maximums; reduce parking minimums</dd>
+        <dt>Reform status</dt>
+        <dd>implemented</dd>
+        <dt>Affected land uses</dt>
+        <dd>commercial; other; residential, all uses</dd>
+        <dt>Reform scope</dt>
+        <dd>city center / business district; citywide</dd>
+        <dt>Requirements</dt>
+        <dd>by right; historic preservation; in-lieu fees; other</dd>
+        <dt>Reporter</dt>
+        <dd>Samuel Deetz</dd>
       </dl>
-      <section class="my-3">
-          <header>
-            <h2>Citation 1</h2>
-          </header>
-          <dl class="row">
-            <dt class="col-12 col-sm-4 col-lg-3">Source description</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">Basalt Zoning Code</dd>
-            <dt class="col-12 col-sm-4 col-lg-3">Type</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">city code</dd>
-            <dt class="col-12 col-sm-4 col-lg-3">URL</dt>
-            <dd class="col-12 col-sm-8 col-lg-9"><a target="_blank" href="https://library.municode.com/co/basalt/codes/municipal_code?nodeId=CH16ZO_ARTVOREPALO_S16-94OTEPA">https://library.municode.com/co/basalt/codes/municipal_code?nodeId=CH16ZO_ARTVOREPALO_S16-94OTEPA</a></dd>
-            <dt class="col-12 col-sm-4 col-lg-3">Notes</dt>
-            <dd class="col-12 col-sm-8 col-lg-9">ARTICLE II - District Regulations	
+      <section>
+          <h2>Citation 1</h2>
+          <dl>
+            <dt>Source</dt>
+            <dd>Basalt Zoning Code</dd>
+            <dt>Type</dt>
+            <dd>city code</dd>
+            <dt>Notes</dt>
+            <dd>ARTICLE II - District Regulations	
   Sec. 16-30. - CSC Zone District.	
     (e)(4)a.
     (e)(4)b.
@@ -87,25 +74,22 @@ ARTICLE V - Off-Street Parking and Loading
 ARTICLE XVIII - Historic Preservation
   Sec. 16-394. - Incentives.	
     (a)</dd>
+            <dt>URL</dt>
+            <dd><a target="_blank" href="https://library.municode.com/co/basalt/codes/municipal_code?nodeId=CH16ZO_ARTVOREPALO_S16-94OTEPA">https://library.municode.com/co/basalt/codes/municipal_code?nodeId=CH16ZO_ARTVOREPALO_S16-94OTEPA</a></dd>
           </dl>
           <h3>Attachments and screenshots</h3>
-            <ul class="mt-4 list-unstyled">
-              <li class="attachment">
-                  <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/ec7446e9-8f65-4b86-a50f-ddadf0f95bd3/Basalt_CO_1_1.png" />
-                </li><li class="attachment">
-                  <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/71e17373-9617-4267-808c-cbec6c819c21/Basalt_CO_1_2.png" />
-                </li><li class="attachment">
-                  <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/3eb59336-56c1-4ca3-b01b-7064150b31ee/Basalt_CO_1_3.png" />
-                </li><li class="attachment">
-                  <img class="img-fluid" border="1" src="https://mandates-map.directus.app/assets/b7ec147f-ad03-42bc-bf0e-c261f0cb0865/Basalt_CO_1_4.png" />
+            <ul class="attachments">
+              <li>
+                  <img src="https://mandates-map.directus.app/assets/ec7446e9-8f65-4b86-a50f-ddadf0f95bd3/Basalt_CO_1_1.png" />
+                </li><li>
+                  <img src="https://mandates-map.directus.app/assets/71e17373-9617-4267-808c-cbec6c819c21/Basalt_CO_1_2.png" />
+                </li><li>
+                  <img src="https://mandates-map.directus.app/assets/3eb59336-56c1-4ca3-b01b-7064150b31ee/Basalt_CO_1_3.png" />
+                </li><li>
+                  <img src="https://mandates-map.directus.app/assets/b7ec147f-ad03-42bc-bf0e-c261f0cb0865/Basalt_CO_1_4.png" />
                 </li>
             </ul>
         </section>
     </main>
-    <script
-      src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js"
-      integrity="sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ"
-      crossorigin="anonymous"
-    ></script>
   </body>
 </html>


### PR DESCRIPTION
Before:
<img width="859" alt="Screenshot 2024-12-25 at 6 34 27 PM" src="https://github.com/user-attachments/assets/6314ea59-9f11-43cb-b017-1eed17140aad" />

After:
<img width="1131" alt="Screenshot 2024-12-25 at 6 34 17 PM" src="https://github.com/user-attachments/assets/ecabdfcd-e836-4cc7-bf28-629a2be26364" />

Changes:

* Removed 'summary' text and horizontal rules. They were not necessary
* Use official font
* Reordered some definition list entries
* Image has a rounded and softer border
* Use larger base font size
