### PR TITLE
Rename details page date label based on status

### DIFF
--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -14,6 +14,12 @@ import { escapePlaceId } from "./src/js/data.js";
 function processPolicyRecord(policy: ProcessedCompletePolicy): object {
   return {
     summary: policy.summary,
+    dateLabel:
+      {
+        adopted: "Adoption date",
+        proposed: "Proposal date",
+        repealed: "Repeal date",
+      }[policy.status] ?? "Reform date",
     date: policy.date?.format(),
     status: capitalize(policy.status),
     scope: policy.scope.map(capitalize),

--- a/scripts/11ty/_includes/policy-record-body.liquid
+++ b/scripts/11ty/_includes/policy-record-body.liquid
@@ -3,7 +3,7 @@
   <dt>Status</dt>
   <dd>{{ record.status }}</dd>
   {% if record.date -%}
-    <dt>Reform date</dt>
+    <dt>{{ record.dateLabel }}</dt>
     <dd>{{ record.date }}</dd>
   {%- endif %}
   <dt>Scope</dt>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/auburn-me.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/auburn-me.html
@@ -49,7 +49,7 @@
 <dl>
   <dt>Status</dt>
   <dd>Adopted</dd>
-  <dt>Reform date</dt>
+  <dt>Adoption date</dt>
     <dd>Jul 19, 2021</dd>
   <dt>Scope</dt>
   <dd>Citywide</dd>


### PR DESCRIPTION
This makes the label much more clear

<img width="353" alt="Screenshot 2025-01-02 at 6 38 05 PM" src="https://github.com/user-attachments/assets/8b43dd4d-3407-45e8-99f3-5759fe0272b3" />
<img width="487" alt="Screenshot 2025-01-02 at 6 38 40 PM" src="https://github.com/user-attachments/assets/ac4fee9a-b362-49ea-96d2-937cfae81baa" />
