### PR TITLE
Remove all minimums checkbox from most datasets

### DIFF
--- a/src/js/filter-features/counters.ts
+++ b/src/js/filter-features/counters.ts
@@ -79,26 +79,13 @@ export function determineAnyReform(
   view: ViewState,
   placeDescription: string,
   matchedPolicyTypes: Set<PolicyType>,
-  allMinimumsRemovedToggle: boolean,
   statePolicyTypes: Set<string>,
 ): string {
   if (view === "table") {
-    const prefix = `Showing an overview of adopted parking reforms in ${placeDescription}`;
-    const suffix = allMinimumsRemovedToggle
-      ? " with all parking minimums removed"
-      : "";
-    return `${prefix}${suffix}`;
+    return `Showing an overview of adopted parking reforms in ${placeDescription}`;
   }
 
   const prefix = `Showing ${placeDescription} with`;
-
-  if (allMinimumsRemovedToggle) {
-    const suffix = isEqual(statePolicyTypes, new Set(["add parking maximums"]))
-      ? "both all parking minimums removed and parking maximums added"
-      : "all parking minimums removed";
-    return `${prefix} ${suffix}`;
-  }
-
   const policyDescriptionMap: Record<PolicyType, string> = {
     "add parking maximums": "parking maximums added",
     "reduce parking minimums": "parking minimums reduced",
@@ -128,18 +115,10 @@ export function determineReduceMin(
 export function determineAddMax(
   view: ViewState,
   placeDescription: string,
-  allMinimumsRemovedToggle: boolean,
 ): string {
-  if (view === "map") {
-    const suffix = allMinimumsRemovedToggle
-      ? "both all parking minimums removed and parking maximums added"
-      : "parking maximums added";
-    return `Showing ${placeDescription} with ${suffix}`;
-  }
-  const prefix = `Showing details about parking maximums for ${placeDescription}`;
-  return allMinimumsRemovedToggle
-    ? `${prefix} that have also removed all parking minimums`
-    : prefix;
+  return view === "map"
+    ? `Showing ${placeDescription} with parking maximums added`
+    : `Showing details about parking maximums for ${placeDescription}`;
 }
 
 export function determineRmMin(
@@ -186,17 +165,12 @@ export function determineHtml(
         view,
         placeDescription,
         matchedPolicyTypes,
-        state.allMinimumsRemovedToggle,
         state.includedPolicyChanges,
       );
     case "reduce parking minimums":
       return determineReduceMin(view, placeDescription);
     case "add parking maximums":
-      return determineAddMax(
-        view,
-        placeDescription,
-        state.allMinimumsRemovedToggle,
-      );
+      return determineAddMax(view, placeDescription);
     case "remove parking minimums":
       return determineRmMin(
         view,

--- a/src/js/filter-features/options.ts
+++ b/src/js/filter-features/options.ts
@@ -274,7 +274,7 @@ function initAllMinimumsToggle(
   filterManager.subscribe(
     `possibly hide all minimums toggle`,
     ({ policyTypeFilter }) => {
-      outerContainer.hidden = policyTypeFilter === "reduce parking minimums";
+      outerContainer.hidden = policyTypeFilter !== "remove parking minimums";
     },
   );
 }

--- a/src/js/state/FilterState.ts
+++ b/src/js/state/FilterState.ts
@@ -186,12 +186,11 @@ export class PlaceFilterManager {
     if (!isCountry) return false;
 
     const isAllMinimumsRepealed =
+      // We only care about the option if the policy is "remove parking minimums"
+      filterState.policyTypeFilter !== "remove parking minimums" ||
       // If the toggle is false, we don't care.
       !filterState.allMinimumsRemovedToggle ||
-      // If the policy type is "reduce parking minimums", we don't care about
-      // `allMinimumsRemovedToggle` because no places have that toggle set &
-      // also have parking minimum reductions.
-      filterState.policyTypeFilter === "reduce parking minimums" ||
+      // Else, we do care that the place has total repeals.
       place.repeal;
     if (!isAllMinimumsRepealed) return false;
 

--- a/tests/app/FilterState.test.ts
+++ b/tests/app/FilterState.test.ts
@@ -109,6 +109,7 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
 
     // The below filters should have no impact.
     manager.update({
+      allMinimumsRemovedToggle: true,
       scope: new Set(),
       landUse: new Set(),
       status: new Set(),
@@ -117,14 +118,6 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
     expect(manager.matchedPlaces).toEqual({
       "Place 1": expectedPlace1Match,
       "Place 2": expectedPlace2Match,
-    });
-
-    manager.update({ allMinimumsRemovedToggle: true });
-    expect(manager.matchedPlaces).toEqual({
-      "Place 2": expectedPlace2Match,
-    });
-    manager.update({
-      allMinimumsRemovedToggle: defaultState().allMinimumsRemovedToggle,
     });
 
     manager.update({
@@ -164,7 +157,7 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
     const manager = new PlaceFilterManager(defaultEntries(), {
       ...defaultState(),
       policyTypeFilter: "reduce parking minimums",
-      // This option should be ignored with 'reduce parking minimums'.
+      // Should be ignored.
       allMinimumsRemovedToggle: true,
       // Should be ignored.
       includedPolicyChanges: new Set(),
@@ -237,6 +230,7 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
     expect(manager.matchedPlaces).toEqual({});
     manager.update({ year: defaultState().year });
 
+    // `allMinimumsRemovedToggle` should not matter.
     const noRepealsEntries = defaultEntries();
     noRepealsEntries["Place 2"].place.repeal = false;
     const manager2 = new PlaceFilterManager(noRepealsEntries, {
@@ -244,7 +238,13 @@ test.describe("PlaceFilterManager.matchedPolicyRecords()", () => {
       policyTypeFilter: "add parking maximums",
       allMinimumsRemovedToggle: true,
     });
-    expect(manager2.matchedPlaces).toEqual({});
+    expect(manager2.matchedPlaces).toEqual({
+      "Place 2": {
+        type: "single policy",
+        policyType: "add parking maximums",
+        matchingIndexes: [0, 1],
+      },
+    });
   });
 
   test("remove minimums", () => {

--- a/tests/app/counters.test.ts
+++ b/tests/app/counters.test.ts
@@ -135,18 +135,11 @@ test("determineSearch()", () => {
 });
 
 test("determineAddMax()", () => {
-  expect(determineAddMax("map", "2 places in Mexico", false)).toEqual(
+  expect(determineAddMax("map", "2 places in Mexico")).toEqual(
     "Showing 2 places in Mexico with parking maximums added",
   );
-  expect(determineAddMax("map", "2 places in Mexico", true)).toEqual(
-    "Showing 2 places in Mexico with both all parking minimums removed and parking maximums added",
-  );
-
-  expect(determineAddMax("table", "2 places in Mexico", false)).toEqual(
+  expect(determineAddMax("table", "2 places in Mexico")).toEqual(
     "Showing details about parking maximums for 2 places in Mexico",
-  );
-  expect(determineAddMax("table", "2 places in Mexico", true)).toEqual(
-    "Showing details about parking maximums for 2 places in Mexico that have also removed all parking minimums",
   );
 });
 
@@ -180,7 +173,6 @@ test("determineAnyReform()", () => {
     args: {
       view: ViewState;
       matched: PolicyType[];
-      allMinimums: boolean;
       statePolicy: PolicyType[];
     },
     expected: string,
@@ -189,7 +181,6 @@ test("determineAnyReform()", () => {
       args.view,
       "5 places in Mexico",
       new Set(args.matched),
-      args.allMinimums,
       new Set(args.statePolicy),
     );
     expect(result).toEqual(expected);
@@ -201,14 +192,9 @@ test("determineAnyReform()", () => {
     "remove parking minimums",
   ];
 
-  // For table view, the text only depends on allMinimumsRemovedToggle.
   assert(
-    { view: "table", matched: [], statePolicy: [], allMinimums: false },
+    { view: "table", matched: [], statePolicy: [] },
     "Showing an overview of adopted parking reforms in 5 places in Mexico",
-  );
-  assert(
-    { view: "table", matched: [], statePolicy: [], allMinimums: true },
-    "Showing an overview of adopted parking reforms in 5 places in Mexico with all parking minimums removed",
   );
 
   // For map view, we only show policy types that are both present in the matched places &
@@ -218,7 +204,6 @@ test("determineAnyReform()", () => {
       view: "map",
       matched: everyPolicyType,
       statePolicy: everyPolicyType,
-      allMinimums: false,
     },
     "Showing 5 places in Mexico with parking minimums removed, parking minimums reduced, or parking maximums added",
   );
@@ -227,7 +212,6 @@ test("determineAnyReform()", () => {
       view: "map",
       matched: ["add parking maximums", "remove parking minimums"],
       statePolicy: everyPolicyType,
-      allMinimums: false,
     },
     "Showing 5 places in Mexico with parking minimums removed or parking maximums added",
   );
@@ -236,7 +220,6 @@ test("determineAnyReform()", () => {
       view: "map",
       matched: everyPolicyType,
       statePolicy: ["add parking maximums", "remove parking minimums"],
-      allMinimums: false,
     },
     "Showing 5 places in Mexico with parking minimums removed or parking maximums added",
   );
@@ -245,7 +228,6 @@ test("determineAnyReform()", () => {
       view: "map",
       matched: ["add parking maximums"],
       statePolicy: everyPolicyType,
-      allMinimums: false,
     },
     "Showing 5 places in Mexico with parking maximums added",
   );
@@ -254,27 +236,7 @@ test("determineAnyReform()", () => {
       view: "map",
       matched: everyPolicyType,
       statePolicy: ["add parking maximums"],
-      allMinimums: false,
     },
     "Showing 5 places in Mexico with parking maximums added",
-  );
-
-  assert(
-    {
-      view: "map",
-      matched: everyPolicyType,
-      statePolicy: everyPolicyType,
-      allMinimums: true,
-    },
-    "Showing 5 places in Mexico with all parking minimums removed",
-  );
-  assert(
-    {
-      view: "map",
-      matched: everyPolicyType,
-      statePolicy: ["add parking maximums"],
-      allMinimums: true,
-    },
-    "Showing 5 places in Mexico with both all parking minimums removed and parking maximums added",
   );
 });

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -87,7 +87,7 @@ const TESTS: EdgeCase[] = [
   },
   {
     desc: "all minimums removed",
-    policyTypeFilter: "any parking reform",
+    policyTypeFilter: "remove parking minimums",
     allMinimumsRemoved: true,
     expectedRange: DEFAULT_ALL_MINIMUMS_RANGE,
   },


### PR DESCRIPTION
Tony and I agreed that it's overly complex to have "only places with all parking minimums removed" for the "any parking reform" and "add parking maximums" datasets. That is a pretty sophisticated query to want the intersection of both criteria. That type of advanced query should instead use our JSON dataset.

There are several motivations for simplifying this:

- Less confusing user experience. They don't have to understand what this niche checkbox is
- Less complex code
- More future-proof for adding new policy types, which themselves will each have their own tiers