### PR TITLE
Refactor counters

### DIFF
--- a/src/js/FilterState.ts
+++ b/src/js/FilterState.ts
@@ -85,7 +85,6 @@ interface CacheEntry {
   matchedCountries: Set<string>;
   matchedPolicyTypesForAnyPolicy: Set<PolicyType>;
   matchedPlaceTypes: Set<PlaceType>;
-  numMatchedPolicyRecordsForSinglePolicy: number;
 }
 
 export class PlaceFilterManager {
@@ -109,13 +108,6 @@ export class PlaceFilterManager {
 
   get matchedPlaces(): Record<PlaceId, PlaceMatch> {
     return this.ensureCache().matchedPlaces;
-  }
-
-  /// The number of matching policy records, given that a place may have >1 policy record.
-  ///
-  /// Note that this will be zero with 'any parking reform' and 'search'.
-  get numMatchedPolicyRecords(): number {
-    return this.ensureCache().numMatchedPolicyRecordsForSinglePolicy;
   }
 
   get placeIds(): Set<PlaceId> {
@@ -168,16 +160,12 @@ export class PlaceFilterManager {
     const matchedCountries = new Set<string>();
     const matchedPolicyTypes = new Set<PolicyType>();
     const matchedPlaceTypes = new Set<PlaceType>();
-    let numMatchedPolicyRecords = 0;
     for (const placeId in this.entries) {
       const match = this.getPlaceMatch(placeId);
       if (!match) continue;
       matchedPlaces[placeId] = match;
       matchedCountries.add(this.entries[placeId].place.country);
       matchedPlaceTypes.add(this.entries[placeId].place.type);
-      if (match.type === "single policy") {
-        numMatchedPolicyRecords += match.matchingIndexes.length;
-      }
       if (match.type === "any") {
         if (match.hasAddMax) matchedPolicyTypes.add("add parking maximums");
         if (match.hasReduceMin)
@@ -192,7 +180,6 @@ export class PlaceFilterManager {
       matchedCountries,
       matchedPolicyTypesForAnyPolicy: matchedPolicyTypes,
       matchedPlaceTypes,
-      numMatchedPolicyRecordsForSinglePolicy: numMatchedPolicyRecords,
     };
     return this.cache;
   }

--- a/src/js/counters.ts
+++ b/src/js/counters.ts
@@ -105,7 +105,6 @@ export function determineRemoveMin(
 }
 
 export function determineHtml(
-  view: "table" | "map",
   state: FilterState,
   numPlaces: number,
   matchedPolicyTypes: Set<PolicyType>,
@@ -172,7 +171,6 @@ export default function initCounters(manager: PlaceFilterManager): void {
 
   manager.subscribe("update counters", (state) => {
     mapCounter.innerHTML = determineHtml(
-      "map",
       state,
       manager.placeIds.size,
       manager.matchedPolicyTypes,
@@ -180,7 +178,6 @@ export default function initCounters(manager: PlaceFilterManager): void {
       manager.matchedPlaceTypes,
     );
     tableCounter.innerHTML = determineHtml(
-      "table",
       state,
       manager.placeIds.size,
       manager.matchedPolicyTypes,

--- a/src/js/counters.ts
+++ b/src/js/counters.ts
@@ -44,18 +44,16 @@ export function determineLegacy(
   return `Showing ${placeDescription} with ${suffix}`;
 }
 
-export function determineAnyParkingReform(
+export function determineAnyReform(
   placeDescription: string,
-  state: FilterState,
   matchedPolicyTypes: Set<PolicyType>,
+  allMinimumsRemovedToggle: boolean,
+  statePolicyTypes: Set<string>,
 ): string {
   const prefix = `Showing ${placeDescription} with`;
 
-  if (state.allMinimumsRemovedToggle) {
-    const suffix = isEqual(
-      state.includedPolicyChanges,
-      new Set(["add parking maximums"]),
-    )
+  if (allMinimumsRemovedToggle) {
+    const suffix = isEqual(statePolicyTypes, new Set(["add parking maximums"]))
       ? "both all parking minimums removed and parking maximums added"
       : "all parking minimums removed";
     return `${prefix} ${suffix}`;
@@ -66,21 +64,19 @@ export function determineAnyParkingReform(
     "reduce parking minimums": "parking minimums reduced",
     "remove parking minimums": "parking minimums removed",
   };
-  const policyDescriptions = Array.from(state.includedPolicyChanges)
+  const policyDescriptions = Array.from(statePolicyTypes)
     .filter((policy) => matchedPolicyTypes.has(policy as PolicyType))
     .map((policy) => policyDescriptionMap[policy as PolicyType])
     .sort()
     .reverse();
   if (!policyDescriptions.length) {
-    throw new Error(
-      `Expected state.includedPolicyChanges to be set: ${JSON.stringify(state)}`,
-    );
+    throw new Error(`Expected state.includedPolicyChanges to be set`);
   }
   const suffix = joinWithConjunction(policyDescriptions, "or");
   return `${prefix} ${suffix}`;
 }
 
-export function determineReduceMinimums(placeDescription: string): string {
+export function determineReduceMin(placeDescription: string): string {
   return `Showing ${placeDescription} with parking minimums reduced`;
 }
 
@@ -94,7 +90,7 @@ export function determineAddMax(
   return `Showing ${placeDescription} with ${suffix}`;
 }
 
-export function determineRemoveMin(
+export function determineRmMin(
   placeDescription: string,
   allMinimumsRemovedToggle: boolean,
 ): string {
@@ -128,20 +124,18 @@ export function determineHtml(
     case "legacy reform":
       return determineLegacy(placeDescription, state.allMinimumsRemovedToggle);
     case "any parking reform":
-      return determineAnyParkingReform(
+      return determineAnyReform(
         placeDescription,
-        state,
         matchedPolicyTypes,
+        state.allMinimumsRemovedToggle,
+        state.includedPolicyChanges,
       );
     case "reduce parking minimums":
-      return determineReduceMinimums(placeDescription);
+      return determineReduceMin(placeDescription);
     case "add parking maximums":
       return determineAddMax(placeDescription, state.allMinimumsRemovedToggle);
     case "remove parking minimums":
-      return determineRemoveMin(
-        placeDescription,
-        state.allMinimumsRemovedToggle,
-      );
+      return determineRmMin(placeDescription, state.allMinimumsRemovedToggle);
     default:
       throw new Error("unreachable");
   }

--- a/src/js/counters.ts
+++ b/src/js/counters.ts
@@ -4,11 +4,110 @@ import { FilterState, PlaceFilterManager } from "./FilterState";
 import { PlaceType, PolicyType } from "./types";
 import { joinWithConjunction } from "./data";
 
+export function determinePlaceDescription(
+  numPlaces: number,
+  matchedCountries: Set<string>,
+  matchedPlaceTypes: Set<PlaceType>,
+): string {
+  let country =
+    matchedCountries.size === 1
+      ? Array.from(matchedCountries)[0]
+      : `${matchedCountries.size} countries`;
+  if (country === "United States" || country === "United Kingdom") {
+    country = `the ${country}`;
+  }
+
+  if (isEqual(matchedPlaceTypes, new Set(["city"]))) {
+    const label = numPlaces === 1 ? "city" : "cities";
+    return `${numPlaces} ${label} in ${country}`;
+  } else if (isEqual(matchedPlaceTypes, new Set(["county"]))) {
+    const label = numPlaces === 1 ? "county" : "counties";
+    return `${numPlaces} ${label} in ${country}`;
+  } else if (isEqual(matchedPlaceTypes, new Set(["state"]))) {
+    const label = numPlaces === 1 ? "state" : "states";
+    return `${numPlaces} ${label} in ${country}`;
+  } else if (isEqual(matchedPlaceTypes, new Set(["country"]))) {
+    return numPlaces === 1 ? "1 country" : `${numPlaces} countries`;
+  } else {
+    const label = numPlaces === 1 ? "place" : "places";
+    return `${numPlaces} ${label} in ${country}`;
+  }
+}
+
+export function determineLegacy(
+  placeDescription: string,
+  allMinimumsRemovedToggle: boolean,
+): string {
+  const suffix = allMinimumsRemovedToggle
+    ? `all parking minimums removed`
+    : `parking reforms`;
+  return `Showing ${placeDescription} with ${suffix}`;
+}
+
+export function determineAnyParkingReform(
+  placeDescription: string,
+  state: FilterState,
+  matchedPolicyTypes: Set<PolicyType>,
+): string {
+  const prefix = `Showing ${placeDescription} with`;
+
+  if (state.allMinimumsRemovedToggle) {
+    const suffix = isEqual(
+      state.includedPolicyChanges,
+      new Set(["add parking maximums"]),
+    )
+      ? "both all parking minimums removed and parking maximums added"
+      : "all parking minimums removed";
+    return `${prefix} ${suffix}`;
+  }
+
+  const policyDescriptionMap: Record<PolicyType, string> = {
+    "add parking maximums": "parking maximums added",
+    "reduce parking minimums": "parking minimums reduced",
+    "remove parking minimums": "parking minimums removed",
+  };
+  const policyDescriptions = Array.from(state.includedPolicyChanges)
+    .filter((policy) => matchedPolicyTypes.has(policy as PolicyType))
+    .map((policy) => policyDescriptionMap[policy as PolicyType])
+    .sort()
+    .reverse();
+  if (!policyDescriptions.length) {
+    throw new Error(
+      `Expected state.includedPolicyChanges to be set: ${JSON.stringify(state)}`,
+    );
+  }
+  const suffix = joinWithConjunction(policyDescriptions, "or");
+  return `${prefix} ${suffix}`;
+}
+
+export function determineReduceMinimums(placeDescription: string): string {
+  return `Showing ${placeDescription} with parking minimums reduced`;
+}
+
+export function determineAddMax(
+  placeDescription: string,
+  allMinimumsRemovedToggle: boolean,
+): string {
+  const suffix = allMinimumsRemovedToggle
+    ? "both all parking minimums removed and parking maximums added"
+    : "parking maximums added";
+  return `Showing ${placeDescription} with ${suffix}`;
+}
+
+export function determineRemoveMin(
+  placeDescription: string,
+  allMinimumsRemovedToggle: boolean,
+): string {
+  const suffix = allMinimumsRemovedToggle
+    ? `all parking minimums removed`
+    : `parking minimums removed`;
+  return `Showing ${placeDescription} with ${suffix}`;
+}
+
 export function determineHtml(
   view: "table" | "map",
   state: FilterState,
   numPlaces: number,
-  numPolicyRecords: number,
   matchedPolicyTypes: Set<PolicyType>,
   matchedCountries: Set<string>,
   matchedPlaceTypes: Set<PlaceType>,
@@ -20,113 +119,33 @@ export function determineHtml(
     return `Showing ${state.searchInput} from search — <a class="counter-search-reset" role="button" aria-label="reset search">reset</a>`;
   }
 
-  let country =
-    matchedCountries.size === 1
-      ? Array.from(matchedCountries)[0]
-      : `${matchedCountries.size} countries`;
-  if (country === "United States" || country === "United Kingdom") {
-    country = `the ${country}`;
+  const placeDescription = determinePlaceDescription(
+    numPlaces,
+    matchedCountries,
+    matchedPlaceTypes,
+  );
+
+  switch (state.policyTypeFilter) {
+    case "legacy reform":
+      return determineLegacy(placeDescription, state.allMinimumsRemovedToggle);
+    case "any parking reform":
+      return determineAnyParkingReform(
+        placeDescription,
+        state,
+        matchedPolicyTypes,
+      );
+    case "reduce parking minimums":
+      return determineReduceMinimums(placeDescription);
+    case "add parking maximums":
+      return determineAddMax(placeDescription, state.allMinimumsRemovedToggle);
+    case "remove parking minimums":
+      return determineRemoveMin(
+        placeDescription,
+        state.allMinimumsRemovedToggle,
+      );
+    default:
+      throw new Error("unreachable");
   }
-
-  let placeDescription;
-  if (isEqual(matchedPlaceTypes, new Set(["city"]))) {
-    const label = numPlaces === 1 ? "city" : "cities";
-    placeDescription = `${label} in ${country}`;
-  } else if (isEqual(matchedPlaceTypes, new Set(["county"]))) {
-    const label = numPlaces === 1 ? "county" : "counties";
-    placeDescription = `${label} in ${country}`;
-  } else if (isEqual(matchedPlaceTypes, new Set(["state"]))) {
-    const label = numPlaces === 1 ? "state" : "states";
-    placeDescription = `${label} in ${country}`;
-  } else if (isEqual(matchedPlaceTypes, new Set(["country"]))) {
-    placeDescription = numPlaces === 1 ? "country" : "countries";
-  } else {
-    const label = numPlaces === 1 ? "place" : "places";
-    placeDescription = `${label} in ${country}`;
-  }
-  const prefix = `Showing ${numPlaces} ${placeDescription} with`;
-
-  // We only show the number of policy records when it's useful information to the user
-  // because it would otherwise be noisy.
-  const recordsWord = numPolicyRecords === 1 ? "record" : "records";
-  const showRecords = view === "table" && numPlaces !== numPolicyRecords;
-  const multipleRecordsExplanation =
-    "because some places have multiple records";
-
-  if (state.policyTypeFilter === "legacy reform") {
-    const suffix = state.allMinimumsRemovedToggle
-      ? "all parking minimums removed"
-      : "parking reforms";
-    return `${prefix} ${suffix}`;
-  }
-
-  if (state.policyTypeFilter === "any parking reform") {
-    // We customize the text based on which policy changes are selected.
-    let suffix;
-    if (state.allMinimumsRemovedToggle) {
-      suffix = isEqual(
-        state.includedPolicyChanges,
-        new Set(["add parking maximums"]),
-      )
-        ? "both all parking minimums removed and parking maximums added"
-        : "all parking minimums removed";
-    } else {
-      const policyDescriptionMap: Record<PolicyType, string> = {
-        "add parking maximums": "parking maximums added",
-        "reduce parking minimums": "parking minimums reduced",
-        "remove parking minimums": "parking minimums removed",
-      };
-      const policyDescriptions = Array.from(state.includedPolicyChanges)
-        .filter((policy) => matchedPolicyTypes.has(policy as PolicyType))
-        .map((policy) => policyDescriptionMap[policy as PolicyType])
-        .sort()
-        .reverse();
-      if (!policyDescriptions.length) {
-        throw new Error(
-          `Expected state.includedPolicyChanges to be set: ${JSON.stringify(state)}`,
-        );
-      }
-      suffix = joinWithConjunction(policyDescriptions, "or");
-    }
-    return `${prefix} ${suffix}`;
-  }
-
-  if (state.policyTypeFilter === "reduce parking minimums") {
-    const firstSentence = `${prefix} parking minimums reduced`;
-    return showRecords
-      ? `${firstSentence}. Matched ${numPolicyRecords} total policy ${recordsWord} ${multipleRecordsExplanation}.`
-      : firstSentence;
-  }
-
-  if (state.policyTypeFilter === "add parking maximums") {
-    let firstSentenceSuffix;
-    let secondSentence;
-    if (state.allMinimumsRemovedToggle) {
-      firstSentenceSuffix =
-        "both all parking minimums removed and parking maximums added";
-      secondSentence = `Matched ${numPolicyRecords} total parking maximum policy ${recordsWord} ${multipleRecordsExplanation}`;
-    } else {
-      firstSentenceSuffix = "parking maximums added";
-      secondSentence = `Matched ${numPolicyRecords} total policy ${recordsWord} ${multipleRecordsExplanation}`;
-    }
-    const firstSentence = `${prefix} ${firstSentenceSuffix}`;
-    return showRecords ? `${firstSentence}. ${secondSentence}.` : firstSentence;
-  }
-
-  if (state.policyTypeFilter === "remove parking minimums") {
-    // It's not necessary to say the # of policy records when allMinimumsRemovedToggle is true because the place should have
-    // only one removal policy record that is citywide & all land uses.
-    if (state.allMinimumsRemovedToggle) {
-      return `${prefix} all parking minimums removed`;
-    }
-
-    const firstSentence = `${prefix} parking minimums removed`;
-    return showRecords
-      ? `${firstSentence}. Matched ${numPolicyRecords} total policy ${recordsWord} ${multipleRecordsExplanation}.`
-      : firstSentence;
-  }
-
-  throw new Error("unreachable");
 }
 
 function setUpResetButton(
@@ -156,7 +175,6 @@ export default function initCounters(manager: PlaceFilterManager): void {
       "map",
       state,
       manager.placeIds.size,
-      manager.numMatchedPolicyRecords,
       manager.matchedPolicyTypes,
       manager.matchedCountries,
       manager.matchedPlaceTypes,
@@ -165,7 +183,6 @@ export default function initCounters(manager: PlaceFilterManager): void {
       "table",
       state,
       manager.placeIds.size,
-      manager.numMatchedPolicyRecords,
       manager.matchedPolicyTypes,
       manager.matchedCountries,
       manager.matchedPlaceTypes,

--- a/tests/app/counters.test.ts
+++ b/tests/app/counters.test.ts
@@ -29,7 +29,6 @@ test.describe("determineHtml", () => {
       "map",
       DEFAULT_STATE,
       0,
-      0,
       new Set(),
       new Set(),
       new Set(),
@@ -37,7 +36,6 @@ test.describe("determineHtml", () => {
     const resultTable = determineHtml(
       "table",
       DEFAULT_STATE,
-      0,
       0,
       new Set(),
       new Set(),
@@ -54,7 +52,6 @@ test.describe("determineHtml", () => {
       "map",
       state,
       1,
-      0,
       new Set(),
       new Set(),
       new Set(),
@@ -63,7 +60,6 @@ test.describe("determineHtml", () => {
       "table",
       state,
       1,
-      0,
       new Set(),
       new Set(),
       new Set(),
@@ -84,7 +80,6 @@ test.describe("determineHtml", () => {
         "map",
         state,
         5,
-        0,
         new Set(matchedPolicyTypes),
         new Set(["Mexico"]),
         new Set(["city", "county"]),
@@ -93,7 +88,6 @@ test.describe("determineHtml", () => {
         "table",
         state,
         5,
-        0,
         new Set(matchedPolicyTypes),
         new Set(["Mexico"]),
         new Set(["city", "county"]),
@@ -190,7 +184,6 @@ test.describe("determineHtml", () => {
       "map",
       state,
       5,
-      6,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
@@ -198,7 +191,6 @@ test.describe("determineHtml", () => {
     const resultTableEqualRecords = determineHtml(
       "table",
       state,
-      5,
       5,
       new Set(),
       new Set(["Mexico", "Brazil"]),
@@ -208,7 +200,6 @@ test.describe("determineHtml", () => {
       "table",
       state,
       5,
-      6,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
@@ -216,7 +207,7 @@ test.describe("determineHtml", () => {
     const expectedNoRecords =
       "Showing 5 places in 2 countries with parking minimums reduced";
     const expectedRecords =
-      "Showing 5 places in 2 countries with parking minimums reduced. Matched 6 total policy records because some places have multiple records.";
+      "Showing 5 places in 2 countries with parking minimums reduced";
     expect(resultMap).toEqual(expectedNoRecords);
     expect(resultTableEqualRecords).toEqual(expectedNoRecords);
     expect(resultTableUnequalRecords).toEqual(expectedRecords);
@@ -231,7 +222,6 @@ test.describe("determineHtml", () => {
       "map",
       allMinimumsRemovedState,
       5,
-      6,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
@@ -239,7 +229,6 @@ test.describe("determineHtml", () => {
     const allMinimumsRemovedTableEqualRecords = determineHtml(
       "table",
       allMinimumsRemovedState,
-      5,
       5,
       new Set(),
       new Set(["Mexico", "Brazil"]),
@@ -249,7 +238,6 @@ test.describe("determineHtml", () => {
       "table",
       allMinimumsRemovedState,
       5,
-      6,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
@@ -268,7 +256,6 @@ test.describe("determineHtml", () => {
       "map",
       state,
       5,
-      6,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
@@ -276,7 +263,6 @@ test.describe("determineHtml", () => {
     const resultTableEqualRecords = determineHtml(
       "table",
       state,
-      5,
       5,
       new Set(),
       new Set(["Mexico", "Brazil"]),
@@ -286,7 +272,6 @@ test.describe("determineHtml", () => {
       "table",
       state,
       5,
-      6,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
@@ -294,7 +279,7 @@ test.describe("determineHtml", () => {
     const expectedNoRecords =
       "Showing 5 places in 2 countries with parking minimums removed";
     const expectedRecords =
-      "Showing 5 places in 2 countries with parking minimums removed. Matched 6 total policy records because some places have multiple records.";
+      "Showing 5 places in 2 countries with parking minimums removed";
     expect(resultMap).toEqual(expectedNoRecords);
     expect(resultTableEqualRecords).toEqual(expectedNoRecords);
     expect(resultTableUnequalRecords).toEqual(expectedRecords);
@@ -308,7 +293,6 @@ test.describe("determineHtml", () => {
       "map",
       allMinimumsRemovedState,
       5,
-      6,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
@@ -316,7 +300,6 @@ test.describe("determineHtml", () => {
     const allMinimumsRemovedTableEqualRecords = determineHtml(
       "table",
       allMinimumsRemovedState,
-      5,
       5,
       new Set(),
       new Set(["Mexico", "Brazil"]),
@@ -326,7 +309,6 @@ test.describe("determineHtml", () => {
       "table",
       allMinimumsRemovedState,
       5,
-      6,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
@@ -351,7 +333,6 @@ test.describe("determineHtml", () => {
       "map",
       state,
       5,
-      6,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
@@ -359,7 +340,6 @@ test.describe("determineHtml", () => {
     const resultTableEqualRecords = determineHtml(
       "table",
       state,
-      5,
       5,
       new Set(),
       new Set(["Mexico", "Brazil"]),
@@ -369,7 +349,6 @@ test.describe("determineHtml", () => {
       "table",
       state,
       5,
-      6,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
@@ -377,7 +356,7 @@ test.describe("determineHtml", () => {
     const expectedNoRecords =
       "Showing 5 places in 2 countries with parking maximums added";
     const expectedRecords =
-      "Showing 5 places in 2 countries with parking maximums added. Matched 6 total policy records because some places have multiple records.";
+      "Showing 5 places in 2 countries with parking maximums added";
     expect(resultMap).toEqual(expectedNoRecords);
     expect(resultTableEqualRecords).toEqual(expectedNoRecords);
     expect(resultTableUnequalRecords).toEqual(expectedRecords);
@@ -391,7 +370,6 @@ test.describe("determineHtml", () => {
       "map",
       allMinimumsRemovedState,
       5,
-      6,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
@@ -399,7 +377,6 @@ test.describe("determineHtml", () => {
     const allMinimumsRemovedTableEqualRecords = determineHtml(
       "table",
       allMinimumsRemovedState,
-      5,
       5,
       new Set(),
       new Set(["Mexico", "Brazil"]),
@@ -409,7 +386,6 @@ test.describe("determineHtml", () => {
       "table",
       allMinimumsRemovedState,
       5,
-      6,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
@@ -417,7 +393,7 @@ test.describe("determineHtml", () => {
     const allMinimumsRemovedExpectedEqualRecords =
       "Showing 5 places in 2 countries with both all parking minimums removed and parking maximums added";
     const allMinimumsRemovedExpectedUnequalRecords =
-      "Showing 5 places in 2 countries with both all parking minimums removed and parking maximums added. Matched 6 total parking maximum policy records because some places have multiple records.";
+      "Showing 5 places in 2 countries with both all parking minimums removed and parking maximums added";
     expect(allMinimumsRemovedMap).toEqual(
       allMinimumsRemovedExpectedEqualRecords,
     );
@@ -434,13 +410,12 @@ test.describe("determineHtml", () => {
       "table",
       { ...DEFAULT_STATE, policyTypeFilter: "reduce parking minimums" },
       1,
-      2,
       new Set(),
       new Set(["United States"]),
       new Set(["city", "county"]),
     );
     expect(result).toEqual(
-      "Showing 1 place in the United States with parking minimums reduced. Matched 2 total policy records because some places have multiple records.",
+      "Showing 1 place in the United States with parking minimums reduced",
     );
   });
 
@@ -448,7 +423,6 @@ test.describe("determineHtml", () => {
     const city = determineHtml(
       "map",
       { ...DEFAULT_STATE, policyTypeFilter: "reduce parking minimums" },
-      2,
       2,
       new Set(),
       new Set(["Mexico"]),
@@ -462,7 +436,6 @@ test.describe("determineHtml", () => {
       "map",
       { ...DEFAULT_STATE, policyTypeFilter: "reduce parking minimums" },
       2,
-      2,
       new Set(),
       new Set(["Mexico"]),
       new Set(["county"]),
@@ -475,7 +448,6 @@ test.describe("determineHtml", () => {
       "map",
       { ...DEFAULT_STATE, policyTypeFilter: "reduce parking minimums" },
       2,
-      2,
       new Set(),
       new Set(["Mexico"]),
       new Set(["state"]),
@@ -487,7 +459,6 @@ test.describe("determineHtml", () => {
     const country = determineHtml(
       "map",
       { ...DEFAULT_STATE, policyTypeFilter: "reduce parking minimums" },
-      1,
       1,
       new Set(),
       new Set(["Mexico"]),

--- a/tests/app/counters.test.ts
+++ b/tests/app/counters.test.ts
@@ -25,75 +25,40 @@ test.describe("determineHtml", () => {
   };
 
   test("no places", () => {
-    const resultMap = determineHtml(
-      "map",
+    const result = determineHtml(
       DEFAULT_STATE,
       0,
       new Set(),
       new Set(),
       new Set(),
     );
-    const resultTable = determineHtml(
-      "table",
-      DEFAULT_STATE,
-      0,
-      new Set(),
-      new Set(),
-      new Set(),
+    expect(result).toEqual(
+      "No places selected — use the filter or search icons",
     );
-    const expected = "No places selected — use the filter or search icons";
-    expect(resultMap).toEqual(expected);
-    expect(resultTable).toEqual(expected);
   });
 
   test("search", () => {
     const state = { ...DEFAULT_STATE, searchInput: "My Town" };
-    const resultMap = determineHtml(
-      "map",
-      state,
-      1,
-      new Set(),
-      new Set(),
-      new Set(),
+    const result = determineHtml(state, 1, new Set(), new Set(), new Set());
+    expect(result).toEqual(
+      'Showing My Town from search — <a class="counter-search-reset" role="button" aria-label="reset search">reset</a>',
     );
-    const resultTable = determineHtml(
-      "table",
-      state,
-      1,
-      new Set(),
-      new Set(),
-      new Set(),
-    );
-    const expected =
-      'Showing My Town from search — <a class="counter-search-reset" role="button" aria-label="reset search">reset</a>';
-    expect(resultMap).toEqual(expected);
-    expect(resultTable).toEqual(expected);
   });
 
   test("any parking reform", () => {
-    const assertMapAndTable = (
+    const assert = (
       state: FilterState,
       matchedPolicyTypes: PolicyType[],
       expected: string,
     ): void => {
-      const resultMap = determineHtml(
-        "map",
+      const result = determineHtml(
         state,
         5,
         new Set(matchedPolicyTypes),
         new Set(["Mexico"]),
         new Set(["city", "county"]),
       );
-      const resultTable = determineHtml(
-        "table",
-        state,
-        5,
-        new Set(matchedPolicyTypes),
-        new Set(["Mexico"]),
-        new Set(["city", "county"]),
-      );
-      expect(resultMap).toEqual(expected);
-      expect(resultTable).toEqual(expected);
+      expect(result).toEqual(expected);
     };
 
     const everyPolicyType: PolicyType[] = [
@@ -104,23 +69,23 @@ test.describe("determineHtml", () => {
 
     // We only show policy types that are both present in the matched places &
     // the user requested to see via `includedPolicyChanges`.
-    assertMapAndTable(
+    assert(
       DEFAULT_STATE,
       everyPolicyType,
       "Showing 5 places in Mexico with parking minimums removed, parking minimums reduced, or parking maximums added",
     );
-    assertMapAndTable(
+    assert(
       DEFAULT_STATE,
       ["add parking maximums", "remove parking minimums"],
       "Showing 5 places in Mexico with parking minimums removed or parking maximums added",
     );
-    assertMapAndTable(
+    assert(
       DEFAULT_STATE,
       ["add parking maximums"],
       "Showing 5 places in Mexico with parking maximums added",
     );
 
-    assertMapAndTable(
+    assert(
       {
         ...DEFAULT_STATE,
         includedPolicyChanges: new Set([
@@ -131,7 +96,7 @@ test.describe("determineHtml", () => {
       everyPolicyType,
       "Showing 5 places in Mexico with parking minimums removed or parking minimums reduced",
     );
-    assertMapAndTable(
+    assert(
       {
         ...DEFAULT_STATE,
         includedPolicyChanges: new Set(["remove parking minimums"]),
@@ -139,7 +104,7 @@ test.describe("determineHtml", () => {
       everyPolicyType,
       "Showing 5 places in Mexico with parking minimums removed",
     );
-    assertMapAndTable(
+    assert(
       {
         ...DEFAULT_STATE,
         includedPolicyChanges: new Set(["reduce parking minimums"]),
@@ -147,7 +112,7 @@ test.describe("determineHtml", () => {
       everyPolicyType,
       "Showing 5 places in Mexico with parking minimums reduced",
     );
-    assertMapAndTable(
+    assert(
       {
         ...DEFAULT_STATE,
         includedPolicyChanges: new Set(["add parking maximums"]),
@@ -156,7 +121,7 @@ test.describe("determineHtml", () => {
       "Showing 5 places in Mexico with parking maximums added",
     );
 
-    assertMapAndTable(
+    assert(
       {
         ...DEFAULT_STATE,
         allMinimumsRemovedToggle: true,
@@ -164,7 +129,7 @@ test.describe("determineHtml", () => {
       everyPolicyType,
       "Showing 5 places in Mexico with all parking minimums removed",
     );
-    assertMapAndTable(
+    assert(
       {
         ...DEFAULT_STATE,
         allMinimumsRemovedToggle: true,
@@ -176,238 +141,99 @@ test.describe("determineHtml", () => {
   });
 
   test("reduce minimums", () => {
-    const state: FilterState = {
-      ...DEFAULT_STATE,
-      policyTypeFilter: "reduce parking minimums",
-    };
-    const resultMap = determineHtml(
-      "map",
-      state,
+    const result = determineHtml(
+      {
+        ...DEFAULT_STATE,
+        policyTypeFilter: "reduce parking minimums",
+      },
       5,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
     );
-    const resultTableEqualRecords = determineHtml(
-      "table",
-      state,
-      5,
-      new Set(),
-      new Set(["Mexico", "Brazil"]),
-      new Set(["city", "county"]),
-    );
-    const resultTableUnequalRecords = determineHtml(
-      "table",
-      state,
-      5,
-      new Set(),
-      new Set(["Mexico", "Brazil"]),
-      new Set(["city", "county"]),
-    );
-    const expectedNoRecords =
+    const expected =
       "Showing 5 places in 2 countries with parking minimums reduced";
-    const expectedRecords =
-      "Showing 5 places in 2 countries with parking minimums reduced";
-    expect(resultMap).toEqual(expectedNoRecords);
-    expect(resultTableEqualRecords).toEqual(expectedNoRecords);
-    expect(resultTableUnequalRecords).toEqual(expectedRecords);
+    expect(result).toEqual(expected);
 
     // allMinimumsRemovedToggle doesn't matter
-    const allMinimumsRemovedState: FilterState = {
-      ...DEFAULT_STATE,
-      policyTypeFilter: "reduce parking minimums",
-      allMinimumsRemovedToggle: true,
-    };
-    const allMinimumsRemovedMap = determineHtml(
-      "map",
-      allMinimumsRemovedState,
+    const allMinimumsRemoved = determineHtml(
+      {
+        ...DEFAULT_STATE,
+        policyTypeFilter: "reduce parking minimums",
+        allMinimumsRemovedToggle: true,
+      },
       5,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
     );
-    const allMinimumsRemovedTableEqualRecords = determineHtml(
-      "table",
-      allMinimumsRemovedState,
-      5,
-      new Set(),
-      new Set(["Mexico", "Brazil"]),
-      new Set(["city", "county"]),
-    );
-    const allMinimumsRemovedTableUnequalRecords = determineHtml(
-      "table",
-      allMinimumsRemovedState,
-      5,
-      new Set(),
-      new Set(["Mexico", "Brazil"]),
-      new Set(["city", "county"]),
-    );
-    expect(allMinimumsRemovedMap).toEqual(expectedNoRecords);
-    expect(allMinimumsRemovedTableEqualRecords).toEqual(expectedNoRecords);
-    expect(allMinimumsRemovedTableUnequalRecords).toEqual(expectedRecords);
+    expect(allMinimumsRemoved).toEqual(expected);
   });
 
   test("remove minimums", () => {
-    const state: FilterState = {
-      ...DEFAULT_STATE,
-      policyTypeFilter: "remove parking minimums",
-    };
-    const resultMap = determineHtml(
-      "map",
-      state,
+    const result = determineHtml(
+      {
+        ...DEFAULT_STATE,
+        policyTypeFilter: "remove parking minimums",
+      },
       5,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
     );
-    const resultTableEqualRecords = determineHtml(
-      "table",
-      state,
-      5,
-      new Set(),
-      new Set(["Mexico", "Brazil"]),
-      new Set(["city", "county"]),
+    expect(result).toEqual(
+      "Showing 5 places in 2 countries with parking minimums removed",
     );
-    const resultTableUnequalRecords = determineHtml(
-      "table",
-      state,
-      5,
-      new Set(),
-      new Set(["Mexico", "Brazil"]),
-      new Set(["city", "county"]),
-    );
-    const expectedNoRecords =
-      "Showing 5 places in 2 countries with parking minimums removed";
-    const expectedRecords =
-      "Showing 5 places in 2 countries with parking minimums removed";
-    expect(resultMap).toEqual(expectedNoRecords);
-    expect(resultTableEqualRecords).toEqual(expectedNoRecords);
-    expect(resultTableUnequalRecords).toEqual(expectedRecords);
 
-    const allMinimumsRemovedState: FilterState = {
-      ...DEFAULT_STATE,
-      policyTypeFilter: "remove parking minimums",
-      allMinimumsRemovedToggle: true,
-    };
-    const allMinimumsRemovedMap = determineHtml(
-      "map",
-      allMinimumsRemovedState,
+    const allMinimumsRemoved = determineHtml(
+      {
+        ...DEFAULT_STATE,
+        policyTypeFilter: "remove parking minimums",
+        allMinimumsRemovedToggle: true,
+      },
       5,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
     );
-    const allMinimumsRemovedTableEqualRecords = determineHtml(
-      "table",
-      allMinimumsRemovedState,
-      5,
-      new Set(),
-      new Set(["Mexico", "Brazil"]),
-      new Set(["city", "county"]),
-    );
-    const allMinimumsRemovedTableUnequalRecords = determineHtml(
-      "table",
-      allMinimumsRemovedState,
-      5,
-      new Set(),
-      new Set(["Mexico", "Brazil"]),
-      new Set(["city", "county"]),
-    );
-    const allMinimumsRemovedExpected =
-      "Showing 5 places in 2 countries with all parking minimums removed";
-    expect(allMinimumsRemovedMap).toEqual(allMinimumsRemovedExpected);
-    expect(allMinimumsRemovedTableEqualRecords).toEqual(
-      allMinimumsRemovedExpected,
-    );
-    expect(allMinimumsRemovedTableUnequalRecords).toEqual(
-      allMinimumsRemovedExpected,
+    expect(allMinimumsRemoved).toEqual(
+      "Showing 5 places in 2 countries with all parking minimums removed",
     );
   });
 
   test("add maximums", () => {
-    const state: FilterState = {
-      ...DEFAULT_STATE,
-      policyTypeFilter: "add parking maximums",
-    };
-    const resultMap = determineHtml(
-      "map",
-      state,
+    const result = determineHtml(
+      {
+        ...DEFAULT_STATE,
+        policyTypeFilter: "add parking maximums",
+      },
       5,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
     );
-    const resultTableEqualRecords = determineHtml(
-      "table",
-      state,
-      5,
-      new Set(),
-      new Set(["Mexico", "Brazil"]),
-      new Set(["city", "county"]),
+    expect(result).toEqual(
+      "Showing 5 places in 2 countries with parking maximums added",
     );
-    const resultTableUnequalRecords = determineHtml(
-      "table",
-      state,
-      5,
-      new Set(),
-      new Set(["Mexico", "Brazil"]),
-      new Set(["city", "county"]),
-    );
-    const expectedNoRecords =
-      "Showing 5 places in 2 countries with parking maximums added";
-    const expectedRecords =
-      "Showing 5 places in 2 countries with parking maximums added";
-    expect(resultMap).toEqual(expectedNoRecords);
-    expect(resultTableEqualRecords).toEqual(expectedNoRecords);
-    expect(resultTableUnequalRecords).toEqual(expectedRecords);
 
-    const allMinimumsRemovedState: FilterState = {
-      ...DEFAULT_STATE,
-      policyTypeFilter: "add parking maximums",
-      allMinimumsRemovedToggle: true,
-    };
-    const allMinimumsRemovedMap = determineHtml(
-      "map",
-      allMinimumsRemovedState,
+    const allMinimumsRemoved = determineHtml(
+      {
+        ...DEFAULT_STATE,
+        policyTypeFilter: "add parking maximums",
+        allMinimumsRemovedToggle: true,
+      },
       5,
       new Set(),
       new Set(["Mexico", "Brazil"]),
       new Set(["city", "county"]),
     );
-    const allMinimumsRemovedTableEqualRecords = determineHtml(
-      "table",
-      allMinimumsRemovedState,
-      5,
-      new Set(),
-      new Set(["Mexico", "Brazil"]),
-      new Set(["city", "county"]),
-    );
-    const allMinimumsRemovedTableUnequalRecords = determineHtml(
-      "table",
-      allMinimumsRemovedState,
-      5,
-      new Set(),
-      new Set(["Mexico", "Brazil"]),
-      new Set(["city", "county"]),
-    );
-    const allMinimumsRemovedExpectedEqualRecords =
-      "Showing 5 places in 2 countries with both all parking minimums removed and parking maximums added";
-    const allMinimumsRemovedExpectedUnequalRecords =
-      "Showing 5 places in 2 countries with both all parking minimums removed and parking maximums added";
-    expect(allMinimumsRemovedMap).toEqual(
-      allMinimumsRemovedExpectedEqualRecords,
-    );
-    expect(allMinimumsRemovedTableEqualRecords).toEqual(
-      allMinimumsRemovedExpectedEqualRecords,
-    );
-    expect(allMinimumsRemovedTableUnequalRecords).toEqual(
-      allMinimumsRemovedExpectedUnequalRecords,
+    expect(allMinimumsRemoved).toEqual(
+      "Showing 5 places in 2 countries with both all parking minimums removed and parking maximums added",
     );
   });
 
   test("grammar", () => {
     const result = determineHtml(
-      "table",
       { ...DEFAULT_STATE, policyTypeFilter: "reduce parking minimums" },
       1,
       new Set(),
@@ -421,7 +247,6 @@ test.describe("determineHtml", () => {
 
   test("place type", () => {
     const city = determineHtml(
-      "map",
       { ...DEFAULT_STATE, policyTypeFilter: "reduce parking minimums" },
       2,
       new Set(),
@@ -433,7 +258,6 @@ test.describe("determineHtml", () => {
     );
 
     const county = determineHtml(
-      "map",
       { ...DEFAULT_STATE, policyTypeFilter: "reduce parking minimums" },
       2,
       new Set(),
@@ -445,7 +269,6 @@ test.describe("determineHtml", () => {
     );
 
     const state = determineHtml(
-      "map",
       { ...DEFAULT_STATE, policyTypeFilter: "reduce parking minimums" },
       2,
       new Set(),
@@ -457,7 +280,6 @@ test.describe("determineHtml", () => {
     );
 
     const country = determineHtml(
-      "map",
       { ...DEFAULT_STATE, policyTypeFilter: "reduce parking minimums" },
       1,
       new Set(),


### PR DESCRIPTION
In preparation for changing the table view text, then the ReformStatus eventually changing the counter.

Changes:

* Remove the number of records, which will not be in the upcoming table view revamp. It's too nitty-gritty for users.
* Use helper functions so that we can early return
* Test the helper functions rather than more integration test style. It makes it easier to test every permutation and makes them less verbose.