### PR TITLE
Restore filtering options by fixing the table view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@fortawesome/free-regular-svg-icons": "^6.7.2",
         "@fortawesome/free-solid-svg-icons": "^6.7.2",
         "choices.js": "^10.2.0",
+        "happy-dom": "^18.0.1",
         "leaflet": "^1.9.4",
         "lodash-es": "^4.17.21",
         "luxon": "^3.3.0",
@@ -3258,6 +3259,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/whatwg-mimetype": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+      "integrity": "sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==",
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.19.0.tgz",
@@ -5757,6 +5764,35 @@
       "bin": {
         "js-yaml": "bin/js-yaml.js"
       }
+    },
+    "node_modules/happy-dom": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/happy-dom/-/happy-dom-18.0.1.tgz",
+      "integrity": "sha512-qn+rKOW7KWpVTtgIUi6RVmTBZJSe2k0Db0vh1f7CWrWclkkc7/Q+FrOfkZIb2eiErLyqu5AXEzE7XthO9JVxRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^20.0.0",
+        "@types/whatwg-mimetype": "^3.0.2",
+        "whatwg-mimetype": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/@types/node": {
+      "version": "20.19.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.4.tgz",
+      "integrity": "sha512-OP+We5WV8Xnbuvw0zC2m4qfB/BJvjyCwtNjhHdJxV1639SGSKrLmJkc3fMnp2Qy8nJyHp8RO6umxELN/dS1/EA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/happy-dom/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -9165,6 +9201,15 @@
       "dependencies": {
         "iconv-lite": "0.6.3"
       },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "license": "MIT",
       "engines": {
         "node": ">=12"
       }

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@fortawesome/free-regular-svg-icons": "^6.7.2",
     "@fortawesome/free-solid-svg-icons": "^6.7.2",
     "choices.js": "^10.2.0",
+    "happy-dom": "^18.0.1",
     "leaflet": "^1.9.4",
     "lodash-es": "^4.17.21",
     "luxon": "^3.3.0",

--- a/src/css/_table.scss
+++ b/src/css/_table.scss
@@ -2,8 +2,7 @@
 @use "theme/typography";
 
 #table-view {
-  // This is the default - it gets set to `flex` in viewToggle.ts
-  display: none;
+  display: flex;
   flex-direction: column;
 }
 

--- a/src/css/theme/_resets.scss
+++ b/src/css/theme/_resets.scss
@@ -42,3 +42,7 @@ dd,
 a {
   line-height: 1.3;
 }
+
+[hidden] {
+  display: none !important;
+}

--- a/src/js/filter-features/options.ts
+++ b/src/js/filter-features/options.ts
@@ -18,51 +18,118 @@ import { initPopulationSlider } from "./populationSlider";
 import optionValuesData from "../../../data/option-values.json" with { type: "json" };
 import { ReformStatus } from "../model/types";
 
-// Keep in alignment with FilterState.
-type FilterGroupKey =
-  | "placeType"
-  | "includedPolicyChanges"
-  | "scope"
-  | "landUse"
-  | "status"
-  | "country"
-  | "year";
+/** These option values change depending on which dataset is loaded.
+ *
+ * Note that some datasets may not actually use a particular option group, but
+ * we still include it to make the modeling simpler.
+ *
+ * Keep in alignment with FilterState.
+ */
+type DataSetSpecificOptions = {
+  includedPolicyChanges: string[];
+  status: string[];
+  scope: string[];
+  landUse: string[];
+  country: string[];
+  year: string[];
+  placeType: string[];
+};
 
 // We only check `adopted` by default. (We should actually fix `status`
 // to be a radio selection rather than multiple choice.)
