### PR TITLE
Reorder keys in details page

### DIFF
--- a/scripts/11ty/_includes/policy-record-body.liquid
+++ b/scripts/11ty/_includes/policy-record-body.liquid
@@ -1,12 +1,12 @@
 <p class="summary">{{ record.summary }}</p>
 <dl>
+  <dt>Status</dt>
+  <dd>{{ record.status }}</dd>
   {% if record.date -%}
     <dt>Reform date</dt>
     <dd>{{ record.date }}</dd>
   {%- endif %}
-  <dt>Reform status</dt>
-  <dd>{{ record.status }}</dd>
-  <dt>Reform scope</dt>
+  <dt>Scope</dt>
   <dd>{% render "string-array" array: record.scope %}</dd>
   <dt>Affected land uses</dt>
   <dd>{% render "string-array" array: record.landUse %}</dd>

--- a/scripts/11ty/legacy.liquid
+++ b/scripts/11ty/legacy.liquid
@@ -14,12 +14,12 @@ layout: layout.liquid
   <dl>
     <dt>Reform type</dt>
     <dd>{% render "string-array" array: entry.policyChange %}</dd>
+    <dt>Reform status</dt>
+    <dd>{{ entry.status }}</dd>
     {% if entry.date -%}
       <dt>Reform date</dt>
       <dd>{{ entry.date }}</dd>
     {%- endif %}
-    <dt>Reform status</dt>
-    <dd>{{ entry.status }}</dd>
     <dt>Reform scope</dt>
     <dd>{% render "string-array" array: entry.scope %}</dd>
     <dt>Affected land uses</dt>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
@@ -48,10 +48,10 @@
       <h2>Parking minimum reduction</h2>
       <p class="summary">Parking requirements may be reduced through on-street parking, public parking and proximity to transit.</p>
 <dl>
-  
-  <dt>Reform status</dt>
+  <dt>Status</dt>
   <dd>Adopted</dd>
-  <dt>Reform scope</dt>
+  
+  <dt>Scope</dt>
   <dd>Citywide</dd>
   <dt>Affected land uses</dt>
   <dd><ul><li>All uses</li><li>Commercial</li><li>Industrial</li><li>Medical</li><li>Other</li><li>Residential, multi-family</li></ul></dd>
@@ -81,10 +81,10 @@
       <h2>Parking maximum</h2>
       <p class="summary">Parking maximums are set at 110% of the minimums for nonresidential uses.</p>
 <dl>
-  
-  <dt>Reform status</dt>
+  <dt>Status</dt>
   <dd>Adopted</dd>
-  <dt>Reform scope</dt>
+  
+  <dt>Scope</dt>
   <dd>Citywide</dd>
   <dt>Affected land uses</dt>
   <dd><ul><li>Commercial</li><li>Industrial</li><li>Medical</li><li>Other</li></ul></dd>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
@@ -48,10 +48,10 @@
       <h2>Parking minimum reduction</h2>
       <p class="summary">Existing buildings within the Central Business (CB) district are exempt from parking requirements. On-street parking may count towards minimums for new development in the district.</p>
 <dl>
-  
-  <dt>Reform status</dt>
+  <dt>Status</dt>
   <dd>Adopted</dd>
-  <dt>Reform scope</dt>
+  
+  <dt>Scope</dt>
   <dd>City center / business district</dd>
   <dt>Affected land uses</dt>
   <dd>All uses</dd>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/auburn-me.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/auburn-me.html
@@ -47,11 +47,11 @@
       <h2>Parking minimum removal</h2>
       <p class="summary">Parking requirements have been removed for all uses except for residential uses under Formed Based Code.</p>
 <dl>
+  <dt>Status</dt>
+  <dd>Adopted</dd>
   <dt>Reform date</dt>
     <dd>Jul 19, 2021</dd>
-  <dt>Reform status</dt>
-  <dd>Adopted</dd>
-  <dt>Reform scope</dt>
+  <dt>Scope</dt>
   <dd>Citywide</dd>
   <dt>Affected land uses</dt>
   <dd><ul><li>Commercial</li><li>Industrial</li><li>Other</li></ul></dd>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
@@ -48,10 +48,10 @@
       <h2>Parking minimum reduction</h2>
       <p class="summary">Within the Downtown Parking Area, a fee in lieu of require parking may be provided for commercial or mixed-use developments. Within the CSC District, parking requirements are reduced and on-street parking may be used to satisfy requirements. Uses designated as landmarks have reduced parking requirements citywide.</p>
 <dl>
-  
-  <dt>Reform status</dt>
+  <dt>Status</dt>
   <dd>Adopted</dd>
-  <dt>Reform scope</dt>
+  
+  <dt>Scope</dt>
   <dd><ul><li>City center / business district</li><li>Citywide</li></ul></dd>
   <dt>Affected land uses</dt>
   <dd><ul><li>Commercial</li><li>Other</li><li>Residential, all uses</li></ul></dd>
@@ -84,10 +84,10 @@ Sec. 16-394.(a)</dd>
       <h2>Parking maximum</h2>
       <p class="summary">Within the CSC District, surface parking is prohibited in between any building on the CDC, Lions Park, and Merino Park parcels and the right-of-ways of Two Rivers Road, Midland Avenue, or the Midland Spur.</p>
 <dl>
-  
-  <dt>Reform status</dt>
+  <dt>Status</dt>
   <dd>Adopted</dd>
-  <dt>Reform scope</dt>
+  
+  <dt>Scope</dt>
   <dd>Main street / special</dd>
   <dt>Affected land uses</dt>
   <dd>All uses</dd>


### PR DESCRIPTION
I realized the status is the most important detail about any particular policy record. We also don't need to say the word "Reform" so much because it's clear that's what it is.