### PR TITLE
Use layout file with Eleventy

### DIFF
--- a/scripts/11ty/_includes/layout.liquid
+++ b/scripts/11ty/_includes/layout.liquid
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    {% capture scss -%} {% render "style.scss" %} {%- endcapture -%}
+    <style>{{ scss | scss_compile | cssmin }}</style>
+    <title>Parking reforms in {{ entry.placeId }} | Parking Reform Network</title>
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=G-5MFS4ZVMY3"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || []; function
+      gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config',
+      'G-5MFS4ZVMY3');
+    </script>
+  </head>
+  <body>
+    {% render "header" %}
+    {{ content }}
+  </body>
+</html>

--- a/scripts/11ty/template.liquid
+++ b/scripts/11ty/template.liquid
@@ -4,55 +4,34 @@ pagination:
   size: 1
   alias: entry
 permalink: "{{ entry.escapedPlaceId }}.html"
+layout: layout.liquid
 ---
-<!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    {% capture scss -%} {% render "style.scss" %} {%- endcapture -%}
-    <style>{{ scss | scss_compile | cssmin }}</style>
-    <title>Parking reforms in {{ entry.placeId }} | Parking Reform Network</title>
-    <script
-      async
-      src="https://www.googletagmanager.com/gtag/js?id=G-5MFS4ZVMY3"
-    ></script>
-    <script>
-      window.dataLayer = window.dataLayer || []; function
-      gtag(){dataLayer.push(arguments);} gtag('js', new Date()); gtag('config',
-      'G-5MFS4ZVMY3');
-    </script>
-  </head>
-  <body>
-    {% render "header" %}
-    <main>
-      <header>
-        <h1>Parking reforms in {{ entry.placeId }}</h1>
-      </header>
-      <p class="summary">{{ entry.summary }}</p>
-      <dl>
-        <dt>Reform type</dt>
-        <dd>{% render "string-array" array: entry.policyChange %}</dd>
-        <dt>Reform status</dt>
-        <dd>{{ entry.status }}</dd>
-        <dt>Affected land uses</dt>
-        <dd>{% render "string-array" array: entry.landUse %}</dd>
-        <dt>Reform scope</dt>
-        <dd>{% render "string-array" array: entry.scope %}</dd>
-        {% if entry.requirements.size > 0 -%}
-          <dt>Requirements</dt>
-          <dd>{% render "string-array" array: entry.requirements %}</dd>
-        {%- endif %}
-        {% if entry.reporter -%}
-          <dt>Reporter</dt>
-          <dd>{{ entry.reporter }}</dd>
-        {%- endif %}
-      </dl>
-      <section aria-label="citations">
-        {% for citation in entry.citations -%}
-          {% render "citation" citation: citation index: forloop.index %}
-        {%- endfor %}
-      <section>
-    </main>
-  </body>
-</html>
+<main>
+  <header>
+    <h1>Parking reforms in {{ entry.placeId }}</h1>
+  </header>
+  <p class="summary">{{ entry.summary }}</p>
+  <dl>
+    <dt>Reform type</dt>
+    <dd>{% render "string-array" array: entry.policyChange %}</dd>
+    <dt>Reform status</dt>
+    <dd>{{ entry.status }}</dd>
+    <dt>Affected land uses</dt>
+    <dd>{% render "string-array" array: entry.landUse %}</dd>
+    <dt>Reform scope</dt>
+    <dd>{% render "string-array" array: entry.scope %}</dd>
+    {% if entry.requirements.size > 0 -%}
+      <dt>Requirements</dt>
+      <dd>{% render "string-array" array: entry.requirements %}</dd>
+    {%- endif %}
+    {% if entry.reporter -%}
+      <dt>Reporter</dt>
+      <dd>{{ entry.reporter }}</dd>
+    {%- endif %}
+  </dl>
+  <section aria-label="citations">
+    {% for citation in entry.citations -%}
+      {% render "citation" citation: citation index: forloop.index %}
+    {%- endfor %}
+  <section>
+</main>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
@@ -36,26 +36,26 @@
 </header>
 
     <main>
