### PR TITLE
Rename PolicyRecord to LandUseRecord

### DIFF
--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -6,12 +6,12 @@ import { compileString as compileStringSass } from "sass";
 import { capitalize } from "lodash-es";
 
 import {
-  ProcessedCompletePolicy,
+  ProcessedCompleteLandUsePolicy,
   readProcessedCompleteData,
 } from "./scripts/lib/data.js";
 import { escapePlaceId } from "./src/js/model/data.js";
 
-function processPolicyRecord(policy: ProcessedCompletePolicy): object {
+function processLandUse(policy: ProcessedCompleteLandUsePolicy): object {
   return {
     summary: policy.summary,
     dateLabel:
@@ -53,9 +53,9 @@ export default async function (eleventyConfig: any) {
     escapedPlaceId: escapePlaceId(placeId),
     population: entry.place.pop.toLocaleString("en-us"),
     repeal: entry.place.repeal,
-    rmMin: entry.rm_min?.map(processPolicyRecord) || [],
-    reduceMin: entry.reduce_min?.map(processPolicyRecord) || [],
-    addMax: entry.add_max?.map(processPolicyRecord) || [],
+    rmMin: entry.rm_min?.map(processLandUse) || [],
+    reduceMin: entry.reduce_min?.map(processLandUse) || [],
+    addMax: entry.add_max?.map(processLandUse) || [],
   }));
 
   eleventyConfig.addGlobalData("entries", entries);

--- a/scripts/generateDataSet.ts
+++ b/scripts/generateDataSet.ts
@@ -10,7 +10,7 @@ import Papa from "papaparse";
 
 import {
   ProcessedCompleteEntry,
-  ProcessedCompletePolicy,
+  ProcessedCompleteLandUsePolicy,
   readProcessedCompleteData,
 } from "./lib/data";
 import { ReformStatus } from "../src/js/model/types";
@@ -105,11 +105,11 @@ export function createAnyPolicyCsvs(data: ProcessedCompleteEntry[]): {
   };
 }
 
