### PR TITLE
Sentence case metadata values in details pages

### DIFF
--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -3,6 +3,7 @@
 // @ts-ignore
 import CleanCSS from "clean-css";
 import { compileString as compileStringSass } from "sass";
+import { capitalize } from "lodash-es";
 
 import { readProcessedCompleteData } from "./scripts/lib/data.js";
 import { escapePlaceId } from "./src/js/data.js";
@@ -29,11 +30,11 @@ export default async function (eleventyConfig: any) {
       escapedPlaceId: escapePlaceId(placeId),
       summary: entry.unifiedPolicy.summary,
       date: entry.unifiedPolicy.date?.format(),
-      status: entry.unifiedPolicy.status,
-      policyChange: entry.unifiedPolicy.policy,
-      landUse: entry.unifiedPolicy.land,
-      scope: entry.unifiedPolicy.scope,
-      requirements: entry.unifiedPolicy.requirements,
+      status: capitalize(entry.unifiedPolicy.status),
+      policyChange: entry.unifiedPolicy.policy.map(capitalize),
+      landUse: entry.unifiedPolicy.land.map(capitalize),
+      scope: entry.unifiedPolicy.scope.map(capitalize),
+      requirements: entry.unifiedPolicy.requirements.map(capitalize),
       reporter: entry.unifiedPolicy.reporter,
       citations: entry.unifiedPolicy.citations.map((citation) => ({
         urlDomain: citation.url ? new URL(citation.url).hostname : null,

--- a/scripts/11ty/template.liquid
+++ b/scripts/11ty/template.liquid
@@ -20,10 +20,10 @@ layout: layout.liquid
     {%- endif %}
     <dt>Reform status</dt>
     <dd>{{ entry.status }}</dd>
-    <dt>Affected land uses</dt>
-    <dd>{% render "string-array" array: entry.landUse %}</dd>
     <dt>Reform scope</dt>
     <dd>{% render "string-array" array: entry.scope %}</dd>
+    <dt>Affected land uses</dt>
+    <dd>{% render "string-array" array: entry.landUse %}</dd>
     {% if entry.requirements.size > 0 -%}
       <dt>Requirements</dt>
       <dd>{% render "string-array" array: entry.requirements %}</dd>

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -1,4 +1,5 @@
 import type { FeatureGroup } from "leaflet";
+import { capitalize } from "lodash-es";
 
 import type { ProcessedCoreEntry, PlaceId } from "./types";
 import Observable from "./Observable";
@@ -45,7 +46,9 @@ function generateScorecardRevamp(
   if (policyTypes.length === 1) {
     singlePolicyType = `<li>Reform type: ${policyTypes[0]}</li>`;
   } else {
-    const policies = policyTypes.map((type) => `<li>${type}</li>`).join("");
+    const policies = policyTypes
+      .map((type) => `<li>${capitalize(type)}</li>`)
+      .join("");
     multiplePolicyTypes = `<div>Reform types:</div><ul>${policies}</ul>`;
   }
 

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
@@ -42,16 +42,16 @@
   <p class="summary">Parking requirements may be reduced through on-street parking, public parking and proximity to transit. Parking maximums are set at 110% of the minimums for nonresidential uses.</p>
   <dl>
     <dt>Reform type</dt>
-    <dd><ul><li>add parking maximums</li><li>reduce parking minimums</li></ul></dd>
+    <dd><ul><li>Add parking maximums</li><li>Reduce parking minimums</li></ul></dd>
     
     <dt>Reform status</dt>
-    <dd>implemented</dd>
-    <dt>Affected land uses</dt>
-    <dd><ul><li>all uses</li><li>commercial</li><li>industrial</li><li>other</li><li>residential, multi-family</li></ul></dd>
+    <dd>Implemented</dd>
     <dt>Reform scope</dt>
-    <dd>citywide</dd>
+    <dd>Citywide</dd>
+    <dt>Affected land uses</dt>
+    <dd><ul><li>All uses</li><li>Commercial</li><li>Industrial</li><li>Other</li><li>Residential, multi-family</li></ul></dd>
     <dt>Requirements</dt>
-      <dd><ul><li>frequent transit</li><li>other</li></ul></dd>
+      <dd><ul><li>Frequent transit</li><li>Other</li></ul></dd>
     <dt>Reporter</dt>
       <dd>Samuel Deetz</dd>
   </dl>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
@@ -42,16 +42,16 @@
   <p class="summary">Existing buildings within the Central Business (CB) district are exempt from parking requirements. On-street parking may count towards minimums for new development in the district.</p>
   <dl>
     <dt>Reform type</dt>
-    <dd>reduce parking minimums</dd>
+    <dd>Reduce parking minimums</dd>
     
     <dt>Reform status</dt>
-    <dd>implemented</dd>
-    <dt>Affected land uses</dt>
-    <dd>all uses</dd>
+    <dd>Implemented</dd>
     <dt>Reform scope</dt>
-    <dd>city center / business district</dd>
+    <dd>City center / business district</dd>
+    <dt>Affected land uses</dt>
+    <dd>All uses</dd>
     <dt>Requirements</dt>
-      <dd>other</dd>
+      <dd>Other</dd>
     <dt>Reporter</dt>
       <dd>Samuel Deetz</dd>
   </dl>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/auburn-me.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/auburn-me.html
@@ -42,17 +42,17 @@
   <p class="summary">Parking requirements have been removed for all uses except for residential uses under Formed Based Code.</p>
   <dl>
     <dt>Reform type</dt>
-    <dd>remove parking minimums</dd>
+    <dd>Remove parking minimums</dd>
     <dt>Reform date</dt>
       <dd>Jul 19, 2021</dd>
     <dt>Reform status</dt>
-    <dd>implemented</dd>
-    <dt>Affected land uses</dt>
-    <dd><ul><li>commercial</li><li>industrial</li><li>other</li></ul></dd>
+    <dd>Implemented</dd>
     <dt>Reform scope</dt>
-    <dd>citywide</dd>
+    <dd>Citywide</dd>
+    <dt>Affected land uses</dt>
+    <dd><ul><li>Commercial</li><li>Industrial</li><li>Other</li></ul></dd>
     <dt>Requirements</dt>
-      <dd>by right</dd>
+      <dd>By right</dd>
     
   </dl>
   <details class="citation">

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
@@ -42,16 +42,16 @@
   <p class="summary">Within the Downtown Parking Area, a fee in lieu of require parking may be provided for commercial or mixed-use developments. Within the CSC District, parking requirements are reduced and on-street parking may be used to satisfy requirements, while surface parking is prohibited in certain areas. Uses designated as landmarks have reduced parking requirements citywide.</p>
   <dl>
     <dt>Reform type</dt>
-    <dd><ul><li>add parking maximums</li><li>reduce parking minimums</li></ul></dd>
+    <dd><ul><li>Add parking maximums</li><li>Reduce parking minimums</li></ul></dd>
     
     <dt>Reform status</dt>
-    <dd>implemented</dd>
-    <dt>Affected land uses</dt>
-    <dd><ul><li>commercial</li><li>other</li><li>residential, all uses</li></ul></dd>
+    <dd>Implemented</dd>
     <dt>Reform scope</dt>
-    <dd><ul><li>city center / business district</li><li>citywide</li></ul></dd>
+    <dd><ul><li>City center / business district</li><li>Citywide</li></ul></dd>
+    <dt>Affected land uses</dt>
+    <dd><ul><li>Commercial</li><li>Other</li><li>Residential, all uses</li></ul></dd>
     <dt>Requirements</dt>
-      <dd><ul><li>by right</li><li>historic preservation</li><li>in-lieu fees</li><li>other</li></ul></dd>
+      <dd><ul><li>By right</li><li>Historic preservation</li><li>In-lieu fees</li><li>Other</li></ul></dd>
     <dt>Reporter</dt>
       <dd>Samuel Deetz</dd>
   </dl>


### PR DESCRIPTION
Gibson recommended it to look more professional.

I also moved "reform scope" above "affected land use" because land use can be seen as a modifier to the scope.