### PR TITLE
Set default policy type to remove minimums

### DIFF
--- a/src/js/filter-features/options.ts
+++ b/src/js/filter-features/options.ts
@@ -313,6 +313,9 @@ function initPolicyTypeFilterDropdown(
     select.append(element);
   });
 
+  // Set initial value.
+  select.value = filterManager.getState().policyTypeFilter;
+
   select.addEventListener("change", () => {
     const policyTypeFilter = select.value as PolicyTypeFilter;
     filterManager.update({ policyTypeFilter });

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -29,7 +29,7 @@ export default async function initApp(): Promise<void> {
 
   const filterManager = new PlaceFilterManager(data, {
     searchInput: null,
-    policyTypeFilter: "any parking reform",
+    policyTypeFilter: "remove parking minimums",
     allMinimumsRemovedToggle: true,
     placeType: filterOptions.default("placeType"),
     includedPolicyChanges: filterOptions.default("includedPolicyChanges"),

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -175,7 +175,7 @@ for (const edgeCase of TESTS) {
       await deselectToggle(page);
     }
 
-    if (edgeCase.policyTypeFilter !== "any parking reform") {
+    if (edgeCase.policyTypeFilter !== "remove parking minimums") {
       await page
         .locator("#filter-policy-type-dropdown")
         .selectOption(edgeCase.policyTypeFilter);


### PR DESCRIPTION
Both Etienne and Tony independently made this request because they want the table view to show date of reform, which is not possible if the default policy type is "any parking reform".

They understand this changes the experience when you uncheck "only places with all parking minimums removed". They are okay with this.