-export function createReformCsv(
+export function createLandUseCsv(
   data: ProcessedCompleteEntry[],
   getter: (
     entry: ProcessedCompleteEntry,
-  ) => ProcessedCompletePolicy[] | undefined,
+  ) => ProcessedCompleteLandUsePolicy[] | undefined,
 ): string {
   const entries = data.flatMap((entry) => {
     const policies = getter(entry);
@@ -170,13 +170,13 @@ async function main(): Promise<void> {
   await writeCsv(proposed, "data/generated/overview_proposed.csv");
   await writeCsv(repealed, "data/generated/overview_repealed.csv");
 
-  const addMax = createReformCsv(data, (entry) => entry.add_max);
+  const addMax = createLandUseCsv(data, (entry) => entry.add_max);
   await writeCsv(addMax, "data/generated/add_maximums.csv");
 
-  const reduceMin = createReformCsv(data, (entry) => entry.reduce_min);
+  const reduceMin = createLandUseCsv(data, (entry) => entry.reduce_min);
   await writeCsv(reduceMin, "data/generated/reduce_minimums.csv");
 
-  const rmMin = createReformCsv(data, (entry) => entry.rm_min);
+  const rmMin = createLandUseCsv(data, (entry) => entry.rm_min);
   await writeCsv(rmMin, "data/generated/remove_minimums.csv");
 
   const files = await glob("data/generated/*");

--- a/scripts/lib/data.ts
+++ b/scripts/lib/data.ts
@@ -7,9 +7,9 @@ import {
   RawCoreEntry,
   PlaceId,
   RawPlace,
-  RawCorePolicy,
+  RawCoreLandUsePolicy,
   ProcessedPlace,
-  ProcessedCorePolicy,
+  ProcessedCoreLandUsePolicy,
 } from "../../src/js/model/types";
 import { processRawCoreEntry } from "../../src/js/model/data";
 
@@ -26,7 +26,7 @@ export interface Citation {
   screenshots: DirectusFile[];
 }
 
-export interface ExtendedPolicy {
+export interface ExtendedLandUsePolicy {
   summary: string;
   reporter: string | null;
   requirements: string[];
@@ -34,33 +34,35 @@ export interface ExtendedPolicy {
 }
 
 export type RawExtendedEntry = {
-  reduce_min?: ExtendedPolicy[];
-  rm_min?: ExtendedPolicy[];
-  add_max?: ExtendedPolicy[];
+  reduce_min?: ExtendedLandUsePolicy[];
+  rm_min?: ExtendedLandUsePolicy[];
+  add_max?: ExtendedLandUsePolicy[];
 };
 
-export type RawCompletePolicy = RawCorePolicy & ExtendedPolicy;
+export type RawCompleteLandUsePolicy = RawCoreLandUsePolicy &
+  ExtendedLandUsePolicy;
 
 export interface RawCompleteEntry {
   place: RawPlace;
-  reduce_min?: Array<RawCompletePolicy>;
-  rm_min?: Array<RawCompletePolicy>;
-  add_max?: Array<RawCompletePolicy>;
+  reduce_min?: Array<RawCompleteLandUsePolicy>;
+  rm_min?: Array<RawCompleteLandUsePolicy>;
+  add_max?: Array<RawCompleteLandUsePolicy>;
 }
 
 export interface ProcessedExtendedEntry {
-  reduce_min?: ExtendedPolicy[];
-  rm_min?: ExtendedPolicy[];
-  add_max?: ExtendedPolicy[];
+  reduce_min?: ExtendedLandUsePolicy[];
+  rm_min?: ExtendedLandUsePolicy[];
+  add_max?: ExtendedLandUsePolicy[];
 }
 
-export type ProcessedCompletePolicy = ProcessedCorePolicy & ExtendedPolicy;
+export type ProcessedCompleteLandUsePolicy = ProcessedCoreLandUsePolicy &
+  ExtendedLandUsePolicy;
 
 export interface ProcessedCompleteEntry {
   place: ProcessedPlace;
-  reduce_min?: Array<ProcessedCompletePolicy>;
-  rm_min?: Array<ProcessedCompletePolicy>;
-  add_max?: Array<ProcessedCompletePolicy>;
+  reduce_min?: Array<ProcessedCompleteLandUsePolicy>;
+  rm_min?: Array<ProcessedCompleteLandUsePolicy>;
+  add_max?: Array<ProcessedCompleteLandUsePolicy>;
 }
 
 export async function readRawCoreData(): Promise<
@@ -77,12 +79,12 @@ export async function readRawExtendedData(): Promise<
   return JSON.parse(raw);
 }
 
-function mergeRawPolicies(
-  corePolicies: RawCorePolicy[],
-  extendedPolicies: ExtendedPolicy[],
+function mergeRawLandUsePolicies(
+  corePolicies: RawCoreLandUsePolicy[],
+  extendedPolicies: ExtendedLandUsePolicy[],
   placeId: PlaceId,
   policyKeyName: string,
-): RawCompletePolicy[] {
+): RawCompleteLandUsePolicy[] {
   return zipWith(
     corePolicies,
     extendedPolicies,
@@ -116,7 +118,7 @@ export async function readRawCompleteData(): Promise<
           place: coreEntry.place,
           ...(coreEntry.reduce_min &&
             extendedEntry.reduce_min && {
-              reduce_min: mergeRawPolicies(
+              reduce_min: mergeRawLandUsePolicies(
                 coreEntry.reduce_min,
                 extendedEntry.reduce_min,
                 placeId,
@@ -125,7 +127,7 @@ export async function readRawCompleteData(): Promise<
             }),
           ...(coreEntry.rm_min &&
             extendedEntry.rm_min && {
-              rm_min: mergeRawPolicies(
+              rm_min: mergeRawLandUsePolicies(
                 coreEntry.rm_min,
                 extendedEntry.rm_min,
                 placeId,
@@ -134,7 +136,7 @@ export async function readRawCompleteData(): Promise<
             }),
           ...(coreEntry.add_max &&
             extendedEntry.add_max && {
-              add_max: mergeRawPolicies(
+              add_max: mergeRawLandUsePolicies(
                 coreEntry.add_max,
                 extendedEntry.add_max,
                 placeId,
@@ -147,9 +149,9 @@ export async function readRawCompleteData(): Promise<
   );
 }
 
-function processCompletePolicy(
-  policy: RawCompletePolicy,
-): ProcessedCompletePolicy {
+function processCompleteLandUsePolicy(
+  policy: RawCompleteLandUsePolicy,
+): ProcessedCompleteLandUsePolicy {
   return {
     ...policy,
     date: Date.fromNullable(policy.date),
@@ -167,13 +169,13 @@ export async function readProcessedCompleteData(): Promise<
         place: processed.place,
       };
       if (entry.add_max) {
-        result.add_max = entry.add_max.map(processCompletePolicy);
+        result.add_max = entry.add_max.map(processCompleteLandUsePolicy);
       }
       if (entry.reduce_min) {
-        result.reduce_min = entry.reduce_min.map(processCompletePolicy);
+        result.reduce_min = entry.reduce_min.map(processCompleteLandUsePolicy);
       }
       if (entry.rm_min) {
-        result.rm_min = entry.rm_min.map(processCompletePolicy);
+        result.rm_min = entry.rm_min.map(processCompleteLandUsePolicy);
       }
       return [placeId, result];
     }),
@@ -181,8 +183,9 @@ export async function readProcessedCompleteData(): Promise<
 }
 
 export function getCitations(entry: RawExtendedEntry): Citation[] {
-  const fromArray = (policies: ExtendedPolicy[] | undefined): Citation[] =>
-    policies?.flatMap((policy) => policy.citations) ?? [];
+  const fromArray = (
+    policies: ExtendedLandUsePolicy[] | undefined,
+  ): Citation[] => policies?.flatMap((policy) => policy.citations) ?? [];
 
   return [
     ...fromArray(entry.add_max),

--- a/scripts/lib/directus.ts
+++ b/scripts/lib/directus.ts
@@ -53,9 +53,9 @@ interface Coordinates {
 export interface Schema {
   places: Place[];
   citations: Citation[];
-  policy_records: PolicyRecord[];
+  policy_records: LandUseRecord[];
   citations_files: CitationsFileJunction[];
-  policy_records_citations: PolicyRecordCitationJunction[];
+  policy_records_citations: LandUseCitationJunction[];
 }
 
 export type Place = {
@@ -78,7 +78,7 @@ export type Citation = {
   attachments: number[];
 } & Metadata;
 
-export type PolicyRecord = {
+export type LandUseRecord = {
   place: number;
   type: PolicyType;
   last_verified_at: string | null;
@@ -99,7 +99,7 @@ export interface CitationsFileJunction {
   directus_files_id: string;
 }
 
-export interface PolicyRecordCitationJunction {
+export interface LandUseCitationJunction {
   id: number;
   policy_records_id: number;
   citations_id: number;

--- a/scripts/lib/optionValues.ts
+++ b/scripts/lib/optionValues.ts
@@ -4,7 +4,7 @@ import { sortBy, without } from "lodash-es";
 
 import { COUNTRY_MAPPING } from "../../src/js/model/data";
 import {
-  RawCorePolicy,
+  RawCoreLandUsePolicy,
   UNKNOWN_YEAR,
   Date,
   RawPlace,
@@ -31,13 +31,13 @@ class OptionValues {
     this.year = new Set([UNKNOWN_YEAR]);
   }
 
-  add(place: RawPlace, policyRecord: RawCorePolicy): void {
+  addLandUse(place: RawPlace, landUseRecord: RawCoreLandUsePolicy): void {
     this.placeType.add(place.type);
     this.country.add(COUNTRY_MAPPING[place.country] ?? place.country);
-    policyRecord.scope.forEach((v) => this.scope.add(v));
-    policyRecord.land.forEach((v) => this.landUse.add(v));
-    if (policyRecord.date) {
-      this.year.add(new Date(policyRecord.date).parsed.year.toString());
+    landUseRecord.scope.forEach((v) => this.scope.add(v));
+    landUseRecord.land.forEach((v) => this.landUse.add(v));
+    if (landUseRecord.date) {
+      this.year.add(new Date(landUseRecord.date).parsed.year.toString());
     }
   }
 
@@ -69,34 +69,34 @@ export function determineOptionValues(entries: RawCoreEntry[]) {
 
   entries.forEach((entry) => {
     entry.add_max?.forEach((policyRecord) => {
-      merged.add(entry.place, policyRecord);
+      merged.addLandUse(entry.place, policyRecord);
       const [any, policy] = {
         adopted: [anyAdopted, addMaxAdopted],
         proposed: [anyProposed, addMaxProposed],
         repealed: [anyRepealed, addMaxRepealed],
       }[policyRecord.status];
-      any.add(entry.place, policyRecord);
-      policy.add(entry.place, policyRecord);
+      any.addLandUse(entry.place, policyRecord);
+      policy.addLandUse(entry.place, policyRecord);
     });
     entry.reduce_min?.forEach((policyRecord) => {
-      merged.add(entry.place, policyRecord);
+      merged.addLandUse(entry.place, policyRecord);
       const [any, policy] = {
         adopted: [anyAdopted, reduceMinAdopted],
         proposed: [anyProposed, reduceMinProposed],
         repealed: [anyRepealed, reduceMinRepealed],
       }[policyRecord.status];
-      any.add(entry.place, policyRecord);
-      policy.add(entry.place, policyRecord);
+      any.addLandUse(entry.place, policyRecord);
+      policy.addLandUse(entry.place, policyRecord);
     });
     entry.rm_min?.forEach((policyRecord) => {
-      merged.add(entry.place, policyRecord);
+      merged.addLandUse(entry.place, policyRecord);
       const [any, policy] = {
         adopted: [anyAdopted, rmMinAdopted],
         proposed: [anyProposed, rmMinProposed],
         repealed: [anyRepealed, rmMinRepealed],
       }[policyRecord.status];
-      any.add(entry.place, policyRecord);
-      policy.add(entry.place, policyRecord);
+      any.addLandUse(entry.place, policyRecord);
+      policy.addLandUse(entry.place, policyRecord);
     });
   });
 

--- a/scripts/syncDirectus.ts
+++ b/scripts/syncDirectus.ts
@@ -363,7 +363,7 @@ function combineData(
                   placeId,
                   hasDistinctPolicyTypes,
                   policyType: record.type!,
-                  policyRecordIdx: policyRecordIdx,
+                  policyRecordIdx,
                 },
               ),
             };

--- a/scripts/syncDirectus.ts
+++ b/scripts/syncDirectus.ts
@@ -15,18 +15,18 @@ import {
   Citation as DirectusCitation,
   readItemsBatched,
   readCitationsFilesBatched,
-  PolicyRecord,
+  LandUseRecord,
 } from "./lib/directus";
 import {
   PlaceId as PlaceStringId,
   PolicyType,
-  RawCorePolicy,
+  RawCoreLandUsePolicy,
 } from "../src/js/model/types";
 import { getLongLat, initGeocoder } from "./lib/geocoder";
 import {
   DirectusFile,
   Citation,
-  ExtendedPolicy,
+  ExtendedLandUsePolicy,
   RawCompleteEntry,
 } from "./lib/data";
 import { saveOptionValues } from "./lib/optionValues";
@@ -90,10 +90,10 @@ async function readPlacesAndEnsureCoordinates(
   };
 }
 
-async function readPolicyRecords(
+async function readLandUseRecords(
   client: DirectusClient,
   placeDirectusIdToStringId: Record<number, PlaceStringId>,
-): Promise<Record<PlaceStringId, Array<Partial<PolicyRecord>>>> {
+): Promise<Record<PlaceStringId, Array<Partial<LandUseRecord>>>> {
   const records = await readItemsBatched(
     client,
     "policy_records",
@@ -136,7 +136,7 @@ async function readCitations(
   return Object.fromEntries(rawCitations.map((record) => [record.id, record]));
 }
 
-async function readCitationsByPolicyRecordJunctionId(
+async function readCitationsByLandUseJunctionId(
   client: DirectusClient,
   citations: Record<number, Partial<DirectusCitation>>,
 ): Promise<Record<number, Partial<DirectusCitation>>> {
@@ -218,7 +218,7 @@ interface AttachmentFileNameArgsBase {
   placeId: string;
   hasDistinctPolicyTypes: boolean;
   policyType: PolicyType;
-  /// The index of policy records for the current `policyType`. If
+  /// The index of land use records for the current `policyType`. If
   /// there is only one record for the `policyType`, this value should
   /// be set to `null`.
   policyRecordIdx: number | null;
@@ -314,8 +314,8 @@ function createCitations(
 
 function combineData(
   places: Record<PlaceStringId, Partial<DirectusPlace>>,
-  policyRecords: Record<PlaceStringId, Array<Partial<PolicyRecord>>>,
-  citationsByPolicyRecordJunctionId: Record<number, Partial<DirectusCitation>>,
+  landUseRecords: Record<PlaceStringId, Array<Partial<LandUseRecord>>>,
+  citationsByLandUseJunctionId: Record<number, Partial<DirectusCitation>>,
   filesByAttachmentJunctionId: Record<number, FileMetadata>,
 ): Record<PlaceStringId, RawCompleteEntry> {
   return Object.fromEntries(
@@ -324,8 +324,8 @@ function combineData(
         let numAddMax = 0;
         let numReduceMin = 0;
         let numRmMin = 0;
-        if (policyRecords[placeId]) {
-          policyRecords[placeId].forEach((record) => {
+        if (landUseRecords[placeId]) {
+          landUseRecords[placeId].forEach((record) => {
             if (record.type === "add parking maximums") numAddMax += 1;
             if (record.type === "reduce parking minimums") numReduceMin += 1;
             if (record.type === "remove parking minimums") numRmMin += 1;
@@ -334,11 +334,12 @@ function combineData(
         const hasDistinctPolicyTypes =
           [numAddMax, numReduceMin, numRmMin].filter(Boolean).length > 1;
 
-        const addMax: Array<RawCorePolicy & ExtendedPolicy> = [];
-        const reduceMin: Array<RawCorePolicy & ExtendedPolicy> = [];
-        const rmMin: Array<RawCorePolicy & ExtendedPolicy> = [];
-        if (policyRecords[placeId]) {
-          policyRecords[placeId].forEach((record) => {
+        const addMax: Array<RawCoreLandUsePolicy & ExtendedLandUsePolicy> = [];
+        const reduceMin: Array<RawCoreLandUsePolicy & ExtendedLandUsePolicy> =
+          [];
+        const rmMin: Array<RawCoreLandUsePolicy & ExtendedLandUsePolicy> = [];
+        if (landUseRecords[placeId]) {
+          landUseRecords[placeId].forEach((record) => {
             const [collection, numPolicyRecords] = {
               "add parking maximums": [addMax, numAddMax] as const,
               "reduce parking minimums": [reduceMin, numReduceMin] as const,
@@ -356,13 +357,13 @@ function combineData(
               requirements: record.requirements!,
               citations: createCitations(
                 record.citations!,
-                citationsByPolicyRecordJunctionId,
+                citationsByLandUseJunctionId,
                 filesByAttachmentJunctionId,
                 {
                   placeId,
                   hasDistinctPolicyTypes,
                   policyType: record.type!,
-                  policyRecordIdx,
+                  policyRecordIdx: policyRecordIdx,
                 },
               ),
             };
@@ -404,7 +405,7 @@ function combineData(
 async function saveCoreData(
   result: Record<PlaceStringId, RawCompleteEntry>,
 ): Promise<void> {
-  const formatPolicy = (record: RawCorePolicy) => ({
+  const formatLandUse = (record: RawCoreLandUsePolicy) => ({
     status: record.status,
     scope: record.scope.sort(),
     land: record.land.sort(),
@@ -425,13 +426,13 @@ async function saveCoreData(
           repeal: entry.place.repeal,
         },
         ...(entry.add_max && {
-          add_max: entry.add_max.map(formatPolicy),
+          add_max: entry.add_max.map(formatLandUse),
         }),
         ...(entry.reduce_min && {
-          reduce_min: entry.reduce_min.map(formatPolicy),
+          reduce_min: entry.reduce_min.map(formatLandUse),
         }),
         ...(entry.rm_min && {
-          rm_min: entry.rm_min.map(formatPolicy),
+          rm_min: entry.rm_min.map(formatLandUse),
         }),
       },
     ]),
@@ -444,7 +445,7 @@ async function saveCoreData(
 async function saveExtendedData(
   result: Record<PlaceStringId, RawCompleteEntry>,
 ): Promise<void> {
-  const formatPolicy = (record: ExtendedPolicy) => ({
+  const formatLandUse = (record: ExtendedLandUsePolicy) => ({
     summary: record.summary,
     reporter: record.reporter,
     requirements: record.requirements.sort(),
@@ -455,11 +456,11 @@ async function saveExtendedData(
     Object.entries(result).map(([placeId, entry]) => [
       placeId,
       {
-        ...(entry.add_max && { add_max: entry.add_max.map(formatPolicy) }),
+        ...(entry.add_max && { add_max: entry.add_max.map(formatLandUse) }),
         ...(entry.reduce_min && {
-          reduce_min: entry.reduce_min.map(formatPolicy),
+          reduce_min: entry.reduce_min.map(formatLandUse),
         }),
-        ...(entry.rm_min && { rm_min: entry.rm_min.map(formatPolicy) }),
+        ...(entry.rm_min && { rm_min: entry.rm_min.map(formatLandUse) }),
       },
     ]),
   );
@@ -477,20 +478,22 @@ async function main(): Promise<void> {
   const geocoder = initGeocoder();
 
   const places = await readPlacesAndEnsureCoordinates(client, geocoder);
-  const policyRecords = await readPolicyRecords(
+  const landUseRecords = await readLandUseRecords(
     client,
     places.directusIdToStringId,
   );
   const citations = await readCitations(client);
-  const citationsByPolicyRecordJunctionId =
-    await readCitationsByPolicyRecordJunctionId(client, citations);
+  const citationsByLandUseJunctionId = await readCitationsByLandUseJunctionId(
+    client,
+    citations,
+  );
   const filesByAttachmentJunctionId =
     await readFilesByAttachmentJunctionId(client);
 
   const result = combineData(
     places.stringIdToPlace,
-    policyRecords,
-    citationsByPolicyRecordJunctionId,
+    landUseRecords,
+    citationsByLandUseJunctionId,
     filesByAttachmentJunctionId,
   );
 

--- a/src/js/model/data.ts
+++ b/src/js/model/data.ts
@@ -2,13 +2,14 @@ import {
   PlaceId,
   ProcessedCoreEntry,
   RawCoreEntry,
-  RawCorePolicy,
+  RawCoreLandUsePolicy,
   PolicyType,
   Date,
   RawPlace,
   ProcessedPlace,
-  ProcessedCorePolicy,
+  ProcessedCoreLandUsePolicy,
   ReformStatus,
+  BaseLandUsePolicy,
 } from "./types";
 
 export const COUNTRIES_PREFIXED_BY_THE = new Set([
@@ -74,9 +75,8 @@ export function determineAllPolicyTypes(
   entry: RawCoreEntry | ProcessedCoreEntry,
   status: ReformStatus,
 ): PolicyType[] {
-  const hasPolicy = (
-    policies: ProcessedCorePolicy[] | RawCorePolicy[] | undefined,
-  ) => !!policies?.filter((policy) => policy.status === status).length;
+  const hasPolicy = (policies: BaseLandUsePolicy[] | undefined) =>
+    !!policies?.filter((policy) => policy.status === status).length;
 
   const result: PolicyType[] = [];
   if (hasPolicy(entry.add_max)) result.push("add parking maximums");
@@ -88,9 +88,8 @@ export function determineAllPolicyTypes(
 export function determinePolicyTypeStatuses(
   entry: RawCoreEntry | ProcessedCoreEntry,
 ): Record<PolicyType, Set<ReformStatus>> {
-  const getStatuses = (
-    policies: ProcessedCorePolicy[] | RawCorePolicy[] | undefined,
-  ) => new Set(policies?.map((policy) => policy.status) ?? []);
+  const getStatuses = (policies: BaseLandUsePolicy[] | undefined) =>
+    new Set(policies?.map((policy) => policy.status) ?? []);
   return {
     "add parking maximums": getStatuses(entry.add_max),
     "reduce parking minimums": getStatuses(entry.reduce_min),
@@ -98,7 +97,9 @@ export function determinePolicyTypeStatuses(
   };
 }
 
-function processPolicy(raw: RawCorePolicy): ProcessedCorePolicy {
+function processLandUsePolicy(
+  raw: RawCoreLandUsePolicy,
+): ProcessedCoreLandUsePolicy {
   return {
     ...raw,
     date: Date.fromNullable(raw.date),
@@ -113,13 +114,13 @@ export function processRawCoreEntry(
     place: processPlace(placeId, raw.place),
   };
   if (raw.add_max) {
-    result.add_max = raw.add_max.map(processPolicy);
+    result.add_max = raw.add_max.map(processLandUsePolicy);
   }
   if (raw.reduce_min) {
-    result.reduce_min = raw.reduce_min.map(processPolicy);
+    result.reduce_min = raw.reduce_min.map(processLandUsePolicy);
   }
   if (raw.rm_min) {
-    result.rm_min = raw.rm_min.map(processPolicy);
+    result.rm_min = raw.rm_min.map(processLandUsePolicy);
   }
   return result;
 }

--- a/src/js/model/types.ts
+++ b/src/js/model/types.ts
@@ -58,28 +58,30 @@ export type PolicyType = (typeof ALL_POLICY_TYPE)[number];
 export const ALL_REFORM_STATUS = ["adopted", "proposed", "repealed"] as const;
 export type ReformStatus = (typeof ALL_REFORM_STATUS)[number];
 
-/// Every policy has these values. It is missing some fields like `date`.
-export interface BasePolicy {
+/// Every land use policy has these values. It is missing some fields like `date`.
+export interface BaseLandUsePolicy {
   status: ReformStatus;
   scope: string[];
   land: string[];
 }
 
-export type RawCorePolicy = BasePolicy & { date: string | null };
-export type ProcessedCorePolicy = BasePolicy & { date: Date | null };
+export type RawCoreLandUsePolicy = BaseLandUsePolicy & { date: string | null };
+export type ProcessedCoreLandUsePolicy = BaseLandUsePolicy & {
+  date: Date | null;
+};
 
 export interface RawCoreEntry {
   place: RawPlace;
-  reduce_min?: RawCorePolicy[];
-  rm_min?: RawCorePolicy[];
-  add_max?: RawCorePolicy[];
+  reduce_min?: RawCoreLandUsePolicy[];
+  rm_min?: RawCoreLandUsePolicy[];
+  add_max?: RawCoreLandUsePolicy[];
 }
 
 export interface ProcessedCoreEntry {
   place: ProcessedPlace;
-  reduce_min?: ProcessedCorePolicy[];
-  rm_min?: ProcessedCorePolicy[];
-  add_max?: ProcessedCorePolicy[];
+  reduce_min?: ProcessedCoreLandUsePolicy[];
+  rm_min?: ProcessedCoreLandUsePolicy[];
+  add_max?: ProcessedCoreLandUsePolicy[];
 }
 export const UNKNOWN_YEAR = "unknown";
 

--- a/src/js/state/FilterState.ts
+++ b/src/js/state/FilterState.ts
@@ -5,7 +5,7 @@ import {
   PlaceType,
   PolicyType,
   ProcessedCoreEntry,
-  ProcessedCorePolicy,
+  ProcessedCoreLandUsePolicy,
   ProcessedPlace,
   ReformStatus,
   UNKNOWN_YEAR,
@@ -237,8 +237,8 @@ export class PlaceFilterManager {
     return isPopulation;
   }
 
-  private matchesPolicyRecord(
-    policyRecord: ProcessedCorePolicy,
+  private matchesLandUsePolicy(
+    policyRecord: ProcessedCoreLandUsePolicy,
     options: { ignoreScope?: boolean; ignoreLand?: boolean },
   ): boolean {
     const filterState = this.state.getValue();
@@ -298,7 +298,7 @@ export class PlaceFilterManager {
     if (filterState.policyTypeFilter === "add parking maximums") {
       const matchingPolicies = getFilteredIndexes(
         entry.add_max ?? [],
-        (policyRecord) => this.matchesPolicyRecord(policyRecord, {}),
+        (policyRecord) => this.matchesLandUsePolicy(policyRecord, {}),
       );
       return matchingPolicies.length
         ? {
@@ -312,7 +312,7 @@ export class PlaceFilterManager {
     if (filterState.policyTypeFilter === "reduce parking minimums") {
       const matchingPolicies = getFilteredIndexes(
         entry.reduce_min ?? [],
-        (policyRecord) => this.matchesPolicyRecord(policyRecord, {}),
+        (policyRecord) => this.matchesLandUsePolicy(policyRecord, {}),
       );
       return matchingPolicies.length
         ? {
@@ -335,7 +335,7 @@ export class PlaceFilterManager {
       };
       const matchingPolicies = getFilteredIndexes(
         entry.rm_min ?? [],
-        (policyRecord) => this.matchesPolicyRecord(policyRecord, options),
+        (policyRecord) => this.matchesLandUsePolicy(policyRecord, options),
       );
       return matchingPolicies.length
         ? {

--- a/src/js/table.ts
+++ b/src/js/table.ts
@@ -15,7 +15,7 @@ import {
 } from "tabulator-tables";
 
 import { PlaceFilterManager, PolicyTypeFilter } from "./state/FilterState";
-import { Date, ProcessedCorePolicy, ReformStatus } from "./model/types";
+import { Date, ProcessedCoreLandUsePolicy, ReformStatus } from "./model/types";
 import { ViewStateObservable } from "./layout/viewToggle";
 import { determineAllPolicyTypes } from "./model/data";
 
@@ -195,9 +195,9 @@ export default function initTable(
       addMax: repealed.includes("add parking maximums"),
     });
 
-    const savePolicies = (
+    const saveLandUsePolicies = (
       collection: any[],
-      policies: ProcessedCorePolicy[] | undefined,
+      policies: ProcessedCoreLandUsePolicy[] | undefined,
     ): void =>
       policies?.forEach((policy, i) =>
         collection.push({
@@ -210,9 +210,9 @@ export default function initTable(
         }),
       );
 
-    savePolicies(dataAddMax, entry.add_max);
-    savePolicies(dataReduceMin, entry.reduce_min);
-    savePolicies(dataRmMin, entry.rm_min);
+    saveLandUsePolicies(dataAddMax, entry.add_max);
+    saveLandUsePolicies(dataReduceMin, entry.reduce_min);
+    saveLandUsePolicies(dataRmMin, entry.rm_min);
   });
 
   const filterStateToConfig: Record<

--- a/tests/app/scorecard.test.ts
+++ b/tests/app/scorecard.test.ts
@@ -4,7 +4,7 @@ import { loadMap } from "./utils";
 import { generateScorecard } from "../../src/js/map-features/scorecard";
 import {
   ProcessedCoreEntry,
-  ProcessedCorePolicy,
+  ProcessedCoreLandUsePolicy,
   ProcessedPlace,
 } from "../../src/js/model/types";
 
@@ -54,7 +54,7 @@ test("generateScorecard()", () => {
     coord: [0, 0],
     url: "https://my-site.org",
   };
-  const policy: ProcessedCorePolicy = {
+  const landUsePolicy: ProcessedCoreLandUsePolicy = {
     status: "adopted",
     scope: [],
     land: [],
@@ -62,7 +62,7 @@ test("generateScorecard()", () => {
   };
   const entry: ProcessedCoreEntry = {
     place,
-    add_max: [policy],
+    add_max: [landUsePolicy],
   };
   expect(generateScorecard(entry, "My City, AZ")).toEqual(
     `
@@ -88,10 +88,10 @@ test("generateScorecard()", () => {
   const repealed: ProcessedCoreEntry = {
     place: { ...place, repeal: false },
     add_max: [
-      { ...policy, status: "repealed" },
-      { ...policy, status: "proposed" },
+      { ...landUsePolicy, status: "repealed" },
+      { ...landUsePolicy, status: "proposed" },
     ],
-    rm_min: [policy],
+    rm_min: [landUsePolicy],
   };
   expect(generateScorecard(repealed, "My City, AZ")).toEqual(
     `

--- a/tests/scripts/generateDataSet.test.ts
+++ b/tests/scripts/generateDataSet.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "@playwright/test";
 
 import {
   createAnyPolicyCsvs,
-  createReformCsv,
+  createLandUseCsv,
 } from "../../scripts/generateDataSet";
 import type { Citation, ProcessedCompleteEntry } from "../../scripts/lib/data";
 import { Date } from "../../src/js/model/types";
@@ -94,6 +94,6 @@ test("generate CSVs", async ({}, testInfo) => {
   expect(normalize(proposed)).toMatchSnapshot("overview-proposed.csv");
   expect(normalize(repealed)).toMatchSnapshot("overview-repealed.csv");
 
-  const maximums = createReformCsv(entries, (entry) => entry.add_max);
+  const maximums = createLandUseCsv(entries, (entry) => entry.add_max);
   expect(normalize(maximums)).toMatchSnapshot("maximums.csv");
 });


### PR DESCRIPTION
Prework for PBDs. New terming:

* LandUseRecord: an individual policy record for maximums, reduce mins, and rm mins
* PbdRecord: an individual policy record for PBDs
* PolicyType: the land use types, plus PBDs and future types
* "policy record": a generic policy entry belonging to a Place. Reminder that there can be >1 policy records for the same policy type