### PR TITLE
Rename map from "mandates map" to "reform map"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Parking Mandates Map
+# Parking reform map
 
-This code runs the Mandates Map app for the Parking Reform Network: https://parkingreform.org/mandates-map/.
+This code runs the Reform Map app for the Parking Reform Network: https://parkingreform.org/mandates-map/.
 
 We do not use frameworks like React or Svelte to keep things simple. However, we do use these techniques:
 

--- a/data/generated/README.md
+++ b/data/generated/README.md
@@ -1,4 +1,4 @@
-# Mandates Map data set
+# Parking Reform Map data set
 
 This folder contains the data used for https://parkingreform.org/resources/mandates-map/, which records places/governments that have implemented parking reform.
 

--- a/index.html
+++ b/index.html
@@ -1,22 +1,22 @@
 <!doctype html>
 <html lang="en">
   <head>
-    <title>Parking Mandates Map | Parking Reform Network</title>
+    <title>Parking reform map | Parking Reform Network</title>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta
       name="description"
-      content="See which places have enacted parking reform to get rid of parking mininums."
+      content="An interactive map showing places with parking reforms, such as removing parking minimums and adding parking benefit districts."
     />
     <meta property="og:locale" content="en_US" />
     <meta property="og:type" content="website" />
     <meta
       property="og:title"
-      content="Parking Reform Map &#x2d; Parking Reform Network"
+      content="Parking reform map &#x2d; Parking Reform Network"
     />
     <meta
       property="og:description"
-      content="See which places have enacted parking reform to get rid of parking mininums."
+      content="An interactive map showing places with parking reforms, such as removing parking minimums."
     />
     <meta
       property="og:url"
@@ -25,11 +25,11 @@
     <meta property="og:site_name" content="Parking Reform Network" />
     <meta
       name="twitter:title"
-      content="Parking Reform Map &#x2d; Parking Reform Network"
+      content="Parking reform map &#x2d; Parking Reform Network"
     />
     <meta
       name="twitter:description"
-      content="See which places have enacted parking reform to get rid of parking mininums."
+      content="An interactive map showing places with parking reforms, such as removing parking minimums."
     />
     <link rel="stylesheet" href="./src/css/style.scss" />
   </head>
@@ -102,7 +102,7 @@
       hidden
     >
       <header class="about-popup-header">
-        <h2>About the Parking Mandates Map</h2>
+        <h2>About the Parking Reform Map</h2>
         <button
           class="about-popup-close-icon-container"
           title="close the about popup"

--- a/scripts/11ty/_includes/header.liquid
+++ b/scripts/11ty/_includes/header.liquid
@@ -8,7 +8,7 @@
   <div class="site-header-right">
     <ul role="menubar">
       <li role="none" class="site-header-map-link">
-        <a role="menuitem" href="https://parkingreform.org/resources/mandates-map">Mandates map</a>
+        <a role="menuitem" href="https://parkingreform.org/resources/mandates-map">Reform map</a>
       </li>
       <li role="none">
         <a role="menuitem" href="https://parkingreform.org/support">Donate</a>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abbottstown-pa.html
@@ -26,7 +26,7 @@
   <div class="site-header-right">
     <ul role="menubar">
       <li role="none" class="site-header-map-link">
-        <a role="menuitem" href="https://parkingreform.org/resources/mandates-map">Mandates map</a>
+        <a role="menuitem" href="https://parkingreform.org/resources/mandates-map">Reform map</a>
       </li>
       <li role="none">
         <a role="menuitem" href="https://parkingreform.org/support">Donate</a>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/abilene-tx.html
@@ -26,7 +26,7 @@
   <div class="site-header-right">
     <ul role="menubar">
       <li role="none" class="site-header-map-link">
-        <a role="menuitem" href="https://parkingreform.org/resources/mandates-map">Mandates map</a>
+        <a role="menuitem" href="https://parkingreform.org/resources/mandates-map">Reform map</a>
       </li>
       <li role="none">
         <a role="menuitem" href="https://parkingreform.org/support">Donate</a>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/auburn-me.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/auburn-me.html
@@ -26,7 +26,7 @@
   <div class="site-header-right">
     <ul role="menubar">
       <li role="none" class="site-header-map-link">
-        <a role="menuitem" href="https://parkingreform.org/resources/mandates-map">Mandates map</a>
+        <a role="menuitem" href="https://parkingreform.org/resources/mandates-map">Reform map</a>
       </li>
       <li role="none">
         <a role="menuitem" href="https://parkingreform.org/support">Donate</a>

--- a/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
+++ b/tests/scripts/generateHtmlPages.test.ts-snapshots/basalt-co.html
@@ -26,7 +26,7 @@
   <div class="site-header-right">
     <ul role="menubar">
       <li role="none" class="site-header-map-link">
-        <a role="menuitem" href="https://parkingreform.org/resources/mandates-map">Mandates map</a>
+        <a role="menuitem" href="https://parkingreform.org/resources/mandates-map">Reform map</a>
       </li>
       <li role="none">
         <a role="menuitem" href="https://parkingreform.org/support">Donate</a>


### PR DESCRIPTION
Now that we're adding PBDs, "Mandates map" is a misnomer. (I always thought it was the wrong name anyways.)