-      <header>
-        <h1>Parking reforms in Abbottstown, PA</h1>
-      </header>
-      <p class="summary">Parking requirements may be reduced through on-street parking, public parking and proximity to transit. Parking maximums are set at 110% of the minimums for nonresidential uses.</p>
-      <dl>
-        <dt>Reform type</dt>
-        <dd><ul><li>add parking maximums</li><li>reduce parking minimums</li></ul></dd>
-        <dt>Reform status</dt>
-        <dd>implemented</dd>
-        <dt>Affected land uses</dt>
-        <dd><ul><li>all uses</li><li>commercial</li><li>industrial</li><li>other</li><li>residential, multi-family</li></ul></dd>
-        <dt>Reform scope</dt>
-        <dd>citywide</dd>
-        <dt>Requirements</dt>
-          <dd><ul><li>frequent transit</li><li>other</li></ul></dd>
-        <dt>Reporter</dt>
-          <dd>Samuel Deetz</dd>
-      </dl>
-      <section aria-label="citations">
-        <article>
+  <header>
+    <h1>Parking reforms in Abbottstown, PA</h1>
+  </header>
+  <p class="summary">Parking requirements may be reduced through on-street parking, public parking and proximity to transit. Parking maximums are set at 110% of the minimums for nonresidential uses.</p>
+  <dl>
+    <dt>Reform type</dt>
+    <dd><ul><li>add parking maximums</li><li>reduce parking minimums</li></ul></dd>
+    <dt>Reform status</dt>
+    <dd>implemented</dd>
+    <dt>Affected land uses</dt>
+    <dd><ul><li>all uses</li><li>commercial</li><li>industrial</li><li>other</li><li>residential, multi-family</li></ul></dd>
+    <dt>Reform scope</dt>
+    <dd>citywide</dd>
+    <dt>Requirements</dt>
+      <dd><ul><li>frequent transit</li><li>other</li></ul></dd>
+    <dt>Reporter</dt>
+      <dd>Samuel Deetz</dd>
+  </dl>
+  <section aria-label="citations">
+    <article>
   <h2>Citation 1</h2>
   <dl>
     <dt>Source</dt>
@@ -70,7 +70,8 @@
     <li><img src="https://mandates-map.directus.app/assets/09f7dee6-0d7e-4c17-9dbc-eba33fa75c23/Abbottstown_PA_1_1.png" /></li><li><img src="https://mandates-map.directus.app/assets/3cd722d2-bedb-4660-99c4-fc851b126c80/Abbottstown_PA_1_2.png" /></li>
     </ul>
 </article>
-      <section>
-    </main>
+  <section>
+</main>
+
   </body>
 </html>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
@@ -36,26 +36,26 @@
 </header>
 
     <main>
-      <header>
-        <h1>Parking reforms in Abilene, TX</h1>
-      </header>
-      <p class="summary">Existing buildings within the Central Business (CB) district are exempt from parking requirements. On-street parking may count towards minimums for new development in the district.</p>
-      <dl>
-        <dt>Reform type</dt>
-        <dd>reduce parking minimums</dd>
-        <dt>Reform status</dt>
-        <dd>implemented</dd>
-        <dt>Affected land uses</dt>
-        <dd>all uses</dd>
-        <dt>Reform scope</dt>
-        <dd>city center / business district</dd>
-        <dt>Requirements</dt>
-          <dd>other</dd>
-        <dt>Reporter</dt>
-          <dd>Samuel Deetz</dd>
-      </dl>
-      <section aria-label="citations">
-        <article>
+  <header>
+    <h1>Parking reforms in Abilene, TX</h1>
+  </header>
+  <p class="summary">Existing buildings within the Central Business (CB) district are exempt from parking requirements. On-street parking may count towards minimums for new development in the district.</p>
+  <dl>
+    <dt>Reform type</dt>
+    <dd>reduce parking minimums</dd>
+    <dt>Reform status</dt>
+    <dd>implemented</dd>
+    <dt>Affected land uses</dt>
+    <dd>all uses</dd>
+    <dt>Reform scope</dt>
+    <dd>city center / business district</dd>
+    <dt>Requirements</dt>
+      <dd>other</dd>
+    <dt>Reporter</dt>
+      <dd>Samuel Deetz</dd>
+  </dl>
+  <section aria-label="citations">
+    <article>
   <h2>Citation 1</h2>
   <dl>
     <dt>Source</dt>
@@ -73,7 +73,8 @@ Section 4.2.1.2 - General Parking and Loading Requirements
     <li><img src="https://mandates-map.directus.app/assets/73ca3464-9cb3-4c0c-b7be-1328f2376620/Abilene_TX_1_1.png" /></li>
     </ul>
 </article>
-      <section>
-    </main>
+  <section>
+</main>
+
   </body>
 </html>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/auburn-me.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/auburn-me.html
@@ -36,25 +36,25 @@
 </header>
 
     <main>
