### PR TITLE
Improve scorecard design & mention status

### DIFF
--- a/src/js/FilterState.ts
+++ b/src/js/FilterState.ts
@@ -9,7 +9,7 @@ import {
   UNKNOWN_YEAR,
 } from "./types";
 import Observable from "./Observable";
-import { determinePolicyTypes, getFilteredIndexes } from "./data";
+import { determineAdoptedPolicyTypes, getFilteredIndexes } from "./data";
 
 export const POPULATION_INTERVALS: Array<[string, number]> = [
   ["100", 100],
@@ -269,7 +269,7 @@ export class PlaceFilterManager {
     }
 
     if (filterState.policyTypeFilter === "any parking reform") {
-      const policyTypes = determinePolicyTypes(entry, { onlyAdopted: true });
+      const policyTypes = determineAdoptedPolicyTypes(entry);
       const isPolicyType = policyTypes.some((v) =>
         filterState.includedPolicyChanges.has(v),
       );

--- a/src/js/counters.ts
+++ b/src/js/counters.ts
@@ -2,6 +2,7 @@ import { isEqual } from "lodash-es";
 
 import { FilterState, PlaceFilterManager } from "./FilterState";
 import { PlaceType, PolicyType } from "./types";
+import { joinWithConjunction } from "./data";
 
 export function determineHtml(
   view: "table" | "map",
@@ -85,12 +86,7 @@ export function determineHtml(
           `Expected state.includedPolicyChanges to be set: ${JSON.stringify(state)}`,
         );
       }
-      if (policyDescriptions.length <= 2) {
-        suffix = policyDescriptions.join(" or ");
-      } else {
-        const lastTerm = policyDescriptions.pop();
-        suffix = `${policyDescriptions.join(", ")}, or ${lastTerm}`;
-      }
+      suffix = joinWithConjunction(policyDescriptions, "or");
     }
     return `${prefix} ${suffix}`;
   }

--- a/src/js/data.ts
+++ b/src/js/data.ts
@@ -185,6 +185,6 @@ export function joinWithConjunction(
     return items.join(` ${conjunction} `);
   }
   const lastItem = items[items.length - 1];
-  const priorItems = items.slice(0, -1)
+  const priorItems = items.slice(0, -1);
   return `${priorItems.join(", ")}, ${conjunction} ${lastItem}`;
 }

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -36,7 +36,7 @@ function generateScorecardLegacy(
     `;
 }
 
-function generateScorecardRevamp(
+export function generateScorecardRevamp(
   entry: ProcessedCoreEntry,
   placeId: PlaceId,
 ): string {

--- a/src/js/scorecard.ts
+++ b/src/js/scorecard.ts
@@ -40,17 +40,10 @@ function generateScorecardRevamp(
   entry: ProcessedCoreEntry,
   placeId: PlaceId,
 ): string {
-  const policyTypes = determinePolicyTypes(entry, { onlyAdopted: false });
-  let singlePolicyType = "";
-  let multiplePolicyTypes = "";
-  if (policyTypes.length === 1) {
-    singlePolicyType = `<li>Reform type: ${policyTypes[0]}</li>`;
-  } else {
-    const policies = policyTypes
-      .map((type) => `<li>${capitalize(type)}</li>`)
-      .join("");
-    multiplePolicyTypes = `<div>Reform types:</div><ul>${policies}</ul>`;
-  }
+  const policies = determinePolicyTypes(entry, { onlyAdopted: false })
+    .map((type) => `<li>${capitalize(type)}</li>`)
+    .join("");
+  const policyTypesHtml = `<div>Reform types:</div><ul>${policies}</ul>`;
 
   const allMinimumsRemoved = entry.place.repeal
     ? "<li>All parking minimums removed</li>"
@@ -68,14 +61,13 @@ function generateScorecardRevamp(
       </button>
     </header>
     <ul>
-      <li><a class="external-link" target="_blank" href=${
-        entry.place.url
-      }>Reform details and citations <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a></li>
       <li>${entry.place.pop.toLocaleString()} residents</li>
       ${allMinimumsRemoved}
-      ${singlePolicyType}
     </ul>
-    ${multiplePolicyTypes}
+    ${policyTypesHtml}
+    <a class="external-link" target="_blank" href=${
+      entry.place.url
+    }>Details and citations <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a>
     `;
 }
 

--- a/src/js/table.ts
+++ b/src/js/table.ts
@@ -14,7 +14,7 @@ import {
 import { PlaceFilterManager, PolicyTypeFilter } from "./FilterState";
 import { Date, ProcessedCorePolicy } from "./types";
 import { ViewStateObservable } from "./viewToggle";
-import { determinePolicyTypes } from "./data";
+import { determineAdoptedPolicyTypes } from "./data";
 
 function formatBoolean(cell: CellComponent): string {
   const v = cell.getValue() as boolean;
@@ -180,7 +180,7 @@ export default function initTable(
 
     if (!options.revampEnabled) return;
 
-    const policyTypes = determinePolicyTypes(entry, { onlyAdopted: true });
+    const policyTypes = determineAdoptedPolicyTypes(entry);
     dataAnyReform.push({
       ...common,
       reduceMin: policyTypes.includes("reduce parking minimums"),

--- a/tests/app/data.test.ts
+++ b/tests/app/data.test.ts
@@ -4,6 +4,7 @@ import {
   escapePlaceId,
   placeIdToUrl,
   getFilteredIndexes,
+  joinWithConjunction,
 } from "../../src/js/data";
 
 test("escapePlaceID", () => {
@@ -21,4 +22,26 @@ test("getFilteredIndexes", () => {
   expect(getFilteredIndexes(["a", "b", "c"], (x) => x !== "b")).toEqual([0, 2]);
   expect(getFilteredIndexes(["a", "b", "c"], (x) => x === "b")).toEqual([1]);
   expect(getFilteredIndexes(["a", "b", "c"], (x) => x === "z")).toEqual([]);
+});
+
+test("joinWithConjunction", () => {
+  expect(joinWithConjunction([], "and")).toEqual("");
+  expect(joinWithConjunction(["apple"], "and")).toEqual("apple");
+
+  expect(joinWithConjunction(["apple", "banana"], "and")).toEqual(
+    "apple and banana",
+  );
+  expect(joinWithConjunction(["read", "write"], "or")).toEqual("read or write");
+
+  expect(joinWithConjunction(["apple", "banana", "orange"], "and")).toEqual(
+    "apple, banana, and orange",
+  );
+  expect(
+    joinWithConjunction(["read", "write", "execute", "delete"], "or"),
+  ).toEqual("read, write, execute, or delete");
+
+  expect(
+    joinWithConjunction(["  space  ", "tab\t", "\nnewline"], "and"),
+  ).toEqual("  space  , tab\t, and \nnewline");
+  expect(joinWithConjunction(["!", "@", "#"], "or")).toEqual("!, @, or #");
 });


### PR DESCRIPTION
We now always use a bullet list for the reform types. The details link comes at the end:

![image](https://github.com/user-attachments/assets/87a73fcf-5006-47c5-9541-51b62cd9a1de)
![image](https://github.com/user-attachments/assets/a71356f0-93ea-4179-ac1d-7655a3b204ef)

If at least one policy record is proposed or repealed (vs adopted), we show the status with everything:

![image](https://github.com/user-attachments/assets/20e02f90-701c-4e79-801a-11a418f1dd82)
![image](https://github.com/user-attachments/assets/accee630-a0d2-4d96-a7f1-79c30c51cd27)
