### PR TITLE
Support encoding the rest of filter state in the URL

### DIFF
--- a/src/js/filter-features/options.ts
+++ b/src/js/filter-features/options.ts
@@ -244,9 +244,10 @@ function generateAccordionForFilterGroup(
   fieldSet.appendChild(filterOptionsContainer);
 
   // When setting up the filter group, we use `merged` to add every option in the universe.
+  // However, we use the initial filterState to determine if it should be checked.
   FILTER_OPTIONS.merged[params.filterStateKey].forEach((val, i) => {
     const inputId = `filter-${params.htmlName}-option-${i}`;
-    const checked = true;
+    const checked = filterState[params.filterStateKey].has(val);
     const description = params.preserveCapitalization ? val : capitalize(val);
     const [label] = generateCheckbox(
       inputId,

--- a/src/js/filter-features/populationSlider.ts
+++ b/src/js/filter-features/populationSlider.ts
@@ -150,10 +150,10 @@ export function initPopulationSlider(
   );
 
   // Set initial state.
-  const maxIndex = populationSliderIndexes[1].toString();
+  const maxIndex = POPULATION_MAX_INDEX.toString();
   sliders.left.setAttribute("max", maxIndex);
   sliders.right.setAttribute("max", maxIndex);
-  sliders.right.setAttribute("value", maxIndex);
+  sliders.right.setAttribute("value", populationSliderIndexes[1].toString());
 
   // Add event listeners.
   const onChange = (): void => {

--- a/src/js/state/urlEncoder.ts
+++ b/src/js/state/urlEncoder.ts
@@ -1,20 +1,31 @@
+import { isEqual } from "lodash-es";
+
 import type { FilterState } from "./FilterState";
 import { FILTER_OPTIONS } from "../filter-features/options";
 import { POPULATION_MAX_INDEX } from "../filter-features/populationSlider";
+import { COUNTRY_MAPPING } from "../model/data";
 
-export const DEFAULT_FILTER_STATE: FilterState = {
-  searchInput: null,
-  policyTypeFilter: "remove parking minimums",
-  status: "adopted",
-  allMinimumsRemovedToggle: true,
+export const MERGED_STRING_SET_OPTIONS = {
   placeType: new Set(FILTER_OPTIONS.merged.placeType),
   includedPolicyChanges: new Set(FILTER_OPTIONS.merged.includedPolicyChanges),
   scope: new Set(FILTER_OPTIONS.merged.scope),
   landUse: new Set(FILTER_OPTIONS.merged.landUse),
   country: new Set(FILTER_OPTIONS.merged.country),
   year: new Set(FILTER_OPTIONS.merged.year),
+};
+
+export const DEFAULT_FILTER_STATE: FilterState = {
+  searchInput: null,
+  policyTypeFilter: "remove parking minimums",
+  status: "adopted",
+  allMinimumsRemovedToggle: true,
+  ...MERGED_STRING_SET_OPTIONS,
   populationSliderIndexes: [0, POPULATION_MAX_INDEX],
 };
+
+const ARRAY_DELIMITER = ".";
+const BOOL_TRUE = "y";
+const BOOL_FALSE = "n";
 
 class BidirectionalMap<K extends string, V extends string> {
   private constructor(
@@ -37,31 +48,92 @@ class BidirectionalMap<K extends string, V extends string> {
     return new BidirectionalMap(encodeMap, decodeMap);
   }
 
+  keys(): Set<string> {
+    return new Set(Object.keys(this.encodeMap));
+  }
+
   encode(key: K): V {
     return this.encodeMap[key];
   }
 
-  decode(value: string | null, fallback: K): K {
+  encodeSet(keys: Set<string>): string {
+    return Array.from(keys)
+      .map((key) => this.encode(key as K))
+      .join(ARRAY_DELIMITER);
+  }
+
+  decode(value: string | null): K | null {
+    if (value === null) return null;
+    return this.decodeMap[value as V] ?? null;
+  }
+
+  decodeSet(value: string | null, fallback: Set<string>): Set<string> {
     if (value === null) return fallback;
-    return this.decodeMap[value as V] ?? fallback;
+    const parsed = new Set(
+      value
+        .split(ARRAY_DELIMITER)
+        .map((v) => this.decode(v))
+        .filter((v) => v !== null),
+    );
+    return parsed.size ? parsed : fallback;
   }
 }
 
 export const POLICY_TYPE_NAME = "reform";
 export const STATUS_NAME = "status";
+export const ALL_MINIMUMS_REPEALED_TOGGLE_NAME = "repeal";
+export const YEAR_NAME = "yr";
+export const COUNTRY_NAME = "cntry";
+export const PLACE_TYPE_NAME = "juris";
+export const INCLUDED_POLICY_NAME = "reforms";
+export const LAND_USE_NAME = "lnd";
+export const SCOPE_NAME = "scp";
+export const POPULATION_NAME = "pop";
 
-const POLICY_TYPE_MAP = BidirectionalMap.from([
+export const POLICY_TYPE_MAP = BidirectionalMap.from([
   ["any parking reform", "any"],
   ["add parking maximums", "mx"],
   ["reduce parking minimums", "rd"],
   ["remove parking minimums", "rm"],
   ["parking benefit district", "bd"],
 ]);
-const STATUS_MAP = BidirectionalMap.from([
+export const STATUS_MAP = BidirectionalMap.from([
   ["adopted", "a"],
   ["proposed", "p"],
   ["repealed", "r"],
 ]);
+export const PLACE_TYPE_MAP = BidirectionalMap.from([
+  ["city", "cty"],
+  ["state", "st"],
+  ["county", "cnty"],
+  ["country", "cntry"],
+]);
+export const LAND_USE_MAP = BidirectionalMap.from([
+  ["all uses", "all"],
+  ["commercial", "com"],
+  ["industrial", "ind"],
+  ["medical", "med"],
+  ["other", "oth"],
+  ["residential, all uses", "res-all"],
+  ["residential, low-density", "res-low"],
+  ["residential, multi-family", "fam"],
+]);
+export const SCOPE_MAP = BidirectionalMap.from([
+  ["city center / business district", "cntr"],
+  ["citywide", "cty"],
+  ["main street / special", "main"],
+  ["regional", "reg"],
+  ["transit-oriented", "trns"],
+]);
+export const COUNTRY_MAP = BidirectionalMap.from(
+  Object.entries(COUNTRY_MAPPING).map(([code, country]) => [
+    country!,
+    code.toLowerCase(),
+  ]),
+);
+export const YEAR_MAP = BidirectionalMap.from(
+  Array.from(MERGED_STRING_SET_OPTIONS.year).map((year) => [year, year]),
+);
 
 export function encodeFilterState(filterState: FilterState): URLSearchParams {
   const result = new URLSearchParams();
@@ -71,11 +143,93 @@ export function encodeFilterState(filterState: FilterState): URLSearchParams {
       POLICY_TYPE_MAP.encode(filterState.policyTypeFilter),
     );
   }
+
   if (filterState.status !== DEFAULT_FILTER_STATE.status) {
     result.append(STATUS_NAME, STATUS_MAP.encode(filterState.status));
   }
+
+  if (
+    filterState.allMinimumsRemovedToggle !==
+    DEFAULT_FILTER_STATE.allMinimumsRemovedToggle
+  ) {
+    result.append(
+      ALL_MINIMUMS_REPEALED_TOGGLE_NAME,
+      filterState.allMinimumsRemovedToggle ? BOOL_TRUE : BOOL_FALSE,
+    );
+  }
+
+  if (
+    !isEqual(
+      filterState.includedPolicyChanges,
+      DEFAULT_FILTER_STATE.includedPolicyChanges,
+    )
+  ) {
+    result.append(
+      INCLUDED_POLICY_NAME,
+      POLICY_TYPE_MAP.encodeSet(filterState.includedPolicyChanges),
+    );
+  }
+
+  if (!isEqual(filterState.placeType, DEFAULT_FILTER_STATE.placeType)) {
+    result.append(
+      PLACE_TYPE_NAME,
+      PLACE_TYPE_MAP.encodeSet(filterState.placeType),
+    );
+  }
+
+  if (!isEqual(filterState.country, DEFAULT_FILTER_STATE.country)) {
+    result.append(COUNTRY_NAME, COUNTRY_MAP.encodeSet(filterState.country));
+  }
+
+  if (!isEqual(filterState.year, DEFAULT_FILTER_STATE.year)) {
+    result.append(YEAR_NAME, YEAR_MAP.encodeSet(filterState.year));
+  }
+
+  if (!isEqual(filterState.landUse, DEFAULT_FILTER_STATE.landUse)) {
+    result.append(LAND_USE_NAME, LAND_USE_MAP.encodeSet(filterState.landUse));
+  }
+
+  if (!isEqual(filterState.scope, DEFAULT_FILTER_STATE.scope)) {
+    result.append(SCOPE_NAME, SCOPE_MAP.encodeSet(filterState.scope));
+  }
+
+  if (
+    !isEqual(
+      filterState.populationSliderIndexes,
+      DEFAULT_FILTER_STATE.populationSliderIndexes,
+    )
+  ) {
+    result.append(
+      POPULATION_NAME,
+      filterState.populationSliderIndexes.join(ARRAY_DELIMITER),
+    );
+  }
+
   result.sort();
   return result;
+}
+
+function decodeAllMinimumsRepealed(v: string | null): boolean {
+  if (v === BOOL_TRUE) return true;
+  if (v === BOOL_FALSE) return false;
+  return DEFAULT_FILTER_STATE.allMinimumsRemovedToggle;
+}
+
+export function decodePopulation(str: string | null): [number, number] {
+  if (str === null) return DEFAULT_FILTER_STATE.populationSliderIndexes;
+  let left: number;
+  let right: number;
+  try {
+    const split = str.split(ARRAY_DELIMITER);
+    if (split.length !== 2) return DEFAULT_FILTER_STATE.populationSliderIndexes;
+    left = Number.parseInt(split[0], 10);
+    right = Number.parseInt(split[1], 10);
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  } catch (e) {
+    return DEFAULT_FILTER_STATE.populationSliderIndexes;
+  }
+  const isValid = left >= 0 && right <= POPULATION_MAX_INDEX && left < right;
+  return isValid ? [left, right] : DEFAULT_FILTER_STATE.populationSliderIndexes;
 }
 
 export function decodeFilterState(queryString: string): FilterState {
@@ -83,15 +237,38 @@ export function decodeFilterState(queryString: string): FilterState {
     ? queryString.slice(1)
     : queryString;
   const params = new URLSearchParams(cleanQuery);
+
   return {
-    ...DEFAULT_FILTER_STATE,
-    policyTypeFilter: POLICY_TYPE_MAP.decode(
-      params.get(POLICY_TYPE_NAME),
+    searchInput: DEFAULT_FILTER_STATE.searchInput,
+    policyTypeFilter:
+      POLICY_TYPE_MAP.decode(params.get(POLICY_TYPE_NAME)) ??
       DEFAULT_FILTER_STATE.policyTypeFilter,
+    status:
+      STATUS_MAP.decode(params.get(STATUS_NAME)) ?? DEFAULT_FILTER_STATE.status,
+    allMinimumsRemovedToggle: decodeAllMinimumsRepealed(
+      params.get(ALL_MINIMUMS_REPEALED_TOGGLE_NAME),
     ),
-    status: STATUS_MAP.decode(
-      params.get(STATUS_NAME),
-      DEFAULT_FILTER_STATE.status,
+    includedPolicyChanges: POLICY_TYPE_MAP.decodeSet(
+      params.get(INCLUDED_POLICY_NAME),
+      DEFAULT_FILTER_STATE.includedPolicyChanges,
     ),
+    year: YEAR_MAP.decodeSet(params.get(YEAR_NAME), DEFAULT_FILTER_STATE.year),
+    country: COUNTRY_MAP.decodeSet(
+      params.get(COUNTRY_NAME),
+      DEFAULT_FILTER_STATE.country,
+    ),
+    placeType: PLACE_TYPE_MAP.decodeSet(
+      params.get(PLACE_TYPE_NAME),
+      DEFAULT_FILTER_STATE.placeType,
+    ),
+    landUse: LAND_USE_MAP.decodeSet(
+      params.get(LAND_USE_NAME),
+      DEFAULT_FILTER_STATE.landUse,
+    ),
+    scope: SCOPE_MAP.decodeSet(
+      params.get(SCOPE_NAME),
+      DEFAULT_FILTER_STATE.scope,
+    ),
+    populationSliderIndexes: decodePopulation(params.get(POPULATION_NAME)),
   };
 }

--- a/tests/app/urlEncoder.test.ts
+++ b/tests/app/urlEncoder.test.ts
@@ -3,9 +3,31 @@ import { expect, test } from "@playwright/test";
 import {
   encodeFilterState,
   decodeFilterState,
+  decodePopulation,
   DEFAULT_FILTER_STATE,
+  STATUS_MAP,
+  POLICY_TYPE_MAP,
+  MERGED_STRING_SET_OPTIONS,
+  PLACE_TYPE_MAP,
+  LAND_USE_MAP,
+  SCOPE_MAP,
+  POLICY_TYPE_NAME,
+  STATUS_NAME,
+  ALL_MINIMUMS_REPEALED_TOGGLE_NAME,
+  YEAR_NAME,
+  INCLUDED_POLICY_NAME,
+  PLACE_TYPE_NAME,
+  LAND_USE_NAME,
+  SCOPE_NAME,
+  COUNTRY_MAP,
+  COUNTRY_NAME,
+  YEAR_MAP,
 } from "../../src/js/state/urlEncoder";
-import { FilterState } from "../../src/js/state/FilterState";
+import {
+  ALL_POLICY_TYPE_FILTER,
+  FilterState,
+} from "../../src/js/state/FilterState";
+import { ALL_REFORM_STATUS, UNKNOWN_YEAR } from "../../src/js/model/types";
 
 test.describe("encodeFilterState", () => {
   test("default state", () => {
@@ -17,10 +39,29 @@ test.describe("encodeFilterState", () => {
       ...DEFAULT_FILTER_STATE,
       policyTypeFilter: "reduce parking minimums",
       status: "repealed",
+      allMinimumsRemovedToggle: false,
+      year: new Set(["1997", UNKNOWN_YEAR]),
+      includedPolicyChanges: new Set([
+        "reduce parking minimums",
+        "parking benefit district",
+      ]),
+      placeType: new Set(["city", "state"]),
+      landUse: new Set(["industrial", "medical"]),
+      scope: new Set(["regional", "transit-oriented"]),
+      country: new Set(["Mexico", "Brazil"]),
+      populationSliderIndexes: [2, 4],
     };
     const result = encodeFilterState(state);
     expect(result.get("reform")).toEqual("rd");
     expect(result.get("status")).toEqual("r");
+    expect(result.get("repeal")).toEqual("n");
+    expect(result.get("yr")).toEqual("1997.unknown");
+    expect(result.get("reforms")).toEqual("rd.bd");
+    expect(result.get("pop")).toEqual("2.4");
+    expect(result.get("juris")).toEqual("cty.st");
+    expect(result.get("lnd")).toEqual("ind.med");
+    expect(result.get("scp")).toEqual("reg.trns");
+    expect(result.get("cntry")).toEqual("mx.br");
 
     // Check round-trip
     expect(decodeFilterState(result.toString())).toEqual(state);
@@ -41,7 +82,7 @@ test.describe("decodeFilterState", () => {
     // Ensure round trip works.
     if (checkRoundTrip) {
       const reEncoded = encodeFilterState(decoded).toString();
-      const originalAsParams = new URLSearchParams(query.slice(1));
+      const originalAsParams = new URLSearchParams(query);
       originalAsParams.sort();
       expect(reEncoded).toEqual(originalAsParams.toString());
     }
@@ -52,20 +93,127 @@ test.describe("decodeFilterState", () => {
   });
 
   test("set every value", () => {
+    const url = [
+      "reform=bd",
+      "status=p",
+      "repeal=n",
+      "yr=2024.2025",
+      "reforms=rd.bd",
+      "pop=1.4",
+      "juris=cty.st",
+      "lnd=ind.med",
+      "scp=reg.trns",
+      "cntry=mx.br",
+    ].join("&");
     assertDecode(
-      "?reform=bd&status=p",
+      url,
       {
         ...DEFAULT_FILTER_STATE,
         policyTypeFilter: "parking benefit district",
         status: "proposed",
+        allMinimumsRemovedToggle: false,
+        year: new Set(["2024", "2025"]),
+        includedPolicyChanges: new Set([
+          "reduce parking minimums",
+          "parking benefit district",
+        ]),
+        placeType: new Set(["city", "state"]),
+        landUse: new Set(["industrial", "medical"]),
+        scope: new Set(["regional", "transit-oriented"]),
+        country: new Set(["Mexico", "Brazil"]),
+        populationSliderIndexes: [1, 4],
       },
       { checkRoundTrip: true },
     );
   });
 
-  test("unrecognized values", () => {
-    assertDecode("?reform=foo&status=foo", DEFAULT_FILTER_STATE, {
+  test("illegal values", () => {
+    const url = [
+      POLICY_TYPE_NAME,
+      STATUS_NAME,
+      ALL_MINIMUMS_REPEALED_TOGGLE_NAME,
+      YEAR_NAME,
+      INCLUDED_POLICY_NAME,
+      PLACE_TYPE_NAME,
+      LAND_USE_NAME,
+      SCOPE_NAME,
+      COUNTRY_NAME,
+    ]
+      .map((x) => `${x}=foo`)
+      .join("&");
+    assertDecode(url, DEFAULT_FILTER_STATE, {
       checkRoundTrip: false,
     });
+  });
+
+  test("some illegal array elements", () => {
+    const url = [
+      "yr=1.2024",
+      "reforms=foo.rm",
+      "juris=foo.cty",
+      "lnd=foo.com",
+      "scp=foo.reg",
+      "cntry=foo.mx",
+    ].join("&");
+    assertDecode(
+      url,
+      {
+        ...DEFAULT_FILTER_STATE,
+        year: new Set(["2024"]),
+        includedPolicyChanges: new Set(["remove parking minimums"]),
+        landUse: new Set(["commercial"]),
+        scope: new Set(["regional"]),
+        placeType: new Set(["city"]),
+        country: new Set(["Mexico"]),
+      },
+      {
+        checkRoundTrip: false,
+      },
+    );
+  });
+});
+
+test("decodePopulation", () => {
+  const defaultVal = DEFAULT_FILTER_STATE.populationSliderIndexes;
+  expect(decodePopulation(null)).toEqual(defaultVal);
+
+  expect(decodePopulation("1.2")).toEqual([1, 2]);
+  expect(decodePopulation("3.5")).toEqual([3, 5]);
+
+  // Invalid vals
+  expect(decodePopulation("foo")).toEqual(defaultVal);
+  expect(decodePopulation("1.2.3")).toEqual(defaultVal);
+  expect(decodePopulation("2.1")).toEqual(defaultVal);
+  expect(decodePopulation("-1.2")).toEqual(defaultVal);
+  expect(decodePopulation("1.11")).toEqual(defaultVal);
+});
+
+test.describe("mappers are fully comprehensive", () => {
+  test("policy type", () => {
+    expect(POLICY_TYPE_MAP.keys()).toEqual(new Set(ALL_POLICY_TYPE_FILTER));
+  });
+
+  test("status", () => {
+    expect(STATUS_MAP.keys()).toEqual(new Set(ALL_REFORM_STATUS));
+  });
+
+  test("place type", () => {
+    expect(PLACE_TYPE_MAP.keys()).toEqual(MERGED_STRING_SET_OPTIONS.placeType);
+  });
+
+  test("land use", () => {
+    expect(LAND_USE_MAP.keys()).toEqual(MERGED_STRING_SET_OPTIONS.landUse);
+  });
+
+  test("scope", () => {
+    expect(SCOPE_MAP.keys()).toEqual(MERGED_STRING_SET_OPTIONS.scope);
+  });
+
+  test("year", () => {
+    expect(YEAR_MAP.keys()).toEqual(MERGED_STRING_SET_OPTIONS.year);
+  });
+
+  test("country", () => {
+    expect(COUNTRY_MAP.keys()).toEqual(MERGED_STRING_SET_OPTIONS.country);
   });
 });


### PR DESCRIPTION
Everything is now supported except for searchInput, which I don't plan to support.

We have tests to ensure that our mappers are fully comprehensive.