### PR TITLE
Dynamically rename "Reform year" filter based on status

### DIFF
--- a/src/js/filter-features/populationSlider.ts
+++ b/src/js/filter-features/populationSlider.ts
@@ -16,13 +16,13 @@ interface Sliders {
   readonly right: HTMLInputElement;
 }
 
-function determineAccordionTitle(
+function determineSupplementalTitle(
   populationSliderIndexes: [number, number],
 ): string {
   const [leftIndex, rightIndex] = populationSliderIndexes;
   const leftLabel = POPULATION_INTERVALS[leftIndex][0];
   const rightLabel = POPULATION_INTERVALS[rightIndex][0];
-  return `Population (${leftLabel}-${rightLabel})`;
+  return ` (${leftLabel}-${rightLabel})`;
 }
 
 function generateSliders(
@@ -66,7 +66,10 @@ function generateSliders(
     {
       hidden: false,
       expanded: false,
-      title: determineAccordionTitle(initialPopulationSliderIndexes),
+      title: "Population",
+      supplementalTitle: determineSupplementalTitle(
+        initialPopulationSliderIndexes,
+      ),
     },
   );
   accordionState.subscribe((state) =>
@@ -172,7 +175,9 @@ export function initPopulationSlider(
     const accordionPriorState = accordionStateObservable.getValue();
     accordionStateObservable.setValue({
       ...accordionPriorState,
-      title: determineAccordionTitle(state.populationSliderIndexes),
+      supplementalTitle: determineSupplementalTitle(
+        state.populationSliderIndexes,
+      ),
     });
 
     if (!accordionStateObservable.getValue().hidden) {

--- a/src/js/layout/accordion.ts
+++ b/src/js/layout/accordion.ts
@@ -9,6 +9,7 @@ export interface AccordionState {
   hidden: boolean;
   expanded: boolean;
   title: string;
+  supplementalTitle?: string;
 }
 
 export function updateAccordionUI(
@@ -16,7 +17,7 @@ export function updateAccordionUI(
   state: AccordionState,
 ): void {
   elements.outerContainer.hidden = state.hidden;
-  elements.accordionTitle.textContent = state.title;
+  elements.accordionTitle.textContent = `${state.title}${state.supplementalTitle ?? ""}`;
 
   const upIcon =
     elements.accordionButton.querySelector<SVGElement>(".fa-chevron-up");

--- a/src/js/table.ts
+++ b/src/js/table.ts
@@ -71,7 +71,7 @@ const PLACE_COLUMNS: ColumnDefinition[] = [
 
 const POLICY_COLUMNS: ColumnDefinition[] = [
   {
-    title: "Reform date",
+    title: "Date",
     field: "date",
     width: 110,
     formatter: formatDate,


### PR DESCRIPTION
Prep for the status becoming a dropdown that changes the data set.

This improves https://github.com/ParkingReformNetwork/reform-map/pull/716 by splitting back out `supplementalTitle`. Turns out, it's useful not to have to recompute the `title` when the `supplementalTitle` changes. However, we still keep `title` as part of the `AccordionState`.