-const DEFAULT_REFORM_STATUS: ReformStatus = "adopted";
+export const DEFAULT_REFORM_STATUS: ReformStatus = "adopted";
 
 export class FilterOptions {
-  readonly options: Record<FilterGroupKey, string[]>;
+  readonly anyReform: DataSetSpecificOptions;
+
+  readonly addMax: DataSetSpecificOptions;
+
+  readonly rmMin: DataSetSpecificOptions;
+
+  readonly reduceMin: DataSetSpecificOptions;
 
   constructor() {
-    this.options = {
+    this.anyReform = {
       includedPolicyChanges: optionValuesData.policy,
       status: optionValuesData.status,
-      placeType: optionValuesData.merged.placeType,
-      scope: optionValuesData.merged.scope,
-      landUse: optionValuesData.merged.landUse,
-      country: optionValuesData.merged.country,
-      year: optionValuesData.merged.year,
+      ...optionValuesData.merged,
+    };
+    this.addMax = {
+      includedPolicyChanges: [],
+      status: optionValuesData.status,
+      ...optionValuesData.addMax,
+    };
+    this.rmMin = {
+      includedPolicyChanges: [],
+      status: optionValuesData.status,
+      ...optionValuesData.rmMin,
+    };
+    this.reduceMin = {
+      includedPolicyChanges: [],
+      status: optionValuesData.status,
+      ...optionValuesData.reduceMin,
     };
   }
 
-  default(groupKey: FilterGroupKey): Set<string> {
-    if (groupKey === "status") return new Set([DEFAULT_REFORM_STATUS]);
-    return new Set(this.all(groupKey));
-  }
-
-  all(groupKey: FilterGroupKey): string[] {
-    return this.options[groupKey];
+  getOptions(policyType: PolicyTypeFilter): DataSetSpecificOptions {
+    switch (policyType) {
+      case "any parking reform":
+        return this.anyReform;
+      case "remove parking minimums":
+        return this.rmMin;
+      case "reduce parking minimums":
+        return this.reduceMin;
+      case "add parking maximums":
+        return this.addMax;
+      default:
+        throw new Error(`Unrecognized policy type: ${policyType}`);
+    }
   }
 }
 
-function determineSupplementalTitle(fieldset: HTMLFieldSetElement): string {
-  const checkboxes = fieldset.querySelectorAll<HTMLInputElement>(
+function getVisibleCheckboxes(
+  fieldset: HTMLFieldSetElement,
+): Array<HTMLInputElement> {
+  const allCheckboxes = fieldset.querySelectorAll<HTMLInputElement>(
     'input[type="checkbox"]',
   );
-  const total = checkboxes.length;
-  const checked = Array.from(checkboxes).filter(
+  return Array.from(allCheckboxes).filter(
+    (checkbox) => !checkbox.parentElement?.hidden,
+  );
+}
+
+function extractLabel(
+  input: HTMLInputElement,
+  preserveCapitalization?: boolean,
+): string | undefined {
+  const text = input.parentElement?.textContent?.trim();
+  return preserveCapitalization ? text : text?.toLowerCase();
+}
+
+/**
+ * Get all options that are checked, regardless of if they are hidden.
+ */
+export function determineCheckedLabels(
+  fieldset: HTMLFieldSetElement,
+  preserveCapitalization?: boolean,
+): Set<string> {
+  return new Set(
+    Array.from(
+      fieldset.querySelectorAll<HTMLInputElement>(
+        'input[type="checkbox"]:checked',
+      ),
+    )
+      .map((input) => extractLabel(input, preserveCapitalization))
+      .filter((x) => x !== undefined),
+  );
+}
+
+export function determineSupplementalTitle(
+  fieldset: HTMLFieldSetElement,
+): string {
+  const visibleCheckboxes = getVisibleCheckboxes(fieldset);
+  const total = visibleCheckboxes.length;
+  const checked = visibleCheckboxes.filter(
     (checkbox) => checkbox.checked,
   ).length;
   return ` (${checked}/${total})`;
@@ -76,7 +143,7 @@ type FilterGroupAccordionElements = BaseAccordionElements & {
 
 type FilterGroupParams = {
   htmlName: string;
-  filterStateKey: FilterGroupKey;
+  filterStateKey: keyof DataSetSpecificOptions;
   legend: string | ((state: FilterState) => string);
   /// If not set to true, the option will use Lodash's `capitalize()`. This
   /// only impacts the UI and not the underlying data.
@@ -119,7 +186,9 @@ function generateAccordionForFilterGroup(
   }
   fieldSet.appendChild(filterOptionsContainer);
 
-  filterOptions.all(params.filterStateKey).forEach((val, i) => {
+  // When setting up the filter group, we use anyReform to add every option in the universe.
+  // (anyReform uses a dataset that merges all the other datasets' values.)
+  filterOptions.anyReform[params.filterStateKey].forEach((val, i) => {
     const inputId = `filter-${params.htmlName}-option-${i}`;
     const checked =
       params.filterStateKey !== "status" || val === DEFAULT_REFORM_STATUS;
@@ -176,6 +245,24 @@ function updateCheckboxStats(
   });
 }
 
+/**
+ * Hide all options not in the dataset.
+ */
+function updateCheckboxVisibility(
+  optionsInDataset: string[],
+  fieldSet: HTMLFieldSetElement,
+  preserveCapitalization?: boolean,
+): void {
+  const validOptions = new Set(optionsInDataset);
+  fieldSet
+    .querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
+    .forEach((checkbox) => {
+      const label = extractLabel(checkbox, preserveCapitalization);
+      // eslint-disable-next-line no-param-reassign
+      checkbox.parentElement!.hidden = !label || !validOptions.has(label);
+    });
+}
+
 function initFilterGroup(
   filterManager: PlaceFilterManager,
   filterOptions: FilterOptions,
@@ -191,53 +278,55 @@ function initFilterGroup(
 
   accordionElements.fieldSet.addEventListener("change", () => {
     updateCheckboxStats(accordionState, accordionElements.fieldSet);
-
-    const checkedLabels = Array.from(
-      accordionElements.fieldSet.querySelectorAll(
-        'input[type="checkbox"]:checked',
-      ),
-    )
-      .map((input) => {
-        const text = input.parentElement?.textContent?.trim();
-        return params.preserveCapitalization ? text : text?.toLowerCase();
-      })
-      .filter((x) => x !== undefined);
-    filterManager.update({ [params.filterStateKey]: new Set(checkedLabels) });
+    const checkedLabels = determineCheckedLabels(
+      accordionElements.fieldSet,
+      params.preserveCapitalization,
+    );
+    filterManager.update({ [params.filterStateKey]: checkedLabels });
   });
 
-  const allCheckboxes = Array.from(
-    accordionElements.fieldSet.querySelectorAll<HTMLInputElement>(
-      'input[type="checkbox"]',
-    ),
-  );
-
   accordionElements.checkAllButton.addEventListener("click", () => {
-    allCheckboxes.forEach((input) => {
+    const visibleCheckboxes = getVisibleCheckboxes(accordionElements.fieldSet);
+    visibleCheckboxes.forEach((input) => {
       // eslint-disable-next-line no-param-reassign
       input.checked = true;
     });
     updateCheckboxStats(accordionState, accordionElements.fieldSet);
+    const checkedLabels = determineCheckedLabels(
+      accordionElements.fieldSet,
+      params.preserveCapitalization,
+    );
     filterManager.update({
-      [params.filterStateKey]: new Set(
-        filterOptions.all(params.filterStateKey),
-      ),
+      [params.filterStateKey]: checkedLabels,
     });
   });
 
   accordionElements.uncheckAllButton.addEventListener("click", () => {
-    allCheckboxes.forEach((input) => {
+    const visibleCheckboxes = getVisibleCheckboxes(accordionElements.fieldSet);
+    visibleCheckboxes.forEach((input) => {
       // eslint-disable-next-line no-param-reassign
       input.checked = false;
     });
     updateCheckboxStats(accordionState, accordionElements.fieldSet);
+    const checkedLabels = determineCheckedLabels(
+      accordionElements.fieldSet,
+      params.preserveCapitalization,
+    );
     filterManager.update({
-      [params.filterStateKey]: new Set(),
+      [params.filterStateKey]: checkedLabels,
     });
   });
 
   filterManager.subscribe(
     `possibly update ${params.htmlName} filter UI`,
     (state) => {
+      updateCheckboxVisibility(
+        filterOptions.getOptions(state.policyTypeFilter)[params.filterStateKey],
+        accordionElements.fieldSet,
+        params.preserveCapitalization,
+      );
+      updateCheckboxStats(accordionState, accordionElements.fieldSet);
+
       const priorAccordionState = accordionState.getValue();
       const hidden = params.hide ? params.hide(state) : false;
       const title =

--- a/src/js/layout/viewToggle.ts
+++ b/src/js/layout/viewToggle.ts
@@ -29,14 +29,14 @@ function updateUI(table: Tabulator, state: ViewState): void {
   if (state === "map") {
     tableIcon.style.display = "inline-flex";
     mapIcon.style.display = "none";
-    tableView.style.display = "none";
+    tableView.hidden = true;
     mapView.hidden = false;
     mapCounter.hidden = false;
     prnLogo.hidden = false;
   } else {
     tableIcon.style.display = "none";
     mapIcon.style.display = "inline-flex";
-    tableView.style.display = "flex";
+    tableView.hidden = false;
     mapView.hidden = true;
     mapCounter.hidden = true;
     prnLogo.hidden = true;

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -7,7 +7,11 @@ import { initViewToggle, addViewToggleSubscribers } from "./layout/viewToggle";
 import readData from "./model/data";
 import { PlaceFilterManager } from "./state/FilterState";
 import { POPULATION_MAX_INDEX } from "./filter-features/populationSlider";
-import { FilterOptions, initFilterOptions } from "./filter-features/options";
+import {
+  DEFAULT_REFORM_STATUS,
+  FilterOptions,
+  initFilterOptions,
+} from "./filter-features/options";
 import initCounters from "./filter-features/counters";
 import subscribeSnapToPlace from "./map-features/position";
 import initPlaceMarkers from "./map-features/markers";
@@ -31,13 +35,15 @@ export default async function initApp(): Promise<void> {
     searchInput: null,
     policyTypeFilter: "remove parking minimums",
     allMinimumsRemovedToggle: true,
-    placeType: filterOptions.default("placeType"),
-    includedPolicyChanges: filterOptions.default("includedPolicyChanges"),
-    scope: filterOptions.default("scope"),
-    landUse: filterOptions.default("landUse"),
-    status: filterOptions.default("status"),
-    country: filterOptions.default("country"),
-    year: filterOptions.default("year"),
+    placeType: new Set(filterOptions.anyReform.placeType),
+    includedPolicyChanges: new Set(
+      filterOptions.anyReform.includedPolicyChanges,
+    ),
+    scope: new Set(filterOptions.anyReform.scope),
+    landUse: new Set(filterOptions.anyReform.landUse),
+    status: new Set([DEFAULT_REFORM_STATUS]),
+    country: new Set(filterOptions.anyReform.country),
+    year: new Set(filterOptions.anyReform.year),
     populationSliderIndexes: [0, POPULATION_MAX_INDEX],
   });
 

--- a/src/js/state/FilterState.ts
+++ b/src/js/state/FilterState.ts
@@ -27,11 +27,16 @@ export type PolicyTypeFilter = PolicyType | "any parking reform";
 // Note that this only tracks state set by the user.
 // Computed values are handled elsewhere.
 //
-// Some of the values are not relevant to certain policy types.
-// For example, "any parking reform" will ignore `scope`. Still,
-// we preserve the state so it persists when changing the policy type.
+// This is a single unified global view of the state, even though we
+// have multiple datasets like 'remove parking minimums'. Some of the
+// option groups are not relevant to certain datasets; for example,
+// "any parking reform" will ignore `scope`. Likewise, certain values
+// within an option group are irrelevant to certain data sets; for example,
+// while all datasets have 'country', their entries usually only have a subset
+// of the total set of countries across all datsets. Nevertheless,
+// we unify the state so that it persists when changing the policy type.
 //
-// Keep key names in alignment with FilterGroupKey in filterOptions.ts
+// Keep key names in alignment with DataSetSpecificOptions in filter-features/options.ts
 export interface FilterState {
   searchInput: string | null;
   policyTypeFilter: PolicyTypeFilter;

--- a/tests/app/filterOptions.test.ts
+++ b/tests/app/filterOptions.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "@playwright/test";
+import { Window } from "happy-dom";
+
+import {
+  determineSupplementalTitle,
+  determineCheckedLabels,
+} from "../../src/js/filter-features/options";
+
+function createFieldset(childrenHTML: string): HTMLFieldSetElement {
+  const window = new Window();
+  const { document } = window;
+  document.body.innerHTML = `<fieldset>${childrenHTML}</fieldset>`;
+  return document.querySelector("fieldset")! as unknown as HTMLFieldSetElement;
+}
+
+test("determineSupplementalTitle", () => {
+  // 5 checkboxes:
+  // - 2 are hidden, one of which is checked
+  // - 3 are visible, two of which are checked
+  const fieldset = createFieldset(`
+      <label><input type="checkbox" checked></label>
+      <label><input type="checkbox"></label>
+      <label><input type="checkbox" checked></label>
+      <label hidden><input type="checkbox" checked></label>
+      <label hidden><input type="checkbox"></label>
+    `);
+  expect(determineSupplementalTitle(fieldset)).toEqual(" (2/3)");
+});
+
+test("determineCheckedLabels should return labels of checked checkboxes", () => {
+  const fieldset = createFieldset(`
+    <div><input type="checkbox" checked>First Option</div>
+    <div><input type="checkbox">Second Option</div>
+    <div><input type="checkbox" checked>Third Option</div>
+    <div hidden><input type="checkbox" checked>Hidden Checked</div>
+    <div hidden><input type="checkbox">Hidden Unchecked</div>
+  `);
+
+  const result = determineCheckedLabels(fieldset);
+  expect(result).toEqual(
+    new Set(["first option", "third option", "hidden checked"]),
+  );
+
+  const preserveCapitalization = determineCheckedLabels(fieldset, true);
+  expect(preserveCapitalization).toEqual(
+    new Set(["First Option", "Third Option", "Hidden Checked"]),
+  );
+});


### PR DESCRIPTION
Restores https://github.com/ParkingReformNetwork/reform-map/pull/765.

The issue was due to this CSS

```css
[hidden] {
  display: none !important;
}
```

We had the table view always marked as hidden, but the CSS was being overridden. That might have actually been breaking semantic web!