-      <header>
-        <h1>Parking reforms in Auburn, ME</h1>
-      </header>
-      <p class="summary">Parking requirements have been removed for all uses except for residential uses under Formed Based Code.</p>
-      <dl>
-        <dt>Reform type</dt>
-        <dd>remove parking minimums</dd>
-        <dt>Reform status</dt>
-        <dd>implemented</dd>
-        <dt>Affected land uses</dt>
-        <dd><ul><li>commercial</li><li>industrial</li><li>other</li></ul></dd>
-        <dt>Reform scope</dt>
-        <dd>citywide</dd>
-        <dt>Requirements</dt>
-          <dd>by right</dd>
-        
-      </dl>
-      <section aria-label="citations">
-        <article>
+  <header>
+    <h1>Parking reforms in Auburn, ME</h1>
+  </header>
+  <p class="summary">Parking requirements have been removed for all uses except for residential uses under Formed Based Code.</p>
+  <dl>
+    <dt>Reform type</dt>
+    <dd>remove parking minimums</dd>
+    <dt>Reform status</dt>
+    <dd>implemented</dd>
+    <dt>Affected land uses</dt>
+    <dd><ul><li>commercial</li><li>industrial</li><li>other</li></ul></dd>
+    <dt>Reform scope</dt>
+    <dd>citywide</dd>
+    <dt>Requirements</dt>
+      <dd>by right</dd>
+    
+  </dl>
+  <section aria-label="citations">
+    <article>
   <h2>Citation 1</h2>
   <dl>
     <dt>Source</dt>
@@ -82,7 +82,8 @@
     <li><img src="https://mandates-map.directus.app/assets/ccdd7ef1-b1de-4de6-bb49-38e7543f7aef/Auburn_ME_2_1.png" /></li>
     </ul>
 </article>
-      <section>
-    </main>
+  <section>
+</main>
+
   </body>
 </html>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
@@ -36,26 +36,26 @@
 </header>
 
     <main>
-      <header>
-        <h1>Parking reforms in Basalt, CO</h1>
-      </header>
-      <p class="summary">Within the Downtown Parking Area, a fee in lieu of require parking may be provided for commercial or mixed-use developments. Within the CSC District, parking requirements are reduced and on-street parking may be used to satisfy requirements, while surface parking is prohibited in certain areas. Uses designated as landmarks have reduced parking requirements citywide.</p>
-      <dl>
-        <dt>Reform type</dt>
-        <dd><ul><li>add parking maximums</li><li>reduce parking minimums</li></ul></dd>
-        <dt>Reform status</dt>
-        <dd>implemented</dd>
-        <dt>Affected land uses</dt>
-        <dd><ul><li>commercial</li><li>other</li><li>residential, all uses</li></ul></dd>
-        <dt>Reform scope</dt>
-        <dd><ul><li>city center / business district</li><li>citywide</li></ul></dd>
-        <dt>Requirements</dt>
-          <dd><ul><li>by right</li><li>historic preservation</li><li>in-lieu fees</li><li>other</li></ul></dd>
-        <dt>Reporter</dt>
-          <dd>Samuel Deetz</dd>
-      </dl>
-      <section aria-label="citations">
-        <article>
+  <header>
+    <h1>Parking reforms in Basalt, CO</h1>
+  </header>
+  <p class="summary">Within the Downtown Parking Area, a fee in lieu of require parking may be provided for commercial or mixed-use developments. Within the CSC District, parking requirements are reduced and on-street parking may be used to satisfy requirements, while surface parking is prohibited in certain areas. Uses designated as landmarks have reduced parking requirements citywide.</p>
+  <dl>
+    <dt>Reform type</dt>
+    <dd><ul><li>add parking maximums</li><li>reduce parking minimums</li></ul></dd>
+    <dt>Reform status</dt>
+    <dd>implemented</dd>
+    <dt>Affected land uses</dt>
+    <dd><ul><li>commercial</li><li>other</li><li>residential, all uses</li></ul></dd>
+    <dt>Reform scope</dt>
+    <dd><ul><li>city center / business district</li><li>citywide</li></ul></dd>
+    <dt>Requirements</dt>
+      <dd><ul><li>by right</li><li>historic preservation</li><li>in-lieu fees</li><li>other</li></ul></dd>
+    <dt>Reporter</dt>
+      <dd>Samuel Deetz</dd>
+  </dl>
+  <section aria-label="citations">
+    <article>
   <h2>Citation 1</h2>
   <dl>
     <dt>Source</dt>
@@ -80,7 +80,8 @@ ARTICLE XVIII - Historic Preservation
     <li><img src="https://mandates-map.directus.app/assets/ec7446e9-8f65-4b86-a50f-ddadf0f95bd3/Basalt_CO_1_1.png" /></li><li><img src="https://mandates-map.directus.app/assets/71e17373-9617-4267-808c-cbec6c819c21/Basalt_CO_1_2.png" /></li><li><img src="https://mandates-map.directus.app/assets/3eb59336-56c1-4ca3-b01b-7064150b31ee/Basalt_CO_1_3.png" /></li><li><img src="https://mandates-map.directus.app/assets/b7ec147f-ad03-42bc-bf0e-c261f0cb0865/Basalt_CO_1_4.png" /></li>
     </ul>
 </article>
-      <section>
-    </main>
+  <section>
+</main>
+
   </body>
 </html>


### PR DESCRIPTION
Reasons why:

1. Separate out the overall page setup vs the interesting parts inside `<main>`
2. Soon we'll probably have two templates: the legacy style and new style. This helps with DRY.