### PR TITLE
Hide proposed and repealed reforms in 'any parking reforms'

### DIFF
--- a/src/js/FilterState.ts
+++ b/src/js/FilterState.ts
@@ -269,7 +269,7 @@ export class PlaceFilterManager {
     }
 
     if (filterState.policyTypeFilter === "any parking reform") {
-      const policyTypes = determinePolicyTypes(entry);
+      const policyTypes = determinePolicyTypes(entry, { onlyPassed: true });
       const isPolicyType = policyTypes.some((v) =>
         filterState.includedPolicyChanges.has(v),
       );

--- a/src/js/data.ts
+++ b/src/js/data.ts
@@ -61,11 +61,19 @@ export function numberOfPolicyRecords(
 
 export function determinePolicyTypes(
   entry: RawCoreEntry | ProcessedCoreEntry,
+  options: { onlyPassed: boolean },
 ): PolicyType[] {
+  const hasPolicy = (
+    policies: ProcessedCorePolicy[] | RawCorePolicy[] | undefined,
+  ) =>
+    !!policies?.filter((policy) =>
+      options.onlyPassed ? policy.status === "passed" : true,
+    ).length;
+
   const result: PolicyType[] = [];
-  if (entry.add_max?.length) result.push("add parking maximums");
-  if (entry.reduce_min?.length) result.push("reduce parking minimums");
-  if (entry.rm_min?.length) result.push("remove parking minimums");
+  if (hasPolicy(entry.add_max)) result.push("add parking maximums");
+  if (hasPolicy(entry.reduce_min)) result.push("reduce parking minimums");
+  if (hasPolicy(entry.rm_min)) result.push("remove parking minimums");
   return result;
 }
 

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -40,7 +40,7 @@ function generateScorecardRevamp(
   entry: ProcessedCoreEntry,
   placeId: PlaceId,
 ): string {
-  const policyTypes = determinePolicyTypes(entry);
+  const policyTypes = determinePolicyTypes(entry, { onlyPassed: false });
   let singlePolicyType = "";
   let multiplePolicyTypes = "";
   if (policyTypes.length === 1) {

--- a/src/js/table.ts
+++ b/src/js/table.ts
@@ -14,6 +14,7 @@ import {
 import { PlaceFilterManager, PolicyTypeFilter } from "./FilterState";
 import { Date, ProcessedCorePolicy } from "./types";
 import { ViewStateObservable } from "./viewToggle";
+import { determinePolicyTypes } from "./data";
 
 function formatBoolean(cell: CellComponent): string {
   const v = cell.getValue() as boolean;
@@ -176,12 +177,15 @@ export default function initTable(
       policyChange: entry.unifiedPolicy.policy,
       scope: entry.unifiedPolicy.scope,
     });
+
     if (!options.revampEnabled) return;
+
+    const policyTypes = determinePolicyTypes(entry, { onlyPassed: true });
     dataAnyReform.push({
       ...common,
-      reduceMin: !!entry.reduce_min?.length,
-      rmMin: !!entry.rm_min?.length,
-      addMax: !!entry.add_max?.length,
+      reduceMin: policyTypes.includes("reduce parking minimums"),
+      rmMin: policyTypes.includes("remove parking minimums"),
+      addMax: policyTypes.includes("add parking maximums"),
     });
 
     const savePolicies = (


### PR DESCRIPTION
As explained in https://github.com/ParkingReformNetwork/reform-map/pull/686, our handling of the Reform Status is off. Eventually, we plan to have a dropdown to choose which data set to load: passed, proposed, or repealed. 

In the meantime, the views for "add max", "rm min", and "reduce min" do have a Reform Status option that lets you union the three statuses. However, we cannot sensibly expose a status option with 'any parking reforms' because the metadata is policy-record-specific rather than place-specific. So, this PR instead completely removes places with only proposed/repealed reforms from 'any parking reforms'. It removes them from the table view (universe of valid places) & also FilterState so they don't match in the map either.