### PR TITLE
Don't hide scope & land use filters with parking maximums

### DIFF
--- a/src/js/filterOptions.ts
+++ b/src/js/filterOptions.ts
@@ -452,13 +452,19 @@ export function initFilterOptions(
       policyTypeFilter !== "any parking reform",
   });
   initFilterGroup(filterManager, filterOptions, filterPopup, {
+    htmlName: "status",
+    filterStateKey: "status",
+    legend: "Reform status",
+    hide: ({ policyTypeFilter }) => policyTypeFilter === "any parking reform",
+  });
+  initFilterGroup(filterManager, filterOptions, filterPopup, {
     htmlName: "scope",
     filterStateKey: "scope",
     legend: "Reform scope",
     hide: ({ policyTypeFilter, allMinimumsRemovedToggle }) =>
       policyTypeFilter === "any parking reform" ||
       (allMinimumsRemovedToggle &&
-        policyTypeFilter !== "reduce parking minimums"),
+        policyTypeFilter === "remove parking minimums"),
   });
   initFilterGroup(filterManager, filterOptions, filterPopup, {
     htmlName: "land-use",
@@ -467,13 +473,7 @@ export function initFilterOptions(
     hide: ({ policyTypeFilter, allMinimumsRemovedToggle }) =>
       policyTypeFilter === "any parking reform" ||
       (allMinimumsRemovedToggle &&
-        policyTypeFilter !== "reduce parking minimums"),
-  });
-  initFilterGroup(filterManager, filterOptions, filterPopup, {
-    htmlName: "status",
-    filterStateKey: "status",
-    legend: "Reform status",
-    hide: ({ policyTypeFilter }) => policyTypeFilter === "any parking reform",
+        policyTypeFilter === "remove parking minimums"),
   });
   initFilterGroup(filterManager, filterOptions, filterPopup, {
     htmlName: "year",

--- a/tests/app/FilterState.test.ts
+++ b/tests/app/FilterState.test.ts
@@ -280,16 +280,24 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
 
     expect(manager.matchedPlaces).toEqual(expectedMatch);
 
+    // `scope` only applies if allMinimumsRemovedToggle is false.
     manager.update({ scope: new Set(["city center / business district"]) });
     expect(manager.matchedPlaces).toEqual({});
+    manager.update({ allMinimumsRemovedToggle: true });
+    expect(manager.matchedPlaces).toEqual(expectedMatch);
     manager.update({
       scope: DEFAULT_STATE.scope,
+      allMinimumsRemovedToggle: false,
     });
 
+    // `landUse` only applies if allMinimumsRemovedToggle is false.
     manager.update({ landUse: new Set(["commercial"]) });
     expect(manager.matchedPlaces).toEqual({});
+    manager.update({ allMinimumsRemovedToggle: true });
+    expect(manager.matchedPlaces).toEqual(expectedMatch);
     manager.update({
       landUse: DEFAULT_STATE.landUse,
+      allMinimumsRemovedToggle: false,
     });
 
     manager.update({ status: new Set(["repealed"]) });


### PR DESCRIPTION
Fixes https://github.com/ParkingReformNetwork/reform-map/pull/696. 

It makes sense to hide "Reform scope" and "Affected land use" when the policy type is minimum removals and "all minimums repealed" is checked. However, we do need to fix FilterState to ignore those two fields in this edge case correctly.

We should not hide the two option groups with "add parking maximums", however, because the options are checking the maximum policy records, not the minimum removal records.