### PR TITLE
Fix issues with structuredClone in tests

### DIFF
--- a/tests/app/FilterState.test.ts
+++ b/tests/app/FilterState.test.ts
@@ -8,80 +8,84 @@ import { POPULATION_MAX_INDEX } from "../../src/js/filter-features/populationSli
 import { PlaceId, ProcessedCoreEntry, Date } from "../../src/js/model/types";
 
 test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
-  const DEFAULT_STATE: FilterState = {
-    searchInput: null,
-    policyTypeFilter: "any parking reform",
-    allMinimumsRemovedToggle: false,
-    includedPolicyChanges: new Set([
-      "add parking maximums",
-      "reduce parking minimums",
-      "remove parking minimums",
-    ]),
-    scope: new Set(["citywide", "city center / business district"]),
-    landUse: new Set(["all uses", "commercial", "other"]),
-    status: new Set(["adopted"]),
-    country: new Set(["United States", "Brazil"]),
-    placeType: new Set(["city", "county"]),
-    year: new Set(["2023", "2024"]),
-    populationSliderIndexes: [0, POPULATION_MAX_INDEX],
-  };
+  function defaultState(): FilterState {
+    return {
+      searchInput: null,
+      policyTypeFilter: "any parking reform",
+      allMinimumsRemovedToggle: false,
+      includedPolicyChanges: new Set([
+        "add parking maximums",
+        "reduce parking minimums",
+        "remove parking minimums",
+      ]),
+      scope: new Set(["citywide", "city center / business district"]),
+      landUse: new Set(["all uses", "commercial", "other"]),
+      status: new Set(["adopted"]),
+      country: new Set(["United States", "Brazil"]),
+      placeType: new Set(["city", "county"]),
+      year: new Set(["2023", "2024"]),
+      populationSliderIndexes: [0, POPULATION_MAX_INDEX],
+    };
+  }
 
