### PR TITLE
Search counter links to place

### DIFF
--- a/src/js/counters.ts
+++ b/src/js/counters.ts
@@ -5,8 +5,8 @@ import {
   PlaceFilterManager,
   PolicyTypeFilter,
 } from "./FilterState";
-import { PlaceType, PolicyType } from "./types";
-import { joinWithConjunction } from "./data";
+import { PlaceId, PlaceType, PolicyType } from "./types";
+import { joinWithConjunction, placeIdToUrl } from "./data";
 import type { ViewState } from "./viewToggle";
 
 export function determinePlaceDescription(
@@ -43,13 +43,17 @@ export const SEARCH_RESET_HTML = `<a class="counter-search-reset" role="button" 
 
 export function determineSearch(
   view: ViewState,
-  searchInput: string,
+  placeId: PlaceId,
   policyType: PolicyTypeFilter,
 ): string {
+  const placeLink = `<a class="external-link" target="_blank" href=${placeIdToUrl(
+    placeId,
+  )}>${placeId} <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a>`;
+
   if (view === "map" || policyType === "legacy reform") {
-    return `Showing ${searchInput} — ${SEARCH_RESET_HTML}`;
+    return `Showing ${placeLink} — ${SEARCH_RESET_HTML}`;
   }
-  const suffix = `in ${searchInput} — ${SEARCH_RESET_HTML}`;
+  const suffix = `in ${placeLink} — ${SEARCH_RESET_HTML}`;
   switch (policyType) {
     case "any parking reform":
       return `Showing an overview of adopted parking reforms ${suffix}`;

--- a/tests/app/counters.test.ts
+++ b/tests/app/counters.test.ts
@@ -107,6 +107,9 @@ test("determineLegacy()", () => {
 });
 
 test("determineSearch()", () => {
+  const placeLink =
+    '<a class="external-link" target="_blank" href=https://parkingreform.org/mandates-map/city_detail/Baltimore_MD.html>Baltimore, MD <i aria-hidden="true" class="fa-solid fa-arrow-right"></i></a>';
+
   // Map view always has the same text.
   for (const policyType of [
     "legacy reform",
@@ -116,29 +119,29 @@ test("determineSearch()", () => {
     "reduce parking minimums",
   ] as const) {
     expect(determineSearch("map", "Baltimore, MD", policyType)).toEqual(
-      `Showing Baltimore, MD — ${SEARCH_RESET_HTML}`,
+      `Showing ${placeLink} — ${SEARCH_RESET_HTML}`,
     );
   }
 
   expect(
     determineSearch("table", "Baltimore, MD", "any parking reform"),
   ).toEqual(
-    `Showing an overview of adopted parking reforms in Baltimore, MD — ${SEARCH_RESET_HTML}`,
+    `Showing an overview of adopted parking reforms in ${placeLink} — ${SEARCH_RESET_HTML}`,
   );
   expect(
     determineSearch("table", "Baltimore, MD", "add parking maximums"),
   ).toEqual(
-    `Showing details about parking maximums in Baltimore, MD — ${SEARCH_RESET_HTML}`,
+    `Showing details about parking maximums in ${placeLink} — ${SEARCH_RESET_HTML}`,
   );
   expect(
     determineSearch("table", "Baltimore, MD", "reduce parking minimums"),
   ).toEqual(
-    `Showing details about parking minimum reductions in Baltimore, MD — ${SEARCH_RESET_HTML}`,
+    `Showing details about parking minimum reductions in ${placeLink} — ${SEARCH_RESET_HTML}`,
   );
   expect(
     determineSearch("table", "Baltimore, MD", "remove parking minimums"),
   ).toEqual(
-    `Showing details about parking minimum removals in Baltimore, MD — ${SEARCH_RESET_HTML}`,
+    `Showing details about parking minimum removals in ${placeLink} — ${SEARCH_RESET_HTML}`,
   );
 });
 


### PR DESCRIPTION
This is necessary because it's possible to have the search result in table view match no records, depending on the policy type filter.

<img width="858" alt="Screenshot 2025-01-05 at 2 36 09 PM" src="https://github.com/user-attachments/assets/19370faf-d8c6-40af-aeb5-d7df844994e0" />