-  const DEFAULT_ENTRIES: Record<PlaceId, ProcessedCoreEntry> = {
-    "Place 1": {
-      place: {
-        name: "Place 1",
-        state: "",
-        country: "United States",
-        type: "city",
-        pop: 48100,
-        repeal: false,
-        coord: [0, 0],
-        url: "",
+  function defaultEntries(): Record<PlaceId, ProcessedCoreEntry> {
+    return {
+      "Place 1": {
+        place: {
+          name: "Place 1",
+          state: "",
+          country: "United States",
+          type: "city",
+          pop: 48100,
+          repeal: false,
+          coord: [0, 0],
+          url: "",
+        },
+        reduce_min: [
+          {
+            status: "adopted",
+            scope: ["citywide"],
+            land: ["all uses"],
+            date: new Date("2024"),
+          },
+        ],
       },
-      reduce_min: [
-        {
-          status: "adopted",
-          scope: ["citywide"],
-          land: ["all uses"],
-          date: new Date("2024"),
+      "Place 2": {
+        place: {
+          name: "Place 2",
+          state: "",
+          country: "Brazil",
+          type: "county",
+          pop: 400,
+          repeal: true,
+          coord: [0, 0],
+          url: "",
         },
-      ],
-    },
-    "Place 2": {
-      place: {
-        name: "Place 2",
-        state: "",
-        country: "Brazil",
-        type: "county",
-        pop: 400,
-        repeal: true,
-        coord: [0, 0],
-        url: "",
+        add_max: [
+          {
+            status: "adopted",
+            scope: ["city center / business district"],
+            land: ["commercial"],
+            date: new Date("2023"),
+          },
+          {
+            status: "adopted",
+            scope: ["citywide"],
+            land: ["other"],
+            date: new Date("2023"),
+          },
+        ],
+        rm_min: [
+          {
+            status: "adopted",
+            scope: ["citywide"],
+            land: ["all uses"],
+            date: new Date("2023"),
+          },
+        ],
       },
-      add_max: [
-        {
-          status: "adopted",
-          scope: ["city center / business district"],
-          land: ["commercial"],
-          date: new Date("2023"),
-        },
-        {
-          status: "adopted",
-          scope: ["citywide"],
-          land: ["other"],
-          date: new Date("2023"),
-        },
-      ],
-      rm_min: [
-        {
-          status: "adopted",
-          scope: ["citywide"],
-          land: ["all uses"],
-          date: new Date("2023"),
-        },
-      ],
-    },
-  };
+    };
+  }
 
   test("any parking reform", () => {
     const expectedPlace1Match = {
@@ -97,10 +101,7 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
       hasReduceMin: false,
     };
 
-    const manager = new PlaceFilterManager(
-      DEFAULT_ENTRIES,
-      structuredClone(DEFAULT_STATE),
-    );
+    const manager = new PlaceFilterManager(defaultEntries(), defaultState());
     expect(manager.matchedPlaces).toEqual({
       "Place 1": expectedPlace1Match,
       "Place 2": expectedPlace2Match,
@@ -123,7 +124,7 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
       "Place 2": expectedPlace2Match,
     });
     manager.update({
-      allMinimumsRemovedToggle: DEFAULT_STATE.allMinimumsRemovedToggle,
+      allMinimumsRemovedToggle: defaultState().allMinimumsRemovedToggle,
     });
 
     manager.update({
@@ -133,21 +134,21 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
       "Place 1": expectedPlace1Match,
     });
     manager.update({
-      includedPolicyChanges: DEFAULT_STATE.includedPolicyChanges,
+      includedPolicyChanges: defaultState().includedPolicyChanges,
     });
 
     manager.update({ country: new Set(["United States"]) });
     expect(manager.matchedPlaces).toEqual({
       "Place 1": expectedPlace1Match,
     });
-    manager.update({ country: DEFAULT_STATE.country });
+    manager.update({ country: defaultState().country });
 
     manager.update({ populationSliderIndexes: [0, 1] });
     expect(manager.matchedPlaces).toEqual({
       "Place 2": expectedPlace2Match,
     });
     manager.update({
-      populationSliderIndexes: DEFAULT_STATE.populationSliderIndexes,
+      populationSliderIndexes: defaultState().populationSliderIndexes,
     });
 
     manager.update({ placeType: new Set(["county"]) });
@@ -155,13 +156,13 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
       "Place 2": expectedPlace2Match,
     });
     manager.update({
-      placeType: DEFAULT_STATE.placeType,
+      placeType: defaultState().placeType,
     });
   });
 
   test("reduce minimums", () => {
-    const manager = new PlaceFilterManager(DEFAULT_ENTRIES, {
-      ...structuredClone(DEFAULT_STATE),
+    const manager = new PlaceFilterManager(defaultEntries(), {
+      ...defaultState(),
       policyTypeFilter: "reduce parking minimums",
       // This option should be ignored with 'reduce parking minimums'.
       allMinimumsRemovedToggle: true,
@@ -178,24 +179,24 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
 
     manager.update({ scope: new Set(["city center / business district"]) });
     expect(manager.matchedPlaces).toEqual({});
-    manager.update({ scope: DEFAULT_STATE.scope });
+    manager.update({ scope: defaultState().scope });
 
     manager.update({ landUse: new Set(["commercial"]) });
     expect(manager.matchedPlaces).toEqual({});
-    manager.update({ landUse: DEFAULT_STATE.landUse });
+    manager.update({ landUse: defaultState().landUse });
 
     manager.update({ status: new Set(["repealed"]) });
     expect(manager.matchedPlaces).toEqual({});
-    manager.update({ status: DEFAULT_STATE.status });
+    manager.update({ status: defaultState().status });
 
     manager.update({ year: new Set(["2023"]) });
     expect(manager.matchedPlaces).toEqual({});
-    manager.update({ year: DEFAULT_STATE.year });
+    manager.update({ year: defaultState().year });
   });
 
   test("add maximums", () => {
-    const manager = new PlaceFilterManager(DEFAULT_ENTRIES, {
-      ...structuredClone(DEFAULT_STATE),
+    const manager = new PlaceFilterManager(defaultEntries(), {
+      ...defaultState(),
       policyTypeFilter: "add parking maximums",
       // Should be ignored.
       includedPolicyChanges: new Set(),
@@ -216,7 +217,7 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
         matchingIndexes: [0],
       },
     });
-    manager.update({ scope: DEFAULT_STATE.scope });
+    manager.update({ scope: defaultState().scope });
 
     manager.update({ landUse: new Set(["commercial"]) });
     expect(manager.matchedPlaces).toEqual({
@@ -226,20 +227,20 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
         matchingIndexes: [0],
       },
     });
-    manager.update({ landUse: DEFAULT_STATE.landUse });
+    manager.update({ landUse: defaultState().landUse });
 
     manager.update({ status: new Set(["repealed"]) });
     expect(manager.matchedPlaces).toEqual({});
-    manager.update({ status: DEFAULT_STATE.status });
+    manager.update({ status: defaultState().status });
 
     manager.update({ year: new Set(["2024"]) });
     expect(manager.matchedPlaces).toEqual({});
-    manager.update({ year: DEFAULT_STATE.year });
+    manager.update({ year: defaultState().year });
 
-    const noRepealsEntries = structuredClone(DEFAULT_ENTRIES);
+    const noRepealsEntries = defaultEntries();
     noRepealsEntries["Place 2"].place.repeal = false;
     const manager2 = new PlaceFilterManager(noRepealsEntries, {
-      ...structuredClone(DEFAULT_STATE),
+      ...defaultState(),
       policyTypeFilter: "add parking maximums",
       allMinimumsRemovedToggle: true,
     });
@@ -247,8 +248,8 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
   });
 
   test("remove minimums", () => {
-    const manager = new PlaceFilterManager(DEFAULT_ENTRIES, {
-      ...structuredClone(DEFAULT_STATE),
+    const manager = new PlaceFilterManager(defaultEntries(), {
+      ...defaultState(),
       policyTypeFilter: "remove parking minimums",
       // Should be ignored.
       includedPolicyChanges: new Set(),
@@ -269,7 +270,7 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
     manager.update({ allMinimumsRemovedToggle: true });
     expect(manager.matchedPlaces).toEqual(expectedMatch);
     manager.update({
-      scope: DEFAULT_STATE.scope,
+      scope: defaultState().scope,
       allMinimumsRemovedToggle: false,
     });
 
@@ -279,22 +280,22 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
     manager.update({ allMinimumsRemovedToggle: true });
     expect(manager.matchedPlaces).toEqual(expectedMatch);
     manager.update({
-      landUse: DEFAULT_STATE.landUse,
+      landUse: defaultState().landUse,
       allMinimumsRemovedToggle: false,
     });
 
     manager.update({ status: new Set(["repealed"]) });
     expect(manager.matchedPlaces).toEqual({});
-    manager.update({ status: DEFAULT_STATE.status });
+    manager.update({ status: defaultState().status });
 
     manager.update({ year: new Set(["2024"]) });
     expect(manager.matchedPlaces).toEqual({});
-    manager.update({ year: DEFAULT_STATE.year });
+    manager.update({ year: defaultState().year });
 
-    const noRepealsEntries = structuredClone(DEFAULT_ENTRIES);
+    const noRepealsEntries = defaultEntries();
     noRepealsEntries["Place 2"].place.repeal = false;
     const manager2 = new PlaceFilterManager(noRepealsEntries, {
-      ...structuredClone(DEFAULT_STATE),
+      ...defaultState(),
       policyTypeFilter: "remove parking minimums",
       allMinimumsRemovedToggle: true,
     });
@@ -303,8 +304,8 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
 
   test("search", () => {
     // Start with a state that does not match anything to prove that search overrides filters.
-    const manager = new PlaceFilterManager(DEFAULT_ENTRIES, {
-      ...structuredClone(DEFAULT_STATE),
+    const manager = new PlaceFilterManager(defaultEntries(), {
+      ...defaultState(),
       country: new Set(),
     });
     expect(manager.matchedPlaces).toEqual({});


### PR DESCRIPTION
Follow up to https://github.com/ParkingReformNetwork/reform-map/pull/707. Turns out `structuredClone` breaks with our custom `Date` class because it tries to convert `Date.parsed` (Luxon DateTime) into an object.

So, now we use factory functions that create a new object for the state and entries each time. This is a little less efficient, but it's a test so it's fine and better to avoid the confusion of accidentally sharing state between tests.