### PR TITLE
Always use full country name

### DIFF
--- a/data/core.json
+++ b/data/core.json
@@ -3,7 +3,7 @@
     "place": {
       "name": "29 Palms",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28158,
       "coord": [-116.0543506, 34.1356915],
@@ -22,7 +22,7 @@
     "place": {
       "name": "Aalborg",
       "state": "Region Nordjylland",
-      "country": "DK",
+      "country": "Denmark",
       "type": "city",
       "pop": 119862,
       "coord": [9.9215263, 57.0462626],
@@ -41,7 +41,7 @@
     "place": {
       "name": "Abbeville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2358,
       "coord": [-85.2503315, 31.5702088],
@@ -60,7 +60,7 @@
     "place": {
       "name": "Abbottstown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1022,
       "coord": [-76.9847013, 39.8864869],
@@ -94,7 +94,7 @@
     "place": {
       "name": "Aberdeen",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4961,
       "coord": [-88.5436553, 33.8251139],
@@ -113,7 +113,7 @@
     "place": {
       "name": "Aberdeen",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28324,
       "coord": [-98.487813, 45.4649805],
@@ -132,7 +132,7 @@
     "place": {
       "name": "Abilene",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6460,
       "coord": [-97.21377, 38.917252],
@@ -151,7 +151,7 @@
     "place": {
       "name": "Abilene",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 125182,
       "coord": [-99.7475905, 32.44645],
@@ -170,7 +170,7 @@
     "place": {
       "name": "Ackley",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1599,
       "coord": [-93.0526788, 42.5539454],
@@ -189,7 +189,7 @@
     "place": {
       "name": "Ada Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14388,
       "coord": [-85.4961581, 42.9593729],
@@ -208,7 +208,7 @@
     "place": {
       "name": "Ada",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5334,
       "coord": [-83.823192, 40.77134],
@@ -227,7 +227,7 @@
     "place": {
       "name": "Ada",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16481,
       "coord": [-96.6783651, 34.7743383],
@@ -246,7 +246,7 @@
     "place": {
       "name": "Adams County",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 519572,
       "coord": [-104.2701374, 39.8714085],
@@ -288,7 +288,7 @@
     "place": {
       "name": "Adrian",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20645,
       "coord": [-84.0373054, 41.8975152],
@@ -315,7 +315,7 @@
     "place": {
       "name": "Aiken",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32025,
       "coord": [-81.721952, 33.5598586],
@@ -334,7 +334,7 @@
     "place": {
       "name": "Aitkin",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2168,
       "coord": [-93.7096936, 46.5333985],
@@ -361,7 +361,7 @@
     "place": {
       "name": "Akron",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1757,
       "coord": [-103.214384, 40.1605374],
@@ -385,7 +385,7 @@
     "place": {
       "name": "Akron",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1558,
       "coord": [-96.5579415, 42.8288056],
@@ -404,7 +404,7 @@
     "place": {
       "name": "Akron",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2888,
       "coord": [-78.4953015, 43.0208924],
@@ -423,7 +423,7 @@
     "place": {
       "name": "Akron",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 197597,
       "coord": [-81.518485, 41.083064],
@@ -450,7 +450,7 @@
     "place": {
       "name": "Akron",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4169,
       "coord": [-76.2021742, 40.1567616],
@@ -469,7 +469,7 @@
     "place": {
       "name": "Alabaster",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 33284,
       "coord": [-86.8163773, 33.2442813],
@@ -488,7 +488,7 @@
     "place": {
       "name": "Alameda County",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 1682353,
       "coord": [-121.8885683, 37.5943781],
@@ -515,7 +515,7 @@
     "place": {
       "name": "Alameda",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 78280,
       "coord": [-122.2416355, 37.7652076],
@@ -542,7 +542,7 @@
     "place": {
       "name": "Alamogordo",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31384,
       "coord": [-105.9602081, 32.8998822],
@@ -561,7 +561,7 @@
     "place": {
       "name": "Albany",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2780,
       "coord": [-94.5700048, 45.6299647],
@@ -580,7 +580,7 @@
     "place": {
       "name": "Albany",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 99224,
       "coord": [-73.754968, 42.6511674],
@@ -621,7 +621,7 @@
     "place": {
       "name": "Albany",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 56472,
       "coord": [-123.1059324, 44.6365071],
@@ -648,7 +648,7 @@
     "place": {
       "name": "Albany",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1096,
       "coord": [-89.4368317, 42.7079729],
@@ -667,7 +667,7 @@
     "place": {
       "name": "Albemarle",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16246,
       "coord": [-80.2000578, 35.3501426],
@@ -686,7 +686,7 @@
     "place": {
       "name": "Albert Lea",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18492,
       "coord": [-93.3682656, 43.6480127],
@@ -705,7 +705,7 @@
     "place": {
       "name": "Alberton",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 452,
       "coord": [-114.477156, 47.0023955],
@@ -732,7 +732,7 @@
     "place": {
       "name": "Albion",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7700,
       "coord": [-84.7530304, 42.243097],
@@ -751,7 +751,7 @@
     "place": {
       "name": "Albion",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1699,
       "coord": [-98.0012269, 41.6929347],
@@ -770,7 +770,7 @@
     "place": {
       "name": "Albion",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1528,
       "coord": [-80.3664542, 41.8906112],
@@ -789,7 +789,7 @@
     "place": {
       "name": "Albuquerque",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 560513,
       "coord": [-106.650985, 35.0841034],
@@ -808,7 +808,7 @@
     "place": {
       "name": "Alburtis",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2596,
       "coord": [-75.6036993, 40.5114787],
@@ -827,7 +827,7 @@
     "place": {
       "name": "Aledo",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3633,
       "coord": [-90.7484836, 41.199665],
@@ -846,7 +846,7 @@
     "place": {
       "name": "Alexander City",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14843,
       "coord": [-85.9538532, 32.944012],
@@ -865,7 +865,7 @@
     "place": {
       "name": "Alexandria",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5149,
       "coord": [-85.675809, 40.2628184],
@@ -884,7 +884,7 @@
     "place": {
       "name": "Alexandria",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 45275,
       "coord": [-92.4616292, 31.2909782],
@@ -911,7 +911,7 @@
     "place": {
       "name": "Alexandria",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13822,
       "coord": [-95.3793539, 45.8860567],
@@ -930,7 +930,7 @@
     "place": {
       "name": "Alexandria",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 159428,
       "coord": [-77.0470229, 38.8051095],
@@ -961,7 +961,7 @@
     "place": {
       "name": "Alfred",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4026,
       "coord": [-77.7906062, 42.2542334],
@@ -980,7 +980,7 @@
     "place": {
       "name": "Algona",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5487,
       "coord": [-94.233019, 43.0699663],
@@ -999,7 +999,7 @@
     "place": {
       "name": "Alleman",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 423,
       "coord": [-93.611251, 41.8200591],
@@ -1018,7 +1018,7 @@
     "place": {
       "name": "Allen Park",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28638,
       "coord": [-83.2107671, 42.2595071],
@@ -1045,7 +1045,7 @@
     "place": {
       "name": "Allentown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 125845,
       "coord": [-75.4712794, 40.6022059],
@@ -1072,7 +1072,7 @@
     "place": {
       "name": "Alliance",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8151,
       "coord": [-102.8707145, 42.0971897],
@@ -1091,7 +1091,7 @@
     "place": {
       "name": "Allouez",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14026,
       "coord": [-88.0163556, 44.4774269],
@@ -1118,7 +1118,7 @@
     "place": {
       "name": "Alma",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9488,
       "coord": [-84.659727, 43.37892],
@@ -1137,7 +1137,7 @@
     "place": {
       "name": "Alma",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1043,
       "coord": [-99.362043, 40.097511],
@@ -1156,7 +1156,7 @@
     "place": {
       "name": "Alma",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 698,
       "coord": [-91.9148839, 44.3199654],
@@ -1175,7 +1175,7 @@
     "place": {
       "name": "Alpena Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9116,
       "coord": [-83.450563, 45.111283],
@@ -1202,7 +1202,7 @@
     "place": {
       "name": "Alpena",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10197,
       "coord": [-83.433388, 45.062251],
@@ -1237,7 +1237,7 @@
     "place": {
       "name": "Alpha",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 675,
       "coord": [-90.3801274, 41.1917031],
@@ -1256,7 +1256,7 @@
     "place": {
       "name": "Alta",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2087,
       "coord": [-95.3039943, 42.6736893],
@@ -1275,7 +1275,7 @@
     "place": {
       "name": "Altamont",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1675,
       "coord": [-74.0337382, 42.7006324],
@@ -1294,7 +1294,7 @@
     "place": {
       "name": "Alton",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25676,
       "coord": [-90.1843091, 38.8908583],
@@ -1313,7 +1313,7 @@
     "place": {
       "name": "Altona",
       "state": "MB",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 4267,
       "coord": [-97.5583611, 49.1031109],
@@ -1340,7 +1340,7 @@
     "place": {
       "name": "Altoona",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19565,
       "coord": [-93.4696031, 41.6437308],
@@ -1367,7 +1367,7 @@
     "place": {
       "name": "Altoona",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43963,
       "coord": [-78.394736, 40.518681],
@@ -1386,7 +1386,7 @@
     "place": {
       "name": "Altoona",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8292,
       "coord": [-91.4429355, 44.8046825],
@@ -1413,7 +1413,7 @@
     "place": {
       "name": "Altus",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18729,
       "coord": [-99.3339754, 34.6381255],
@@ -1432,7 +1432,7 @@
     "place": {
       "name": "Alva",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5028,
       "coord": [-98.6660278, 36.8030501],
@@ -1451,7 +1451,7 @@
     "place": {
       "name": "Amanda",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 637,
       "coord": [-82.7443367, 39.649508],
@@ -1470,7 +1470,7 @@
     "place": {
       "name": "Amarillo",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 200393,
       "coord": [-101.833824, 35.2072185],
@@ -1489,7 +1489,7 @@
     "place": {
       "name": "Ambridge",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6972,
       "coord": [-80.22506, 40.5892339],
@@ -1516,7 +1516,7 @@
     "place": {
       "name": "Ames",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 66427,
       "coord": [-93.6170448, 42.0267567],
@@ -1535,7 +1535,7 @@
     "place": {
       "name": "Amherst",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1125,
       "coord": [-89.2845905, 44.4506775],
@@ -1554,7 +1554,7 @@
     "place": {
       "name": "Anaconda-Deer Lodge County",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 9421,
       "coord": [-112.953131, 46.1294685],
@@ -1581,7 +1581,7 @@
     "place": {
       "name": "Anacortes",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18089,
       "coord": [-122.6237356, 48.5020123],
@@ -1600,7 +1600,7 @@
     "place": {
       "name": "Anaheim",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 346824,
       "coord": [-117.911732, 33.8347516],
@@ -1619,7 +1619,7 @@
     "place": {
       "name": "Anamosa",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5450,
       "coord": [-91.2851594, 42.1083371],
@@ -1638,7 +1638,7 @@
     "place": {
       "name": "Anchorage",
       "state": "AK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 291247,
       "coord": [-149.894852, 61.2163129],
@@ -1657,7 +1657,7 @@
     "place": {
       "name": "Anchorage",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2500,
       "coord": [-85.5330114, 38.2665993],
@@ -1684,7 +1684,7 @@
     "place": {
       "name": "Andalusia",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8805,
       "coord": [-86.482424, 31.3080607],
@@ -1703,7 +1703,7 @@
     "place": {
       "name": "Anderson",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 54788,
       "coord": [-85.6802541, 40.1053196],
@@ -1722,7 +1722,7 @@
     "place": {
       "name": "Andover",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3151,
       "coord": [-72.37036, 41.7373212],
@@ -1755,7 +1755,7 @@
     "place": {
       "name": "Angola",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9340,
       "coord": [-84.99928, 41.634874],
@@ -1782,7 +1782,7 @@
     "place": {
       "name": "Angola",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2046,
       "coord": [-79.027816, 42.638393],
@@ -1801,7 +1801,7 @@
     "place": {
       "name": "Ankeny",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 67887,
       "coord": [-93.605092, 41.7320796],
@@ -1820,7 +1820,7 @@
     "place": {
       "name": "Ann Arbor",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 120735,
       "coord": [-83.7312291, 42.2681569],
@@ -1847,7 +1847,7 @@
     "place": {
       "name": "Anna",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4303,
       "coord": [-89.2470282, 37.4603274],
@@ -1866,7 +1866,7 @@
     "place": {
       "name": "Annandale",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3763,
       "coord": [-94.1244271, 45.2627428],
@@ -1885,7 +1885,7 @@
     "place": {
       "name": "Annapolis",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40812,
       "coord": [-76.492786, 38.9786401],
@@ -1904,7 +1904,7 @@
     "place": {
       "name": "Anne Arundel County",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 588261,
       "coord": [-76.573454, 38.9722583],
@@ -1923,7 +1923,7 @@
     "place": {
       "name": "Anniston",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21564,
       "coord": [-85.8283224, 33.6624824],
@@ -1950,7 +1950,7 @@
     "place": {
       "name": "Anoka",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17921,
       "coord": [-93.3871758, 45.1977428],
@@ -1969,7 +1969,7 @@
     "place": {
       "name": "Ansonia",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18918,
       "coord": [-73.0787468, 41.3429922],
@@ -1996,7 +1996,7 @@
     "place": {
       "name": "Antigo",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8100,
       "coord": [-89.152335, 45.140245],
@@ -2023,7 +2023,7 @@
     "place": {
       "name": "Antioch",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14622,
       "coord": [-88.0950691, 42.4767131],
@@ -2058,7 +2058,7 @@
     "place": {
       "name": "Appleton",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1392,
       "coord": [-96.019767, 45.196906],
@@ -2077,7 +2077,7 @@
     "place": {
       "name": "Appleton",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 75644,
       "coord": [-88.4069744, 44.2613967],
@@ -2102,7 +2102,7 @@
     "place": {
       "name": "Arab",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8461,
       "coord": [-86.4958219, 34.3181497],
@@ -2129,7 +2129,7 @@
     "place": {
       "name": "Arcadia",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2746,
       "coord": [-92.9217754, 32.5489683],
@@ -2148,7 +2148,7 @@
     "place": {
       "name": "Arcata",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18857,
       "coord": [-124.08284, 40.866517],
@@ -2167,7 +2167,7 @@
     "place": {
       "name": "Archbald",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7297,
       "coord": [-75.5368521, 41.4948038],
@@ -2186,7 +2186,7 @@
     "place": {
       "name": "Archbold",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4516,
       "coord": [-84.3065469, 41.5211332],
@@ -2205,7 +2205,7 @@
     "place": {
       "name": "Arcola",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2927,
       "coord": [-88.3064367, 39.684755],
@@ -2224,7 +2224,7 @@
     "place": {
       "name": "Ardmore",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24725,
       "coord": [-97.1436254, 34.1742611],
@@ -2243,7 +2243,7 @@
     "place": {
       "name": "Argo",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4368,
       "coord": [-86.5232569, 33.6961317],
@@ -2270,7 +2270,7 @@
     "place": {
       "name": "Argyle",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 813,
       "coord": [-89.8670532, 42.701208],
@@ -2289,7 +2289,7 @@
     "place": {
       "name": "Arkansas City",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11974,
       "coord": [-97.0388338, 37.0622562],
@@ -2308,7 +2308,7 @@
     "place": {
       "name": "Arlington Heights",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 77676,
       "coord": [-87.9802164, 42.0811563],
@@ -2327,7 +2327,7 @@
     "place": {
       "name": "Arlington",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 46308,
       "coord": [-71.1564428, 42.4153739],
@@ -2346,7 +2346,7 @@
     "place": {
       "name": "Arlington",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14549,
       "coord": [-89.661664, 35.296145],
@@ -2387,7 +2387,7 @@
     "place": {
       "name": "Arlington",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 394266,
       "coord": [-97.1071186, 32.7355816],
@@ -2414,7 +2414,7 @@
     "place": {
       "name": "Armada",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1684,
       "coord": [-82.8843722, 42.8441964],
@@ -2441,7 +2441,7 @@
     "place": {
       "name": "Armadale",
       "state": "WA",
-      "country": "AU",
+      "country": "Australia",
       "type": "city",
       "pop": 94184,
       "coord": [116.016204, -32.151264],
@@ -2460,7 +2460,7 @@
     "place": {
       "name": "Arnolds Park",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1110,
       "coord": [-95.1258882, 43.3704506],
@@ -2479,7 +2479,7 @@
     "place": {
       "name": "Arran-Elderslie",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 6913,
       "coord": [-81.2000689260308, 44.398078350000006],
@@ -2498,7 +2498,7 @@
     "place": {
       "name": "Arvada",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 124402,
       "coord": [-105.0811573, 39.8005505],
@@ -2525,7 +2525,7 @@
     "place": {
       "name": "Ascension Parish",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 126500,
       "coord": [-90.9186104, 30.2116442],
@@ -2544,7 +2544,7 @@
     "place": {
       "name": "Asheville",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 92870,
       "coord": [-82.5540161, 35.6009498],
@@ -2563,7 +2563,7 @@
     "place": {
       "name": "Ashford",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2246,
       "coord": [-85.2358439, 31.1838319],
@@ -2582,7 +2582,7 @@
     "place": {
       "name": "Ashland",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1984,
       "coord": [-85.8360741, 33.2737256],
@@ -2601,7 +2601,7 @@
     "place": {
       "name": "Ashland",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1218,
       "coord": [-90.0078907, 39.8878264],
@@ -2620,7 +2620,7 @@
     "place": {
       "name": "Ashland",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21625,
       "coord": [-82.6379387, 38.4784144],
@@ -2639,7 +2639,7 @@
     "place": {
       "name": "Ashland",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21360,
       "coord": [-122.7153995, 42.1972487],
@@ -2672,7 +2672,7 @@
     "place": {
       "name": "Ashland",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7908,
       "coord": [-90.884466, 46.590959],
@@ -2699,7 +2699,7 @@
     "place": {
       "name": "Ashtabula",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17975,
       "coord": [-80.789809, 41.865054],
@@ -2718,7 +2718,7 @@
     "place": {
       "name": "Ashville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4621,
       "coord": [-82.9529584, 39.7156186],
@@ -2737,7 +2737,7 @@
     "place": {
       "name": "Ashwaubenon",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16991,
       "coord": [-88.060735, 44.4752606],
@@ -2756,7 +2756,7 @@
     "place": {
       "name": "Aspen",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7004,
       "coord": [-106.82356, 39.1911128],
@@ -2783,7 +2783,7 @@
     "place": {
       "name": "Atchison",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10476,
       "coord": [-95.1199452, 39.5632392],
@@ -2802,7 +2802,7 @@
     "place": {
       "name": "Atglen",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1311,
       "coord": [-75.9735608, 39.9492712],
@@ -2821,7 +2821,7 @@
     "place": {
       "name": "Athens",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25406,
       "coord": [-86.9711698, 34.8045487],
@@ -2854,7 +2854,7 @@
     "place": {
       "name": "Athens",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24536,
       "coord": [-82.1012479, 39.3289242],
@@ -2881,7 +2881,7 @@
     "place": {
       "name": "Athens",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1069,
       "coord": [-90.0740226, 45.0330224],
@@ -2900,7 +2900,7 @@
     "place": {
       "name": "Athens-Clarke County",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 127315,
       "coord": [-83.3557816, 33.9458693],
@@ -2927,7 +2927,7 @@
     "place": {
       "name": "Atikokan",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 2642,
       "coord": [-91.624603, 48.762526],
@@ -2946,7 +2946,7 @@
     "place": {
       "name": "Atkinson",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1306,
       "coord": [-98.9781525, 42.5313912],
@@ -2965,7 +2965,7 @@
     "place": {
       "name": "Atlanta",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 498715,
       "coord": [-84.3902644, 33.7489924],
@@ -2984,7 +2984,7 @@
     "place": {
       "name": "Auburn Hills",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24360,
       "coord": [-83.2341028, 42.6875323],
@@ -3003,7 +3003,7 @@
     "place": {
       "name": "Auburn",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 76143,
       "coord": [-85.4807825, 32.6098566],
@@ -3022,7 +3022,7 @@
     "place": {
       "name": "Auburn",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4574,
       "coord": [-89.7464874, 39.5917197],
@@ -3041,7 +3041,7 @@
     "place": {
       "name": "Auburn",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13820,
       "coord": [-85.0588632, 41.3669902],
@@ -3060,7 +3060,7 @@
     "place": {
       "name": "Auburn",
       "state": "ME",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23414,
       "coord": [-70.2311655, 44.0978509],
@@ -3079,7 +3079,7 @@
     "place": {
       "name": "Auburn",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2068,
       "coord": [-84.069705, 43.603358],
@@ -3098,7 +3098,7 @@
     "place": {
       "name": "Auburn",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3470,
       "coord": [-95.839047, 40.392616],
@@ -3117,7 +3117,7 @@
     "place": {
       "name": "Auburn",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26866,
       "coord": [-76.5672029, 42.9320202],
@@ -3136,7 +3136,7 @@
     "place": {
       "name": "Augsburg",
       "state": "BY",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 301033,
       "coord": [10.8979522, 48.3690341],
@@ -3155,7 +3155,7 @@
     "place": {
       "name": "Augusta Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7083,
       "coord": [-83.5993266, 42.1259516],
@@ -3174,7 +3174,7 @@
     "place": {
       "name": "Augusta",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 202081,
       "coord": [-81.9748429, 33.4709714],
@@ -3193,7 +3193,7 @@
     "place": {
       "name": "Augusta",
       "state": "ME",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18899,
       "coord": [-69.7734278, 44.3169922],
@@ -3212,7 +3212,7 @@
     "place": {
       "name": "Aurelia",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 968,
       "coord": [-95.4366206, 42.7125676],
@@ -3231,7 +3231,7 @@
     "place": {
       "name": "Aurora",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 386261,
       "coord": [-104.830994, 39.7405111],
@@ -3259,7 +3259,7 @@
     "place": {
       "name": "Aurora",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 180542,
       "coord": [-88.3147539, 41.7571701],
@@ -3278,7 +3278,7 @@
     "place": {
       "name": "Aurora",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3479,
       "coord": [-84.9013402, 39.0570022],
@@ -3297,7 +3297,7 @@
     "place": {
       "name": "Aurora",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4678,
       "coord": [-98.004508, 40.866888],
@@ -3316,7 +3316,7 @@
     "place": {
       "name": "Aurora",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17239,
       "coord": [-81.345386, 41.317555],
@@ -3335,7 +3335,7 @@
     "place": {
       "name": "Austin",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 974447,
       "coord": [-97.7436995, 30.2711286],
@@ -3354,7 +3354,7 @@
     "place": {
       "name": "Auxvasse",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1001,
       "coord": [-91.8971198, 39.0180962],
@@ -3373,7 +3373,7 @@
     "place": {
       "name": "Avalon",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4762,
       "coord": [-80.0675554, 40.5009019],
@@ -3392,7 +3392,7 @@
     "place": {
       "name": "Avilla",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2438,
       "coord": [-85.2388673, 41.3658823],
@@ -3411,7 +3411,7 @@
     "place": {
       "name": "Avon Lake",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25206,
       "coord": [-82.0185895, 41.510033],
@@ -3430,7 +3430,7 @@
     "place": {
       "name": "Avon",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6072,
       "coord": [-106.522243, 39.6342752],
@@ -3449,7 +3449,7 @@
     "place": {
       "name": "Avon",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19795,
       "coord": [-72.8306541, 41.8098209],
@@ -3468,7 +3468,7 @@
     "place": {
       "name": "Avon",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1618,
       "coord": [-94.4516668, 45.6091313],
@@ -3487,7 +3487,7 @@
     "place": {
       "name": "Avondale",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 89334,
       "coord": [-112.349602, 33.4355977],
@@ -3522,7 +3522,7 @@
     "place": {
       "name": "Badin",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2024,
       "coord": [-80.1167203, 35.4059744],
@@ -3541,7 +3541,7 @@
     "place": {
       "name": "Bagley",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1285,
       "coord": [-95.398349, 47.521623],
@@ -3560,7 +3560,7 @@
     "place": {
       "name": "Baker",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1802,
       "coord": [-104.2752261, 46.3678114],
@@ -3579,7 +3579,7 @@
     "place": {
       "name": "Bakersfield",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 403455,
       "coord": [-119.0194639, 35.3738712],
@@ -3625,7 +3625,7 @@
     "place": {
       "name": "Baldwin",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 863,
       "coord": [-85.851729, 43.901123],
@@ -3644,7 +3644,7 @@
     "place": {
       "name": "Baldwin",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4267,
       "coord": [-92.3743576, 44.9666323],
@@ -3663,7 +3663,7 @@
     "place": {
       "name": "Ballwin",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31103,
       "coord": [-90.5387318, 38.5961694],
@@ -3682,7 +3682,7 @@
     "place": {
       "name": "Baltic",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1246,
       "coord": [-96.7404105, 43.760461],
@@ -3701,7 +3701,7 @@
     "place": {
       "name": "Baltimore County",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 854535,
       "coord": [-76.6483482, 39.4445243],
@@ -3726,7 +3726,7 @@
     "place": {
       "name": "Baltimore",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 593490,
       "coord": [-76.610759, 39.2908816],
@@ -3779,7 +3779,7 @@
     "place": {
       "name": "Baltimore",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2981,
       "coord": [-82.6007185, 39.8453418],
@@ -3798,7 +3798,7 @@
     "place": {
       "name": "Bandera",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 671,
       "coord": [-99.0724586, 29.7270068],
@@ -3825,7 +3825,7 @@
     "place": {
       "name": "Bangor",
       "state": "ME",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31753,
       "coord": [-68.7713289, 44.8016255],
@@ -3852,7 +3852,7 @@
     "place": {
       "name": "Bangor",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5187,
       "coord": [-75.2064003, 40.86577],
@@ -3879,7 +3879,7 @@
     "place": {
       "name": "Baraboo",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12556,
       "coord": [-89.7437844, 43.4704014],
@@ -3898,7 +3898,7 @@
     "place": {
       "name": "Barberton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25191,
       "coord": [-81.6051221, 41.012833],
@@ -3917,7 +3917,7 @@
     "place": {
       "name": "Bargersville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9560,
       "coord": [-86.1677657, 39.5208818],
@@ -3944,7 +3944,7 @@
     "place": {
       "name": "Barnesville",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2759,
       "coord": [-96.41979, 46.652182],
@@ -3963,7 +3963,7 @@
     "place": {
       "name": "Barneveld",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1331,
       "coord": [-89.8958792, 43.0153376],
@@ -3982,7 +3982,7 @@
     "place": {
       "name": "Barrie",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 147829,
       "coord": [-79.6901302, 44.3893208],
@@ -4021,7 +4021,7 @@
     "place": {
       "name": "Barrington Hills",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4114,
       "coord": [-88.1556336, 42.1447475],
@@ -4040,7 +4040,7 @@
     "place": {
       "name": "Barrington",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17153,
       "coord": [-71.3084633, 41.7407661],
@@ -4059,7 +4059,7 @@
     "place": {
       "name": "Barron",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3674,
       "coord": [-91.8490626, 45.4013471],
@@ -4078,7 +4078,7 @@
     "place": {
       "name": "Barry",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1303,
       "coord": [-91.0390246, 39.6942135],
@@ -4104,7 +4104,7 @@
     "place": {
       "name": "Bartlesville",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 37290,
       "coord": [-95.9528877, 36.7421089],
@@ -4123,7 +4123,7 @@
     "place": {
       "name": "Bartlett",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 41105,
       "coord": [-88.1850028, 41.9908485],
@@ -4142,7 +4142,7 @@
     "place": {
       "name": "Basalt",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3984,
       "coord": [-107.032824, 39.3688731],
@@ -4169,7 +4169,7 @@
     "place": {
       "name": "Basel",
       "state": "BS",
-      "country": "CH",
+      "country": "Switzerland",
       "type": "city",
       "pop": 177595,
       "coord": [7.5878261, 47.5581077],
@@ -4188,7 +4188,7 @@
     "place": {
       "name": "Basin",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1225,
       "coord": [-108.038989, 44.379956],
@@ -4207,7 +4207,7 @@
     "place": {
       "name": "Bastrop",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9691,
       "coord": [-91.9082967, 32.7761446],
@@ -4242,7 +4242,7 @@
     "place": {
       "name": "Bastrop",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9242,
       "coord": [-97.3152701, 30.1104947],
@@ -4261,7 +4261,7 @@
     "place": {
       "name": "Batavia",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26098,
       "coord": [-88.3125738, 41.8500284],
@@ -4294,7 +4294,7 @@
     "place": {
       "name": "Batavia",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1972,
       "coord": [-84.1768795, 39.0770072],
@@ -4313,7 +4313,7 @@
     "place": {
       "name": "Batesville",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11191,
       "coord": [-91.6409722, 35.769799],
@@ -4332,7 +4332,7 @@
     "place": {
       "name": "Batesville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7202,
       "coord": [-85.222184, 39.3000065],
@@ -4351,7 +4351,7 @@
     "place": {
       "name": "Batesville",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7523,
       "coord": [-89.9527108, 34.316488],
@@ -4370,7 +4370,7 @@
     "place": {
       "name": "Bath Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2319,
       "coord": [-84.42386188, 42.82751485],
@@ -4389,7 +4389,7 @@
     "place": {
       "name": "Bath",
       "state": "ME",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8338,
       "coord": [-69.820862, 43.910755],
@@ -4408,7 +4408,7 @@
     "place": {
       "name": "Bath",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2808,
       "coord": [-75.3934911, 40.726519],
@@ -4427,7 +4427,7 @@
     "place": {
       "name": "Baton Rouge",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 227470,
       "coord": [-91.1869659, 30.4494155],
@@ -4462,7 +4462,7 @@
     "place": {
       "name": "Battle Creek",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 52731,
       "coord": [-85.1824269, 42.3192548],
@@ -4497,7 +4497,7 @@
     "place": {
       "name": "Baudette",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 966,
       "coord": [-94.600171, 48.7124408],
@@ -4516,7 +4516,7 @@
     "place": {
       "name": "Bay City",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32661,
       "coord": [-83.8888648, 43.5944677],
@@ -4535,7 +4535,7 @@
     "place": {
       "name": "Bayard",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 405,
       "coord": [-94.5580829, 41.8519311],
@@ -4554,7 +4554,7 @@
     "place": {
       "name": "Bayfield",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2838,
       "coord": [-107.600936, 37.22534],
@@ -4573,7 +4573,7 @@
     "place": {
       "name": "Bayfield",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 584,
       "coord": [-90.82, 46.811667],
@@ -4592,7 +4592,7 @@
     "place": {
       "name": "Beacon",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13769,
       "coord": [-73.9695409, 41.5048402],
@@ -4627,7 +4627,7 @@
     "place": {
       "name": "Bear Lake",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 342,
       "coord": [-86.148143, 44.420835],
@@ -4654,7 +4654,7 @@
     "place": {
       "name": "Beatrice",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12261,
       "coord": [-96.747369, 40.266429],
@@ -4673,7 +4673,7 @@
     "place": {
       "name": "Beaumont",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 115282,
       "coord": [-94.1018461, 30.0860459],
@@ -4700,7 +4700,7 @@
     "place": {
       "name": "Beausejour",
       "state": "MB",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 3307,
       "coord": [-96.5140821, 50.0619312],
@@ -4719,7 +4719,7 @@
     "place": {
       "name": "Beaver Falls",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9005,
       "coord": [-80.3192295, 40.7520097],
@@ -4738,7 +4738,7 @@
     "place": {
       "name": "Beaver",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4438,
       "coord": [-80.3709999, 40.6916624],
@@ -4757,7 +4757,7 @@
     "place": {
       "name": "Beaverton",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 99000,
       "coord": [-122.80378, 45.4871723],
@@ -4776,7 +4776,7 @@
     "place": {
       "name": "Beckley",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17286,
       "coord": [-81.1881557, 37.7781702],
@@ -4795,7 +4795,7 @@
     "place": {
       "name": "Bedford Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31813,
       "coord": [-83.5965049, 41.7772927],
@@ -4814,7 +4814,7 @@
     "place": {
       "name": "Bedford",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2861,
       "coord": [-78.5039069, 40.0186921],
@@ -4833,7 +4833,7 @@
     "place": {
       "name": "Beijing",
       "state": "BJ",
-      "country": "CN",
+      "country": "China",
       "type": "city",
       "pop": 21893095,
       "coord": [116.3912972, 39.9057136],
@@ -4860,7 +4860,7 @@
     "place": {
       "name": "Bel Air",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10661,
       "coord": [-76.3490396, 39.5355063],
@@ -4887,7 +4887,7 @@
     "place": {
       "name": "Belding",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5938,
       "coord": [-85.228906, 43.09781],
@@ -4906,7 +4906,7 @@
     "place": {
       "name": "Belen",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7360,
       "coord": [-106.7762, 34.6627495],
@@ -4925,7 +4925,7 @@
     "place": {
       "name": "Belfast",
       "state": "ME",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6679,
       "coord": [-69.0067359, 44.4261194],
@@ -4944,7 +4944,7 @@
     "place": {
       "name": "Bella Vista",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30104,
       "coord": [-94.2669727, 36.4678036],
@@ -4963,7 +4963,7 @@
     "place": {
       "name": "Bellaire",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1053,
       "coord": [-85.2099992, 44.9754211],
@@ -4982,7 +4982,7 @@
     "place": {
       "name": "Bellbrook",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7317,
       "coord": [-84.0701766, 39.6358399],
@@ -5001,7 +5001,7 @@
     "place": {
       "name": "Belle Center",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 809,
       "coord": [-83.7479894, 40.506718],
@@ -5020,7 +5020,7 @@
     "place": {
       "name": "Belle Fourche",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5617,
       "coord": [-103.851407, 44.670905],
@@ -5039,7 +5039,7 @@
     "place": {
       "name": "Belle Plaine",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1467,
       "coord": [-97.281155, 37.3939098],
@@ -5058,7 +5058,7 @@
     "place": {
       "name": "Belle Plaine",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7395,
       "coord": [-93.7685729, 44.622741],
@@ -5077,7 +5077,7 @@
     "place": {
       "name": "Bellefontaine Neighbors",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10740,
       "coord": [-90.2265001, 38.7403281],
@@ -5096,7 +5096,7 @@
     "place": {
       "name": "Bellefonte",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1225,
       "coord": [-75.4985522, 39.7677156],
@@ -5115,7 +5115,7 @@
     "place": {
       "name": "Bellefonte",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6105,
       "coord": [-77.7737471, 40.9134862],
@@ -5142,7 +5142,7 @@
     "place": {
       "name": "Belleville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 42404,
       "coord": [-89.9839935, 38.5200504],
@@ -5161,7 +5161,7 @@
     "place": {
       "name": "Belleville",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2007,
       "coord": [-97.6325554, 39.8246673],
@@ -5180,7 +5180,7 @@
     "place": {
       "name": "Belleville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2491,
       "coord": [-89.5333388, 42.8595048],
@@ -5199,7 +5199,7 @@
     "place": {
       "name": "Bellevue",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2363,
       "coord": [-90.4230824, 42.2587152],
@@ -5218,7 +5218,7 @@
     "place": {
       "name": "Bellevue",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8249,
       "coord": [-82.8409057, 41.2736163],
@@ -5237,7 +5237,7 @@
     "place": {
       "name": "Bellevue",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8311,
       "coord": [-80.0517216, 40.4939576],
@@ -5256,7 +5256,7 @@
     "place": {
       "name": "Bellevue",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 151854,
       "coord": [-122.192337, 47.6144219],
@@ -5283,7 +5283,7 @@
     "place": {
       "name": "Bellflower",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 346,
       "coord": [-88.5270053, 40.3400336],
@@ -5302,7 +5302,7 @@
     "place": {
       "name": "Bellingham",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 92314,
       "coord": [-122.4788361, 48.7544012],
@@ -5327,7 +5327,7 @@
     "place": {
       "name": "Bellwood",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18789,
       "coord": [-87.883117, 41.8814197],
@@ -5346,7 +5346,7 @@
     "place": {
       "name": "Bellwood",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 407,
       "coord": [-97.2383727, 41.3427903],
@@ -5365,7 +5365,7 @@
     "place": {
       "name": "Belmond",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2463,
       "coord": [-93.6143413, 42.8459977],
@@ -5384,7 +5384,7 @@
     "place": {
       "name": "Belmont",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15010,
       "coord": [-81.0377322, 35.2438272],
@@ -5419,7 +5419,7 @@
     "place": {
       "name": "Belmont",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 856,
       "coord": [-78.0344506, 42.2231241],
@@ -5438,7 +5438,7 @@
     "place": {
       "name": "Beloit",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36609,
       "coord": [-89.031784, 42.5083272],
@@ -5457,7 +5457,7 @@
     "place": {
       "name": "Belvidere",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25339,
       "coord": [-88.841734, 42.2579991],
@@ -5476,7 +5476,7 @@
     "place": {
       "name": "Ben Avon",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1918,
       "coord": [-80.0831114, 40.5081241],
@@ -5495,7 +5495,7 @@
     "place": {
       "name": "Bend",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 100421,
       "coord": [-121.3153096, 44.0581728],
@@ -5528,7 +5528,7 @@
     "place": {
       "name": "Bennet",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1082,
       "coord": [-96.5078002, 40.6790215],
@@ -5547,7 +5547,7 @@
     "place": {
       "name": "Bennington",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2026,
       "coord": [-96.1577968, 41.3647193],
@@ -5566,7 +5566,7 @@
     "place": {
       "name": "Bensenville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18813,
       "coord": [-87.9431781, 41.9538384],
@@ -5601,7 +5601,7 @@
     "place": {
       "name": "Benson",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5355,
       "coord": [-110.294517, 31.9678611],
@@ -5620,7 +5620,7 @@
     "place": {
       "name": "Benton Harbor",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9103,
       "coord": [-86.4541894, 42.1167065],
@@ -5647,7 +5647,7 @@
     "place": {
       "name": "Benton",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35014,
       "coord": [-92.586931, 34.563483],
@@ -5682,7 +5682,7 @@
     "place": {
       "name": "Benton",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6708,
       "coord": [-88.9200685, 37.9967163],
@@ -5701,7 +5701,7 @@
     "place": {
       "name": "Benton",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 943,
       "coord": [-97.1086498, 37.7889039],
@@ -5720,7 +5720,7 @@
     "place": {
       "name": "Benton",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 946,
       "coord": [-90.3809239, 42.569382],
@@ -5739,7 +5739,7 @@
     "place": {
       "name": "Bentonville",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 54164,
       "coord": [-94.2088172, 36.3728538],
@@ -5766,7 +5766,7 @@
     "place": {
       "name": "Benwood",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1269,
       "coord": [-80.7347236, 40.0169542],
@@ -5785,7 +5785,7 @@
     "place": {
       "name": "Benzonia",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 551,
       "coord": [-86.099258, 44.621389],
@@ -5812,7 +5812,7 @@
     "place": {
       "name": "Beresford",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2180,
       "coord": [-96.7742341, 43.0806132],
@@ -5831,7 +5831,7 @@
     "place": {
       "name": "Berkeley",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 121363,
       "coord": [-122.272863, 37.8708393],
@@ -5858,7 +5858,7 @@
     "place": {
       "name": "Berkley",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15194,
       "coord": [-83.1835389, 42.5030909],
@@ -5885,7 +5885,7 @@
     "place": {
       "name": "Berlin",
       "state": "BE",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 3576873,
       "coord": [13.4349112, 52.5103817],
@@ -5904,7 +5904,7 @@
     "place": {
       "name": "Berlin",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20175,
       "coord": [-72.7456519, 41.621488],
@@ -5923,7 +5923,7 @@
     "place": {
       "name": "Berlin",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5026,
       "coord": [-75.2188589, 38.324505],
@@ -5942,7 +5942,7 @@
     "place": {
       "name": "Bernice",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 422,
       "coord": [-94.9177365, 36.6159107],
@@ -5961,7 +5961,7 @@
     "place": {
       "name": "Berrien Springs",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1727,
       "coord": [-86.3388965, 41.9464336],
@@ -5980,7 +5980,7 @@
     "place": {
       "name": "Berryville",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5682,
       "coord": [-93.5695551, 36.3704704],
@@ -5999,7 +5999,7 @@
     "place": {
       "name": "Berthold",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 490,
       "coord": [-101.737108, 48.313069],
@@ -6026,7 +6026,7 @@
     "place": {
       "name": "Berthoud",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10332,
       "coord": [-105.081092, 40.3083174],
@@ -6053,7 +6053,7 @@
     "place": {
       "name": "Bertrand Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2611,
       "coord": [-86.3404660849385, 41.78629925],
@@ -6080,7 +6080,7 @@
     "place": {
       "name": "Berwick",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10355,
       "coord": [-76.2461259, 41.0602024],
@@ -6099,7 +6099,7 @@
     "place": {
       "name": "Berwyn",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 57250,
       "coord": [-87.7936685, 41.8505874],
@@ -6118,7 +6118,7 @@
     "place": {
       "name": "Bessemer City",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5428,
       "coord": [-81.283906, 35.284733],
@@ -6145,7 +6145,7 @@
     "place": {
       "name": "Bessemer",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26019,
       "coord": [-86.954437, 33.4017766],
@@ -6172,7 +6172,7 @@
     "place": {
       "name": "Bessemer",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1805,
       "coord": [-90.0529504, 46.4813363],
@@ -6191,7 +6191,7 @@
     "place": {
       "name": "Bethany Beach",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 954,
       "coord": [-75.0588646, 38.5379676],
@@ -6210,7 +6210,7 @@
     "place": {
       "name": "Bethel",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20358,
       "coord": [-73.4140097, 41.3712063],
@@ -6229,7 +6229,7 @@
     "place": {
       "name": "Bethel",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 476,
       "coord": [-93.2678063, 45.404098],
@@ -6248,7 +6248,7 @@
     "place": {
       "name": "Bethlehem",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 75781,
       "coord": [-75.3786521, 40.6178915],
@@ -6267,7 +6267,7 @@
     "place": {
       "name": "Beulah",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 313,
       "coord": [-86.090924, 44.631944],
@@ -6286,7 +6286,7 @@
     "place": {
       "name": "Beverly Hills",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10599,
       "coord": [-83.241357, 42.5226219],
@@ -6305,7 +6305,7 @@
     "place": {
       "name": "Bexley",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13928,
       "coord": [-82.936864, 39.9692378],
@@ -6332,7 +6332,7 @@
     "place": {
       "name": "Big Lake",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11686,
       "coord": [-93.7460804, 45.3324647],
@@ -6367,7 +6367,7 @@
     "place": {
       "name": "Big Rapids",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7727,
       "coord": [-85.483656, 43.698078],
@@ -6394,7 +6394,7 @@
     "place": {
       "name": "Big Rock",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1104,
       "coord": [-88.5470219, 41.7639181],
@@ -6413,7 +6413,7 @@
     "place": {
       "name": "Big Timber",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1650,
       "coord": [-109.955311, 45.834901],
@@ -6432,7 +6432,7 @@
     "place": {
       "name": "Billings",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1084,
       "coord": [-93.5521411, 37.0675544],
@@ -6451,7 +6451,7 @@
     "place": {
       "name": "Billings",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 109577,
       "coord": [-108.49607, 45.7874957],
@@ -6486,7 +6486,7 @@
     "place": {
       "name": "Biloxi",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 49449,
       "coord": [-88.8893818, 30.4007626],
@@ -6505,7 +6505,7 @@
     "place": {
       "name": "Binghamton",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 47969,
       "coord": [-75.9125187, 42.098698],
@@ -6546,7 +6546,7 @@
     "place": {
       "name": "Birchwood",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 402,
       "coord": [-91.5561191, 45.6580886],
@@ -6565,7 +6565,7 @@
     "place": {
       "name": "Birmingham",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 210928,
       "coord": [-86.8024326, 33.5206824],
@@ -6592,7 +6592,7 @@
     "place": {
       "name": "Birmingham",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21813,
       "coord": [-83.2113192, 42.5467012],
@@ -6624,7 +6624,7 @@
     "place": {
       "name": "Biron",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 826,
       "coord": [-89.780401, 44.4238544],
@@ -6643,7 +6643,7 @@
     "place": {
       "name": "Bisbee",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4923,
       "coord": [-109.9159946, 31.4417165],
@@ -6662,7 +6662,7 @@
     "place": {
       "name": "Bismarck",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 73529,
       "coord": [-100.783739, 46.808327],
@@ -6681,7 +6681,7 @@
     "place": {
       "name": "Bixby",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28609,
       "coord": [-95.8833235, 35.9420431],
@@ -6700,7 +6700,7 @@
     "place": {
       "name": "Black Creek",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1357,
       "coord": [-88.4506568, 44.4774856],
@@ -6719,7 +6719,7 @@
     "place": {
       "name": "Black Hawk County",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 131144,
       "coord": [-92.3030235, 42.4607526],
@@ -6738,7 +6738,7 @@
     "place": {
       "name": "Black Hawk",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 127,
       "coord": [-105.4932708, 39.8011469],
@@ -6757,7 +6757,7 @@
     "place": {
       "name": "Black River Falls",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3493,
       "coord": [-90.8484137, 44.2952152],
@@ -6776,7 +6776,7 @@
     "place": {
       "name": "Blaine",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 70222,
       "coord": [-93.2349489, 45.1607987],
@@ -6795,7 +6795,7 @@
     "place": {
       "name": "Blissfield",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3277,
       "coord": [-83.8624411, 41.8325487],
@@ -6814,7 +6814,7 @@
     "place": {
       "name": "Bloomfield Hills",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4460,
       "coord": [-83.2454883, 42.583645],
@@ -6833,7 +6833,7 @@
     "place": {
       "name": "Bloomfield",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21535,
       "coord": [-72.7300945, 41.826488],
@@ -6860,7 +6860,7 @@
     "place": {
       "name": "Bloomfield",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2682,
       "coord": [-92.4143872, 40.7510398],
@@ -6879,7 +6879,7 @@
     "place": {
       "name": "Bloomfield",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7421,
       "coord": [-107.984511, 36.7111165],
@@ -6898,7 +6898,7 @@
     "place": {
       "name": "Bloomingdale",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22382,
       "coord": [-88.0809036, 41.9575285],
@@ -6917,7 +6917,7 @@
     "place": {
       "name": "Bloomington",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 78680,
       "coord": [-88.9939147, 40.4797828],
@@ -6944,7 +6944,7 @@
     "place": {
       "name": "Bloomington",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 79168,
       "coord": [-86.5342881, 39.1670396],
@@ -6971,7 +6971,7 @@
     "place": {
       "name": "Bloomsburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12711,
       "coord": [-76.4537302, 41.0044958],
@@ -6990,7 +6990,7 @@
     "place": {
       "name": "Blue Ash",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13394,
       "coord": [-84.3782817, 39.2320073],
@@ -7022,7 +7022,7 @@
     "place": {
       "name": "Blue Earth",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3174,
       "coord": [-94.102459, 43.638629],
@@ -7041,7 +7041,7 @@
     "place": {
       "name": "Blue Island",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22558,
       "coord": [-87.6801848, 41.6572753],
@@ -7068,7 +7068,7 @@
     "place": {
       "name": "Blue River",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 877,
       "coord": [-106.156231, 39.7703516],
@@ -7087,7 +7087,7 @@
     "place": {
       "name": "Blue Springs",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 58604,
       "coord": [-94.282265, 39.017316],
@@ -7114,7 +7114,7 @@
     "place": {
       "name": "Bluefield",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9658,
       "coord": [-81.2223195, 37.2698395],
@@ -7133,7 +7133,7 @@
     "place": {
       "name": "Bluewater",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 7540,
       "coord": [-81.61287622487282, 43.4679793],
@@ -7152,7 +7152,7 @@
     "place": {
       "name": "Boaz",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10107,
       "coord": [-86.1649421, 34.1983281],
@@ -7171,7 +7171,7 @@
     "place": {
       "name": "Boiling Springs",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4615,
       "coord": [-81.6670407, 35.254292],
@@ -7204,7 +7204,7 @@
     "place": {
       "name": "Boise",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 235684,
       "coord": [-116.24210864118, 43.6008183],
@@ -7239,7 +7239,7 @@
     "place": {
       "name": "Bolivar",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10679,
       "coord": [-93.4107968, 37.6110502],
@@ -7258,7 +7258,7 @@
     "place": {
       "name": "Bolivar",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1000,
       "coord": [-81.4520613, 40.650061],
@@ -7277,7 +7277,7 @@
     "place": {
       "name": "Bolton",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4858,
       "coord": [-72.4334173, 41.7689878],
@@ -7312,7 +7312,7 @@
     "place": {
       "name": "Bonduel",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1417,
       "coord": [-88.4448243, 44.7402679],
@@ -7331,7 +7331,7 @@
     "place": {
       "name": "Bonn",
       "state": "NW",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 336465,
       "coord": [7.10066, 50.735851],
@@ -7350,7 +7350,7 @@
     "place": {
       "name": "Boone County",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 135968,
       "coord": [-84.7160121, 38.9589235],
@@ -7374,7 +7374,7 @@
     "place": {
       "name": "Boone",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12460,
       "coord": [-93.8802202, 42.0596994],
@@ -7393,7 +7393,7 @@
     "place": {
       "name": "Boonsboro",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3779,
       "coord": [-77.6522171, 39.506926],
@@ -7412,7 +7412,7 @@
     "place": {
       "name": "Bosque Farms",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4020,
       "coord": [-106.7051477, 34.8547713],
@@ -7431,7 +7431,7 @@
     "place": {
       "name": "Bossier City",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 62701,
       "coord": [-93.6952689, 32.5369356],
@@ -7450,7 +7450,7 @@
     "place": {
       "name": "Boston Heights",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1402,
       "coord": [-81.513171, 41.264778],
@@ -7469,7 +7469,7 @@
     "place": {
       "name": "Boston",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 692600,
       "coord": [-71.0582912, 42.3602534],
@@ -7502,7 +7502,7 @@
     "place": {
       "name": "Bothell",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 48161,
       "coord": [-122.2054035, 47.7623204],
@@ -7521,7 +7521,7 @@
     "place": {
       "name": "Boulder City",
       "state": "NV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14879,
       "coord": [-114.8337739, 35.9787638],
@@ -7540,7 +7540,7 @@
     "place": {
       "name": "Boulder",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 108250,
       "coord": [-105.270545, 40.0149856],
@@ -7567,7 +7567,7 @@
     "place": {
       "name": "Bountiful",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 45762,
       "coord": [-111.8804817, 40.8894611],
@@ -7586,7 +7586,7 @@
     "place": {
       "name": "Bourbonnais",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18164,
       "coord": [-87.8839693, 41.1639309],
@@ -7605,7 +7605,7 @@
     "place": {
       "name": "Bowling Green",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4195,
       "coord": [-91.1951437, 39.3419891],
@@ -7624,7 +7624,7 @@
     "place": {
       "name": "Bowling Green",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31504,
       "coord": [-83.6513229, 41.3747744],
@@ -7643,7 +7643,7 @@
     "place": {
       "name": "Bowman",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1470,
       "coord": [-103.3949061, 46.1830618],
@@ -7662,7 +7662,7 @@
     "place": {
       "name": "Boyd",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 604,
       "coord": [-91.0348656, 44.9519088],
@@ -7681,7 +7681,7 @@
     "place": {
       "name": "Boyertown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4264,
       "coord": [-75.6374083, 40.3337075],
@@ -7708,7 +7708,7 @@
     "place": {
       "name": "Boyne City",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3816,
       "coord": [-85.013942, 45.216675],
@@ -7727,7 +7727,7 @@
     "place": {
       "name": "Bozeman",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 49831,
       "coord": [-111.044047, 45.6794293],
@@ -7746,7 +7746,7 @@
     "place": {
       "name": "Bracebridge",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 17305,
       "coord": [-79.310989, 45.041508],
@@ -7765,7 +7765,7 @@
     "place": {
       "name": "Braceville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 724,
       "coord": [-88.2647833, 41.2269765],
@@ -7784,7 +7784,7 @@
     "place": {
       "name": "Bradford West Gwillimbury",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 42880,
       "coord": [-79.5647069, 44.1143279],
@@ -7803,7 +7803,7 @@
     "place": {
       "name": "Bradford",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1796,
       "coord": [-84.4308181, 40.1321489],
@@ -7822,7 +7822,7 @@
     "place": {
       "name": "Brady",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 383,
       "coord": [-100.3657985, 41.0220411],
@@ -7841,7 +7841,7 @@
     "place": {
       "name": "Braham",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1769,
       "coord": [-93.1706367, 45.7247444],
@@ -7860,7 +7860,7 @@
     "place": {
       "name": "Brainerd",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13434,
       "coord": [-94.2008288, 46.3580221],
@@ -7895,7 +7895,7 @@
     "place": {
       "name": "Brandenburg",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2984,
       "coord": [-86.1694143, 37.9989592],
@@ -7914,7 +7914,7 @@
     "place": {
       "name": "Brandon",
       "state": "MB",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 51313,
       "coord": [-99.9608924, 49.8511143],
@@ -7933,7 +7933,7 @@
     "place": {
       "name": "Brandon",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25138,
       "coord": [-89.9868058, 32.2731475],
@@ -7952,7 +7952,7 @@
     "place": {
       "name": "Brandon",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11048,
       "coord": [-96.5874544, 43.5909294],
@@ -7971,7 +7971,7 @@
     "place": {
       "name": "Brandon",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 883,
       "coord": [-88.7812212, 43.7352624],
@@ -7990,7 +7990,7 @@
     "place": {
       "name": "Branford",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28273,
       "coord": [-72.8150989, 41.2795414],
@@ -8025,7 +8025,7 @@
     "place": {
       "name": "Branson",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11630,
       "coord": [-93.2175285, 36.6411357],
@@ -8052,7 +8052,7 @@
     "place": {
       "name": "Brantley",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 825,
       "coord": [-86.2571786, 31.5823832],
@@ -8071,7 +8071,7 @@
     "place": {
       "name": "Brattleboro",
       "state": "VT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12184,
       "coord": [-72.5572913, 42.8507588],
@@ -8090,7 +8090,7 @@
     "place": {
       "name": "Breckenridge",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5078,
       "coord": [-106.0465486, 39.4829124],
@@ -8124,7 +8124,7 @@
     "place": {
       "name": "Breckenridge",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1238,
       "coord": [-84.478870397714, 43.4053835],
@@ -8143,7 +8143,7 @@
     "place": {
       "name": "Bremerhaven",
       "state": "HB",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 113173,
       "coord": [8.5851945, 53.5505392],
@@ -8162,7 +8162,7 @@
     "place": {
       "name": "Bremerton",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43505,
       "coord": [-122.6246836, 47.5653663],
@@ -8181,7 +8181,7 @@
     "place": {
       "name": "Brentwood",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10082,
       "coord": [-79.9756206, 40.3732693],
@@ -8200,7 +8200,7 @@
     "place": {
       "name": "Brevard",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7824,
       "coord": [-82.7342919, 35.2334472],
@@ -8227,7 +8227,7 @@
     "place": {
       "name": "Brian Head",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 151,
       "coord": [-112.850776, 37.6927551],
@@ -8246,7 +8246,7 @@
     "place": {
       "name": "Bridgeport Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10104,
       "coord": [-83.8755054919001, 43.34653835],
@@ -8273,7 +8273,7 @@
     "place": {
       "name": "Bridgeport",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 148654,
       "coord": [-73.2048348, 41.1670412],
@@ -8300,7 +8300,7 @@
     "place": {
       "name": "Bridgeport",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5015,
       "coord": [-75.3429522, 40.1043042],
@@ -8319,7 +8319,7 @@
     "place": {
       "name": "Bridgman",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2096,
       "coord": [-86.5569659, 41.9430986],
@@ -8346,7 +8346,7 @@
     "place": {
       "name": "Brigham City",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19650,
       "coord": [-112.0154991, 41.5110434],
@@ -8373,7 +8373,7 @@
     "place": {
       "name": "Brighton Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19144,
       "coord": [-83.7305556, 42.5622222],
@@ -8392,7 +8392,7 @@
     "place": {
       "name": "Brighton",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40083,
       "coord": [-104.8110775, 39.983721],
@@ -8427,7 +8427,7 @@
     "place": {
       "name": "Brighton",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7446,
       "coord": [-83.7846458, 42.5316918],
@@ -8446,7 +8446,7 @@
     "place": {
       "name": "Brimfield",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 778,
       "coord": [-89.8864976, 40.838926],
@@ -8465,7 +8465,7 @@
     "place": {
       "name": "Brisbane",
       "state": "QLD",
-      "country": "AU",
+      "country": "Australia",
       "type": "city",
       "pop": 1242825,
       "coord": [153.0234991, -27.4689682],
@@ -8484,7 +8484,7 @@
     "place": {
       "name": "Bristol",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 61844,
       "coord": [-72.9464859, 41.6735209],
@@ -8503,7 +8503,7 @@
     "place": {
       "name": "Bristol",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9861,
       "coord": [-74.8644705768123, 40.1229002],
@@ -8522,7 +8522,7 @@
     "place": {
       "name": "Bristol",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22493,
       "coord": [-71.272081, 41.670428],
@@ -8557,7 +8557,7 @@
     "place": {
       "name": "Broadview",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7998,
       "coord": [-87.8533931, 41.8639201],
@@ -8576,7 +8576,7 @@
     "place": {
       "name": "Brockton",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 9784,
       "coord": [-81.22181375972701, 44.186126650000006],
@@ -8595,7 +8595,7 @@
     "place": {
       "name": "Brodhead",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3274,
       "coord": [-89.3768296, 42.6197159],
@@ -8614,7 +8614,7 @@
     "place": {
       "name": "Broken Arrow",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 113540,
       "coord": [-95.7908195, 36.0525993],
@@ -8633,7 +8633,7 @@
     "place": {
       "name": "Broken Bow",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3506,
       "coord": [-99.6393288, 41.4018116],
@@ -8652,7 +8652,7 @@
     "place": {
       "name": "Bromont",
       "state": "QC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 7649,
       "coord": [-72.6463074, 45.3187339],
@@ -8671,7 +8671,7 @@
     "place": {
       "name": "Bronson",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2307,
       "coord": [-85.1946963, 41.8722716],
@@ -8690,7 +8690,7 @@
     "place": {
       "name": "Brooke-Alvinston",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 2359,
       "coord": [-81.8975070722232, 42.84477855],
@@ -8709,7 +8709,7 @@
     "place": {
       "name": "Brookfield",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19476,
       "coord": [-87.848085, 41.8228378],
@@ -8728,7 +8728,7 @@
     "place": {
       "name": "Brookfield",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 41464,
       "coord": [-88.1261984, 43.0578479],
@@ -8747,7 +8747,7 @@
     "place": {
       "name": "Brookhaven",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8300,
       "coord": [-75.3823039, 39.8693003],
@@ -8766,7 +8766,7 @@
     "place": {
       "name": "Brookings",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23577,
       "coord": [-96.79844, 44.311461],
@@ -8785,7 +8785,7 @@
     "place": {
       "name": "Brookline",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 63191,
       "coord": [-71.1211635, 42.3317642],
@@ -8804,7 +8804,7 @@
     "place": {
       "name": "Brooklyn Center",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 33782,
       "coord": [-93.3296296, 45.0748543],
@@ -8823,7 +8823,7 @@
     "place": {
       "name": "Brooklyn Park",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 86478,
       "coord": [-93.3443585, 45.1004807],
@@ -8842,7 +8842,7 @@
     "place": {
       "name": "Brooklyn",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1313,
       "coord": [-84.2482819, 42.105874],
@@ -8861,7 +8861,7 @@
     "place": {
       "name": "Brookville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3995,
       "coord": [-79.0794702, 41.1604348],
@@ -8880,7 +8880,7 @@
     "place": {
       "name": "Broomfield",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 74112,
       "coord": [-105.05208, 39.9403995],
@@ -8907,7 +8907,7 @@
     "place": {
       "name": "Brown City",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1302,
       "coord": [-82.98966, 43.212249],
@@ -8926,7 +8926,7 @@
     "place": {
       "name": "Brown Deer",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12507,
       "coord": [-87.972722, 43.1744352],
@@ -8945,7 +8945,7 @@
     "place": {
       "name": "Brownsburg",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28973,
       "coord": [-86.3970115, 39.8436954],
@@ -8964,7 +8964,7 @@
     "place": {
       "name": "Brownstown Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 33194,
       "coord": [-83.2753247, 42.1529228],
@@ -8991,7 +8991,7 @@
     "place": {
       "name": "Brownsville",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 186738,
       "coord": [-97.4984005, 25.9015688],
@@ -9026,7 +9026,7 @@
     "place": {
       "name": "Brownsville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 598,
       "coord": [-88.4906592, 43.6163809],
@@ -9045,7 +9045,7 @@
     "place": {
       "name": "Brunswick",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15210,
       "coord": [-81.4914894, 31.1499528],
@@ -9064,7 +9064,7 @@
     "place": {
       "name": "Brunswick",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7762,
       "coord": [-77.6281858, 39.3131621],
@@ -9083,7 +9083,7 @@
     "place": {
       "name": "Brunswick",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35426,
       "coord": [-81.8275398, 41.2456819],
@@ -9102,7 +9102,7 @@
     "place": {
       "name": "Bryan",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8729,
       "coord": [-84.5524508, 41.4747732],
@@ -9121,7 +9121,7 @@
     "place": {
       "name": "Buchanan",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4300,
       "coord": [-86.3598709, 41.8273815],
@@ -9140,7 +9140,7 @@
     "place": {
       "name": "Buckeye",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 91502,
       "coord": [-112.583776, 33.3703197],
@@ -9164,7 +9164,7 @@
     "place": {
       "name": "Buckley",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 775,
       "coord": [-85.677014, 44.504447],
@@ -9183,7 +9183,7 @@
     "place": {
       "name": "Bucyrus",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11684,
       "coord": [-82.9754649, 40.8083909],
@@ -9202,7 +9202,7 @@
     "place": {
       "name": "Buena Vista Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7664,
       "coord": [-83.862197382276, 43.4579315],
@@ -9221,7 +9221,7 @@
     "place": {
       "name": "Buena Vista",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2855,
       "coord": [-106.126747857914, 38.83492115],
@@ -9256,7 +9256,7 @@
     "place": {
       "name": "Buffalo",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 255284,
       "coord": [-78.8783922, 42.8867166],
@@ -9275,7 +9275,7 @@
     "place": {
       "name": "Buhl",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 952,
       "coord": [-92.77796, 47.49354],
@@ -9294,7 +9294,7 @@
     "place": {
       "name": "Burk's Falls",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 957,
       "coord": [-79.408916, 45.6202244],
@@ -9313,7 +9313,7 @@
     "place": {
       "name": "Burlington",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3172,
       "coord": [-102.271389, 39.304444],
@@ -9332,7 +9332,7 @@
     "place": {
       "name": "Burlington",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23713,
       "coord": [-91.1020205, 40.8126922],
@@ -9351,7 +9351,7 @@
     "place": {
       "name": "Burlington",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2634,
       "coord": [-95.7427641, 38.1944667],
@@ -9370,7 +9370,7 @@
     "place": {
       "name": "Burlington",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1291,
       "coord": [-101.428775, 48.275288],
@@ -9389,7 +9389,7 @@
     "place": {
       "name": "Burlington",
       "state": "VT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 42819,
       "coord": [-73.212906, 44.4761601],
@@ -9416,7 +9416,7 @@
     "place": {
       "name": "Burlington",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11047,
       "coord": [-88.27619, 42.6780758],
@@ -9435,7 +9435,7 @@
     "place": {
       "name": "Burnett County",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 16526,
       "coord": [-92.2673161, 45.8652437],
@@ -9454,7 +9454,7 @@
     "place": {
       "name": "Burnie",
       "state": "TAS",
-      "country": "AU",
+      "country": "Australia",
       "type": "city",
       "pop": 19348,
       "coord": [145.9064073, -41.0523688],
@@ -9473,7 +9473,7 @@
     "place": {
       "name": "Burnsville",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 64317,
       "coord": [-93.2773887, 44.7670567],
@@ -9500,7 +9500,7 @@
     "place": {
       "name": "Burr Ridge",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11192,
       "coord": [-87.9161818, 41.7502971],
@@ -9519,7 +9519,7 @@
     "place": {
       "name": "Butler",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2635,
       "coord": [-84.8713507, 41.4297694],
@@ -9538,7 +9538,7 @@
     "place": {
       "name": "Butte-Silver Bow County",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 34494,
       "coord": [-112.536508, 46.0131505],
@@ -9565,7 +9565,7 @@
     "place": {
       "name": "Byesville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2364,
       "coord": [-81.5365108, 39.9697942],
@@ -9584,7 +9584,7 @@
     "place": {
       "name": "Byron",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3784,
       "coord": [-89.2556618, 42.1269692],
@@ -9603,7 +9603,7 @@
     "place": {
       "name": "Byron",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6312,
       "coord": [-92.6454395, 44.0325922],
@@ -9622,7 +9622,7 @@
     "place": {
       "name": "Cabot",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26569,
       "coord": [-92.0165336, 34.974532],
@@ -9641,7 +9641,7 @@
     "place": {
       "name": "Cache",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2930,
       "coord": [-98.6286741, 34.6295165],
@@ -9660,7 +9660,7 @@
     "place": {
       "name": "Cadillac",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10371,
       "coord": [-85.4011619, 44.2519526],
@@ -9679,7 +9679,7 @@
     "place": {
       "name": "Cadiz",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3051,
       "coord": [-80.9967628, 40.2728452],
@@ -9698,7 +9698,7 @@
     "place": {
       "name": "Cadott",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1493,
       "coord": [-91.1507031, 44.9480187],
@@ -9717,7 +9717,7 @@
     "place": {
       "name": "Caledonia Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15811,
       "coord": [-85.4875643, 42.8121694],
@@ -9736,7 +9736,7 @@
     "place": {
       "name": "Calera",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16494,
       "coord": [-86.7505733, 33.1035045],
@@ -9771,7 +9771,7 @@
     "place": {
       "name": "Calgary",
       "state": "AB",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1335145,
       "coord": [-114.065465, 51.0460954],
@@ -9790,7 +9790,7 @@
     "place": {
       "name": "California",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "state",
       "pop": 39700000,
       "coord": [-118.7088613, 36],
@@ -9809,7 +9809,7 @@
     "place": {
       "name": "Calmar",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1125,
       "coord": [-91.86481, 43.1828024],
@@ -9828,7 +9828,7 @@
     "place": {
       "name": "Calumet City",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36033,
       "coord": [-87.5295837, 41.616016],
@@ -9855,7 +9855,7 @@
     "place": {
       "name": "Calumet Park",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7025,
       "coord": [-87.6575786, 41.6639076],
@@ -9882,7 +9882,7 @@
     "place": {
       "name": "Calumet",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 621,
       "coord": [-88.454006, 47.246592],
@@ -9909,7 +9909,7 @@
     "place": {
       "name": "Calvert County",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 92783,
       "coord": [-76.537764, 38.5288529],
@@ -9936,7 +9936,7 @@
     "place": {
       "name": "Cambridge",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 827,
       "coord": [-93.5294029, 41.8990768],
@@ -9955,7 +9955,7 @@
     "place": {
       "name": "Cambridge",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 117090,
       "coord": [-71.1056157, 42.3750997],
@@ -9974,7 +9974,7 @@
     "place": {
       "name": "Cambridge",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13096,
       "coord": [-76.0763177, 38.5714624],
@@ -10001,7 +10001,7 @@
     "place": {
       "name": "Cambridge",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9611,
       "coord": [-93.2243921, 45.5727408],
@@ -10020,7 +10020,7 @@
     "place": {
       "name": "Cambridge",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1071,
       "coord": [-100.1660494, 40.2820371],
@@ -10039,7 +10039,7 @@
     "place": {
       "name": "Cambridge",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10089,
       "coord": [-81.5884561, 40.031183],
@@ -10058,7 +10058,7 @@
     "place": {
       "name": "Cambridge",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1638,
       "coord": [-89.0164995, 43.0036122],
@@ -10085,7 +10085,7 @@
     "place": {
       "name": "Camden",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10612,
       "coord": [-92.8343294, 33.5845582],
@@ -10104,7 +10104,7 @@
     "place": {
       "name": "Cameron",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8513,
       "coord": [-94.2376137, 39.7406116],
@@ -10123,7 +10123,7 @@
     "place": {
       "name": "Camp Hill",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8130,
       "coord": [-76.9199742, 40.2398118],
@@ -10142,7 +10142,7 @@
     "place": {
       "name": "Camp Verde",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12147,
       "coord": [-111.854317, 34.5636358],
@@ -10161,7 +10161,7 @@
     "place": {
       "name": "Campbell",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7852,
       "coord": [-80.5932556, 41.0761424],
@@ -10180,7 +10180,7 @@
     "place": {
       "name": "Campbellsville",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11426,
       "coord": [-85.3419069, 37.3433974],
@@ -10199,7 +10199,7 @@
     "place": {
       "name": "Campton Hills",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10885,
       "coord": [-88.3997579, 41.9361328],
@@ -10218,7 +10218,7 @@
     "place": {
       "name": "Camrose",
       "state": "AB",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 18742,
       "coord": [-112.840576, 53.013131],
@@ -10237,7 +10237,7 @@
     "place": {
       "name": "Canada",
       "state": null,
-      "country": "CA",
+      "country": "Canada",
       "type": "country",
       "pop": 36991981,
       "coord": [-107.991707, 61.0666922],
@@ -10256,7 +10256,7 @@
     "place": {
       "name": "Canal Winchester",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9107,
       "coord": [-82.805646, 39.8428215],
@@ -10275,7 +10275,7 @@
     "place": {
       "name": "Canandaigua",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10156,
       "coord": [-77.2799761, 42.8858579],
@@ -10294,7 +10294,7 @@
     "place": {
       "name": "Cannon Falls",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4220,
       "coord": [-92.90084727, 44.5109025],
@@ -10313,7 +10313,7 @@
     "place": {
       "name": "Canonsburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9735,
       "coord": [-80.186732, 40.2588431],
@@ -10332,7 +10332,7 @@
     "place": {
       "name": "Canterbury",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5045,
       "coord": [-71.9709821, 41.6982056],
@@ -10351,7 +10351,7 @@
     "place": {
       "name": "Canton",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10124,
       "coord": [-72.8937122, 41.8245424],
@@ -10378,7 +10378,7 @@
     "place": {
       "name": "Canton",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13242,
       "coord": [-90.0351167, 40.5580945],
@@ -10405,7 +10405,7 @@
     "place": {
       "name": "Canton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 70872,
       "coord": [-81.3749508, 40.7985464],
@@ -10424,7 +10424,7 @@
     "place": {
       "name": "Canton",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3066,
       "coord": [-96.592707, 43.300858],
@@ -10443,7 +10443,7 @@
     "place": {
       "name": "Canyon Lake",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11082,
       "coord": [-117.262615, 33.6836539],
@@ -10462,7 +10462,7 @@
     "place": {
       "name": "Capac",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1983,
       "coord": [-82.9279881, 43.0125274],
@@ -10481,7 +10481,7 @@
     "place": {
       "name": "Cape Breton Regional Municipality",
       "state": "NS",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 93694,
       "coord": [-60.334048393102876, 46.03504935],
@@ -10500,7 +10500,7 @@
     "place": {
       "name": "Cape Canaveral",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9912,
       "coord": [-80.608104, 28.391754],
@@ -10519,7 +10519,7 @@
     "place": {
       "name": "Cape Coral",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 194016,
       "coord": [-81.9438802, 26.5625742],
@@ -10546,7 +10546,7 @@
     "place": {
       "name": "Cape Girardeau",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 39540,
       "coord": [-89.5230357, 37.3034933],
@@ -10565,7 +10565,7 @@
     "place": {
       "name": "Cape Town",
       "state": "WC",
-      "country": "ZA",
+      "country": "South Africa",
       "type": "city",
       "pop": 4772846,
       "coord": [18.4263523, -33.9224221],
@@ -10592,7 +10592,7 @@
     "place": {
       "name": "Carbondale",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6434,
       "coord": [-107.2112407, 39.4005647],
@@ -10632,7 +10632,7 @@
     "place": {
       "name": "Carbondale",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25083,
       "coord": [-89.216655, 37.7274692],
@@ -10659,7 +10659,7 @@
     "place": {
       "name": "Carbondale",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1352,
       "coord": [-95.6891498, 38.8186156],
@@ -10678,7 +10678,7 @@
     "place": {
       "name": "Cardiff",
       "state": "Wales",
-      "country": "UK",
+      "country": "United Kingdom",
       "type": "city",
       "pop": 362310,
       "coord": [-3.1791934, 51.4816546],
@@ -10705,7 +10705,7 @@
     "place": {
       "name": "Cardington",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2051,
       "coord": [-82.8942351, 40.5004881],
@@ -10724,7 +10724,7 @@
     "place": {
       "name": "Carlisle",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4160,
       "coord": [-93.4867511, 41.4986831],
@@ -10743,7 +10743,7 @@
     "place": {
       "name": "Carlisle",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20118,
       "coord": [-77.1890783, 40.201499],
@@ -10762,7 +10762,7 @@
     "place": {
       "name": "Carlsbad",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32238,
       "coord": [-104.237612, 32.4257456],
@@ -10785,7 +10785,7 @@
     "place": {
       "name": "Carlyle",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3222,
       "coord": [-89.3725796, 38.6103264],
@@ -10804,7 +10804,7 @@
     "place": {
       "name": "Carman",
       "state": "MB",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 3114,
       "coord": [-98.0016853, 49.5082995],
@@ -10823,7 +10823,7 @@
     "place": {
       "name": "Carmel",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 99757,
       "coord": [-86.1283681, 39.9784186],
@@ -10842,7 +10842,7 @@
     "place": {
       "name": "Carnegie",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8134,
       "coord": [-80.0833885, 40.4086802],
@@ -10869,7 +10869,7 @@
     "place": {
       "name": "Carol Stream",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 39854,
       "coord": [-88.1347927, 41.9125286],
@@ -10888,7 +10888,7 @@
     "place": {
       "name": "Carrboro",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21295,
       "coord": [-79.0752876, 35.9099875],
@@ -10915,7 +10915,7 @@
     "place": {
       "name": "Carrington",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2080,
       "coord": [-99.126224, 47.44972],
@@ -10934,7 +10934,7 @@
     "place": {
       "name": "Carroll",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10321,
       "coord": [-94.8666108, 42.0651109],
@@ -10953,7 +10953,7 @@
     "place": {
       "name": "Carroll",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 501,
       "coord": [-82.701861, 39.799135],
@@ -10972,7 +10972,7 @@
     "place": {
       "name": "Carrollton Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5750,
       "coord": [-83.9341620084823, 43.4616848],
@@ -10991,7 +10991,7 @@
     "place": {
       "name": "Carrollton",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3514,
       "coord": [-93.4965428, 39.3582412],
@@ -11010,7 +11010,7 @@
     "place": {
       "name": "Carrollton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3087,
       "coord": [-81.0856532, 40.5728404],
@@ -11029,7 +11029,7 @@
     "place": {
       "name": "Carrollton",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 133434,
       "coord": [-96.8902816, 32.9537349],
@@ -11056,7 +11056,7 @@
     "place": {
       "name": "Carson City",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1120,
       "coord": [-84.846395, 43.176977],
@@ -11075,7 +11075,7 @@
     "place": {
       "name": "Carson City",
       "state": "NV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 58639,
       "coord": [-119.7670374, 39.1663259],
@@ -11094,7 +11094,7 @@
     "place": {
       "name": "Carterville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5848,
       "coord": [-89.0774278, 37.7597872],
@@ -11113,7 +11113,7 @@
     "place": {
       "name": "Carthage",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15522,
       "coord": [-94.3103412, 37.1765141],
@@ -11132,7 +11132,7 @@
     "place": {
       "name": "Caruthersville",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5562,
       "coord": [-89.6556353, 36.1931245],
@@ -11151,7 +11151,7 @@
     "place": {
       "name": "Carver",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5829,
       "coord": [-93.625791, 44.7635738],
@@ -11184,7 +11184,7 @@
     "place": {
       "name": "Cary",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 174721,
       "coord": [-78.7812081, 35.7882893],
@@ -11211,7 +11211,7 @@
     "place": {
       "name": "Casa Grande",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 55653,
       "coord": [-111.757311, 32.8795266],
@@ -11235,7 +11235,7 @@
     "place": {
       "name": "Casco Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2796,
       "coord": [-86.1921940024734, 42.46304575],
@@ -11254,7 +11254,7 @@
     "place": {
       "name": "Casey",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 387,
       "coord": [-94.5193809, 41.5051917],
@@ -11273,7 +11273,7 @@
     "place": {
       "name": "Cashton",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1158,
       "coord": [-90.7792984, 43.7419143],
@@ -11292,7 +11292,7 @@
     "place": {
       "name": "Casper",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 59038,
       "coord": [-106.325138, 42.8501191],
@@ -11311,7 +11311,7 @@
     "place": {
       "name": "Cass City",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2494,
       "coord": [-83.174669, 43.600852],
@@ -11330,7 +11330,7 @@
     "place": {
       "name": "Cassadaga",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 569,
       "coord": [-79.309489, 42.344225],
@@ -11349,7 +11349,7 @@
     "place": {
       "name": "Cassopolis",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1712,
       "coord": [-86.0100069, 41.9117134],
@@ -11368,7 +11368,7 @@
     "place": {
       "name": "Cassville",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3190,
       "coord": [-93.868811, 36.6770111],
@@ -11387,7 +11387,7 @@
     "place": {
       "name": "Castle Pines",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11036,
       "coord": [-104.895157375468, 39.4712369],
@@ -11406,7 +11406,7 @@
     "place": {
       "name": "Castle Rock",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 73158,
       "coord": [-104.858682, 39.3722552],
@@ -11441,7 +11441,7 @@
     "place": {
       "name": "Castle Shannon",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8249,
       "coord": [-80.0222753, 40.3647917],
@@ -11460,7 +11460,7 @@
     "place": {
       "name": "Catasauqua",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6518,
       "coord": [-75.4744827, 40.6533565],
@@ -11479,7 +11479,7 @@
     "place": {
       "name": "Catawissa",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1539,
       "coord": [-76.4609868, 40.9548267],
@@ -11498,7 +11498,7 @@
     "place": {
       "name": "Catlin",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1983,
       "coord": [-87.7019675, 40.0650363],
@@ -11517,7 +11517,7 @@
     "place": {
       "name": "Catoosa",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7440,
       "coord": [-95.745817, 36.188987],
@@ -11536,7 +11536,7 @@
     "place": {
       "name": "Cayce",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14009,
       "coord": [-81.0739827, 33.9657091],
@@ -11555,7 +11555,7 @@
     "place": {
       "name": "Cañon City",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17141,
       "coord": [-105.222494, 38.4423644],
@@ -11582,7 +11582,7 @@
     "place": {
       "name": "Cecil",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 528,
       "coord": [-88.4523248, 44.8099895],
@@ -11601,7 +11601,7 @@
     "place": {
       "name": "Cedar Creek Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3192,
       "coord": [-86.0983970595338, 43.3230283],
@@ -11620,7 +11620,7 @@
     "place": {
       "name": "Cedar Falls",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40713,
       "coord": [-92.447758, 42.5361805],
@@ -11639,7 +11639,7 @@
     "place": {
       "name": "Cedar Rapids",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 133562,
       "coord": [-91.6704053, 41.9758872],
@@ -11674,7 +11674,7 @@
     "place": {
       "name": "Cedar Springs",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3627,
       "coord": [-85.551424, 43.22336],
@@ -11701,7 +11701,7 @@
     "place": {
       "name": "Cedarburg",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12121,
       "coord": [-87.9875348, 43.2966545],
@@ -11720,7 +11720,7 @@
     "place": {
       "name": "Celina",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10935,
       "coord": [-84.5702338, 40.5489358],
@@ -11739,7 +11739,7 @@
     "place": {
       "name": "Centennial",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 108418,
       "coord": [-104.8769227, 39.579155],
@@ -11758,7 +11758,7 @@
     "place": {
       "name": "Center Line",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8552,
       "coord": [-83.0277002, 42.4850362],
@@ -11777,7 +11777,7 @@
     "place": {
       "name": "Center",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1929,
       "coord": [-106.108215, 37.7535441],
@@ -11796,7 +11796,7 @@
     "place": {
       "name": "Centerburg",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1690,
       "coord": [-82.6962829, 40.3045067],
@@ -11829,7 +11829,7 @@
     "place": {
       "name": "Centerville",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5325,
       "coord": [-92.8742102, 40.7344306],
@@ -11848,7 +11848,7 @@
     "place": {
       "name": "Centerville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2748,
       "coord": [-84.9963518, 39.8178246],
@@ -11867,7 +11867,7 @@
     "place": {
       "name": "Centerville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24240,
       "coord": [-84.1593818, 39.6283928],
@@ -11886,7 +11886,7 @@
     "place": {
       "name": "Central City",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 779,
       "coord": [-105.514163, 39.8019322],
@@ -11905,7 +11905,7 @@
     "place": {
       "name": "Central Falls",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22583,
       "coord": [-71.3876472, 41.8873726],
@@ -11924,7 +11924,7 @@
     "place": {
       "name": "Central Huron",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 7799,
       "coord": [-81.54332585139252, 43.6600733],
@@ -11951,7 +11951,7 @@
     "place": {
       "name": "Central Point",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18997,
       "coord": [-122.912721, 42.376782],
@@ -11978,7 +11978,7 @@
     "place": {
       "name": "Central",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29565,
       "coord": [-91.0367175, 30.5542266],
@@ -12005,7 +12005,7 @@
     "place": {
       "name": "Centralia",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12182,
       "coord": [-89.1334037, 38.5250491],
@@ -12024,7 +12024,7 @@
     "place": {
       "name": "Centralia",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4541,
       "coord": [-92.1379539, 39.2103186],
@@ -12043,7 +12043,7 @@
     "place": {
       "name": "Centre Hall",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1268,
       "coord": [-77.6836445, 40.844505],
@@ -12062,7 +12062,7 @@
     "place": {
       "name": "Centreville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2800,
       "coord": [-87.1386067, 32.9445682],
@@ -12081,7 +12081,7 @@
     "place": {
       "name": "Cerro Gordo",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1316,
       "coord": [-88.7281262, 39.8905912],
@@ -12100,7 +12100,7 @@
     "place": {
       "name": "Chadron",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5206,
       "coord": [-103.0003729, 42.8309807],
@@ -12119,7 +12119,7 @@
     "place": {
       "name": "Chaffee",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3057,
       "coord": [-89.6550896, 37.1800513],
@@ -12138,7 +12138,7 @@
     "place": {
       "name": "Chagrin Falls",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4188,
       "coord": [-81.3855058, 41.436589],
@@ -12157,7 +12157,7 @@
     "place": {
       "name": "Chalfont",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 748,
       "coord": [-75.210702324928, 40.29066735],
@@ -12176,7 +12176,7 @@
     "place": {
       "name": "Chama",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 917,
       "coord": [-106.579887, 36.9036557],
@@ -12202,7 +12202,7 @@
     "place": {
       "name": "Chambersburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21903,
       "coord": [-77.6612586, 39.9375112],
@@ -12229,7 +12229,7 @@
     "place": {
       "name": "Champaign County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 205865,
       "coord": [-88.1975558, 40.1346857],
@@ -12248,7 +12248,7 @@
     "place": {
       "name": "Champaign",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 88909,
       "coord": [-88.2430932, 40.1164841],
@@ -12267,7 +12267,7 @@
     "place": {
       "name": "Chandler",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 279458,
       "coord": [-111.841185, 33.3062031],
@@ -12294,7 +12294,7 @@
     "place": {
       "name": "Chanute",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8722,
       "coord": [-95.4572034, 37.6792135],
@@ -12313,7 +12313,7 @@
     "place": {
       "name": "Chapel Hill",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 64051,
       "coord": [-79.05578, 35.9131542],
@@ -12348,7 +12348,7 @@
     "place": {
       "name": "Chapleau",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1942,
       "coord": [-83.4036099, 47.8416702],
@@ -12367,7 +12367,7 @@
     "place": {
       "name": "Chardon",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5242,
       "coord": [-81.2034066, 41.5824944],
@@ -12386,7 +12386,7 @@
     "place": {
       "name": "Charleroi",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4210,
       "coord": [-79.8981035, 40.1378499],
@@ -12413,7 +12413,7 @@
     "place": {
       "name": "Charles City",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7396,
       "coord": [-92.6794258, 43.0662177],
@@ -12432,7 +12432,7 @@
     "place": {
       "name": "Charles County",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 166617,
       "coord": [-77.027847, 38.4991611],
@@ -12459,7 +12459,7 @@
     "place": {
       "name": "Charles Town",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6534,
       "coord": [-77.859581, 39.2891836],
@@ -12478,7 +12478,7 @@
     "place": {
       "name": "Charleston",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17286,
       "coord": [-88.1761521, 39.4961458],
@@ -12497,7 +12497,7 @@
     "place": {
       "name": "Charleston",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5056,
       "coord": [-89.350631, 36.9208854],
@@ -12516,7 +12516,7 @@
     "place": {
       "name": "Charleston",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 150277,
       "coord": [-79.9399309, 32.7884363],
@@ -12543,7 +12543,7 @@
     "place": {
       "name": "Charleston",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 48864,
       "coord": [-81.6332812, 38.3505995],
@@ -12570,7 +12570,7 @@
     "place": {
       "name": "Charlestown",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7997,
       "coord": [-71.641729, 41.3831566],
@@ -12611,7 +12611,7 @@
     "place": {
       "name": "Charlevoix",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2348,
       "coord": [-85.258725, 45.318139],
@@ -12638,7 +12638,7 @@
     "place": {
       "name": "Charlotte",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 885708,
       "coord": [-80.8430827, 35.2272086],
@@ -12657,7 +12657,7 @@
     "place": {
       "name": "Charlottesville",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 47096,
       "coord": [-78.4766781, 38.029306],
@@ -12676,7 +12676,7 @@
     "place": {
       "name": "Chaska",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28047,
       "coord": [-93.6021791, 44.7894072],
@@ -12695,7 +12695,7 @@
     "place": {
       "name": "Chatfield",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2997,
       "coord": [-92.1880907, 43.8446296],
@@ -12714,7 +12714,7 @@
     "place": {
       "name": "Chatham",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14377,
       "coord": [-89.7045439, 39.676163],
@@ -12733,7 +12733,7 @@
     "place": {
       "name": "Chatham",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1529,
       "coord": [-73.5948391, 42.3642517],
@@ -12752,7 +12752,7 @@
     "place": {
       "name": "Chatham-Kent",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 103988,
       "coord": [-82.0898417, 42.41833],
@@ -12779,7 +12779,7 @@
     "place": {
       "name": "Chattahoochee Hills",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3084,
       "coord": [-84.7686732, 33.5790874],
@@ -12806,7 +12806,7 @@
     "place": {
       "name": "Chattanooga",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 182799,
       "coord": [-85.3094883, 35.0457219],
@@ -12825,7 +12825,7 @@
     "place": {
       "name": "Cheboygan",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4770,
       "coord": [-84.475751, 45.645867],
@@ -12844,7 +12844,7 @@
     "place": {
       "name": "Chelsea",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14982,
       "coord": [-86.6302625, 33.3401108],
@@ -12877,7 +12877,7 @@
     "place": {
       "name": "Chelsea",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5467,
       "coord": [-84.020224, 42.3180163],
@@ -12910,7 +12910,7 @@
     "place": {
       "name": "Cheltenham Township",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 37452,
       "coord": [-75.13853756577605, 40.07795585],
@@ -12937,7 +12937,7 @@
     "place": {
       "name": "Cherokee",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5199,
       "coord": [-95.5548229, 42.7499398],
@@ -12956,7 +12956,7 @@
     "place": {
       "name": "Cherryvale",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2192,
       "coord": [-95.5524788, 37.270344],
@@ -12975,7 +12975,7 @@
     "place": {
       "name": "Cherryville",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6078,
       "coord": [-81.3789739, 35.3787442],
@@ -12994,7 +12994,7 @@
     "place": {
       "name": "Chesapeake",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 249422,
       "coord": [-76.2466798, 36.7183708],
@@ -13021,7 +13021,7 @@
     "place": {
       "name": "Cheshire",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28733,
       "coord": [-72.900658, 41.4989861],
@@ -13040,7 +13040,7 @@
     "place": {
       "name": "Chester",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3749,
       "coord": [-72.4509204, 41.4031547],
@@ -13059,7 +13059,7 @@
     "place": {
       "name": "Chester",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32605,
       "coord": [-75.358851, 39.848779],
@@ -13086,7 +13086,7 @@
     "place": {
       "name": "Chester",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5269,
       "coord": [-81.213516, 34.705305],
@@ -13105,7 +13105,7 @@
     "place": {
       "name": "Chesterfield Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 45376,
       "coord": [-82.7973252, 42.6749681],
@@ -13124,7 +13124,7 @@
     "place": {
       "name": "Chesterfield",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 49999,
       "coord": [-90.5643258, 38.661953],
@@ -13143,7 +13143,7 @@
     "place": {
       "name": "Chesterton",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14241,
       "coord": [-87.0641992, 41.6105938],
@@ -13162,7 +13162,7 @@
     "place": {
       "name": "Chesterville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 191,
       "coord": [-82.6835057, 40.4800607],
@@ -13181,7 +13181,7 @@
     "place": {
       "name": "Cheyenne",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 65051,
       "coord": [-104.820246, 41.139981],
@@ -13200,7 +13200,7 @@
     "place": {
       "name": "Chicago Heights",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27480,
       "coord": [-87.6357079, 41.5062834],
@@ -13219,7 +13219,7 @@
     "place": {
       "name": "Chicago Ridge",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14433,
       "coord": [-87.7792196, 41.7014217],
@@ -13238,7 +13238,7 @@
     "place": {
       "name": "Chicago",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2693976,
       "coord": [-87.6244212, 41.8755616],
@@ -13277,7 +13277,7 @@
     "place": {
       "name": "Chico",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 94529,
       "coord": [-121.8374777, 39.7284945],
@@ -13296,7 +13296,7 @@
     "place": {
       "name": "Chillicothe",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6128,
       "coord": [-89.4884384, 40.9161637],
@@ -13315,7 +13315,7 @@
     "place": {
       "name": "Chillicothe",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22059,
       "coord": [-82.9824019, 39.3331197],
@@ -13334,7 +13334,7 @@
     "place": {
       "name": "Chilton",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4080,
       "coord": [-88.1628151, 44.028944],
@@ -13353,7 +13353,7 @@
     "place": {
       "name": "Chino Valley",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13020,
       "coord": [-112.45378, 34.7575227],
@@ -13372,7 +13372,7 @@
     "place": {
       "name": "Chippewa Falls",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14731,
       "coord": [-91.3932118, 44.9371325],
@@ -13391,7 +13391,7 @@
     "place": {
       "name": "Choteau",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1721,
       "coord": [-112.183375, 47.812243],
@@ -13410,7 +13410,7 @@
     "place": {
       "name": "Chouteau",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2059,
       "coord": [-95.3430239, 36.1859301],
@@ -13429,7 +13429,7 @@
     "place": {
       "name": "Christopher",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2697,
       "coord": [-89.053408, 37.9725501],
@@ -13448,7 +13448,7 @@
     "place": {
       "name": "Chubbuck",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15570,
       "coord": [-112.47315011566246, 42.92765095],
@@ -13467,7 +13467,7 @@
     "place": {
       "name": "Chula Vista",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 275487,
       "coord": [-117.084195, 32.6400541],
@@ -13486,7 +13486,7 @@
     "place": {
       "name": "Chur",
       "state": "GR",
-      "country": "CH",
+      "country": "Switzerland",
       "type": "city",
       "pop": 35373,
       "coord": [9.5264904, 46.854747],
@@ -13505,7 +13505,7 @@
     "place": {
       "name": "Cincinnati",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 303940,
       "coord": [-84.5124602, 39.1014537],
@@ -13532,7 +13532,7 @@
     "place": {
       "name": "Circleville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13927,
       "coord": [-82.9460133, 39.600618],
@@ -13551,7 +13551,7 @@
     "place": {
       "name": "Citronelle",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3946,
       "coord": [-88.234284, 31.0937841],
@@ -13570,7 +13570,7 @@
     "place": {
       "name": "Clairton",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6181,
       "coord": [-79.8817181, 40.2922938],
@@ -13589,7 +13589,7 @@
     "place": {
       "name": "Claremont",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 513,
       "coord": [-92.9976958, 44.0441674],
@@ -13608,7 +13608,7 @@
     "place": {
       "name": "Claremore",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19580,
       "coord": [-95.6160686, 36.3126005],
@@ -13635,7 +13635,7 @@
     "place": {
       "name": "Clarendon Hills",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8702,
       "coord": [-87.9551429, 41.7961237],
@@ -13654,7 +13654,7 @@
     "place": {
       "name": "Clarion",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2810,
       "coord": [-93.7321871, 42.7317899],
@@ -13673,7 +13673,7 @@
     "place": {
       "name": "Clarion",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3931,
       "coord": [-79.385664, 41.214714],
@@ -13692,7 +13692,7 @@
     "place": {
       "name": "Clark County",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 36972,
       "coord": [-84.116458, 37.966101],
@@ -13711,7 +13711,7 @@
     "place": {
       "name": "Clark",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1148,
       "coord": [-97.733141, 44.877743],
@@ -13730,7 +13730,7 @@
     "place": {
       "name": "Clarkdale",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4424,
       "coord": [-112.057936, 34.7711319],
@@ -13749,7 +13749,7 @@
     "place": {
       "name": "Clarksburg",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16039,
       "coord": [-80.3445341, 39.2806451],
@@ -13768,7 +13768,7 @@
     "place": {
       "name": "Clarkston",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 928,
       "coord": [-83.4188304, 42.735863],
@@ -13795,7 +13795,7 @@
     "place": {
       "name": "Clarksville",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9381,
       "coord": [-93.4664819, 35.4713108],
@@ -13814,7 +13814,7 @@
     "place": {
       "name": "Clarksville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22333,
       "coord": [-85.7602087, 38.2967791],
@@ -13833,7 +13833,7 @@
     "place": {
       "name": "Clarksville",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 166722,
       "coord": [-87.3588703, 36.5277607],
@@ -13852,7 +13852,7 @@
     "place": {
       "name": "Clawson",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11389,
       "coord": [-83.1463166, 42.5333682],
@@ -13879,7 +13879,7 @@
     "place": {
       "name": "Clay",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10291,
       "coord": [-86.60629532442134, 33.69925340933071],
@@ -13912,7 +13912,7 @@
     "place": {
       "name": "Clayton",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 639,
       "coord": [-90.9606897, 40.0314366],
@@ -13931,7 +13931,7 @@
     "place": {
       "name": "Clayton",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17355,
       "coord": [-90.3362473, 38.6504352],
@@ -13950,7 +13950,7 @@
     "place": {
       "name": "Clayton",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2643,
       "coord": [-103.184797, 36.4507836],
@@ -13969,7 +13969,7 @@
     "place": {
       "name": "Clayton",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 554,
       "coord": [-92.1712964, 45.331349],
@@ -13988,7 +13988,7 @@
     "place": {
       "name": "Clear Lake",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7687,
       "coord": [-93.3813637, 43.1370751],
@@ -14007,7 +14007,7 @@
     "place": {
       "name": "Clear Lake",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 641,
       "coord": [-93.9988708, 45.4449657],
@@ -14026,7 +14026,7 @@
     "place": {
       "name": "Clearfield",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31909,
       "coord": [-112.0244841, 41.1135837],
@@ -14053,7 +14053,7 @@
     "place": {
       "name": "Clearview",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 14814,
       "coord": [-80.06694727187954, 44.36827245],
@@ -14072,7 +14072,7 @@
     "place": {
       "name": "Clearwater",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 116946,
       "coord": [-82.8001026, 27.9658533],
@@ -14091,7 +14091,7 @@
     "place": {
       "name": "Clearwater",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2653,
       "coord": [-97.5044921, 37.5027959],
@@ -14110,7 +14110,7 @@
     "place": {
       "name": "Clearwater",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1922,
       "coord": [-95.3747844, 47.5643825],
@@ -14129,7 +14129,7 @@
     "place": {
       "name": "Cleburne",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31352,
       "coord": [-97.4091960984105, 32.35747395],
@@ -14156,7 +14156,7 @@
     "place": {
       "name": "Clemson",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17681,
       "coord": [-82.8364111, 34.6850749],
@@ -14175,7 +14175,7 @@
     "place": {
       "name": "Cleveland Heights",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 45312,
       "coord": [-81.556235, 41.5200518],
@@ -14208,7 +14208,7 @@
     "place": {
       "name": "Cleveland",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11199,
       "coord": [-90.7248187, 33.7440023],
@@ -14227,7 +14227,7 @@
     "place": {
       "name": "Cleveland",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 846,
       "coord": [-80.6770111, 35.7331953],
@@ -14246,7 +14246,7 @@
     "place": {
       "name": "Cleveland",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 381009,
       "coord": [-81.6934446, 41.5051613],
@@ -14265,7 +14265,7 @@
     "place": {
       "name": "Cleveland",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 497,
       "coord": [-110.8517022, 39.3489213],
@@ -14284,7 +14284,7 @@
     "place": {
       "name": "Clever",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2918,
       "coord": [-93.4729712, 37.0303327],
@@ -14303,7 +14303,7 @@
     "place": {
       "name": "Clinton ",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24434,
       "coord": [-90.1877485, 41.8502821],
@@ -14322,7 +14322,7 @@
     "place": {
       "name": "Clinton Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 100513,
       "coord": [-82.9200047, 42.5869782],
@@ -14341,7 +14341,7 @@
     "place": {
       "name": "Clinton County",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 33190,
       "coord": [-86.4692735, 40.2992769],
@@ -14360,7 +14360,7 @@
     "place": {
       "name": "Clinton",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13185,
       "coord": [-72.5275904, 41.2787104],
@@ -14393,7 +14393,7 @@
     "place": {
       "name": "Clinton",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7004,
       "coord": [-88.960538, 40.152712],
@@ -14412,7 +14412,7 @@
     "place": {
       "name": "Clinton",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2517,
       "coord": [-83.971731, 42.072048],
@@ -14431,7 +14431,7 @@
     "place": {
       "name": "Clinton",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8792,
       "coord": [-93.7782689, 38.3686325],
@@ -14450,7 +14450,7 @@
     "place": {
       "name": "Clinton",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2221,
       "coord": [-88.865107, 42.5577925],
@@ -14469,7 +14469,7 @@
     "place": {
       "name": "Clintonville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4591,
       "coord": [-88.7623227, 44.6205348],
@@ -14488,7 +14488,7 @@
     "place": {
       "name": "Clio",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2525,
       "coord": [-83.7346897, 43.1774215],
@@ -14507,7 +14507,7 @@
     "place": {
       "name": "Cloquet",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12568,
       "coord": [-92.4613669, 46.7217279],
@@ -14534,7 +14534,7 @@
     "place": {
       "name": "Cloudcroft",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 750,
       "coord": [-105.742721, 32.9576648],
@@ -14561,7 +14561,7 @@
     "place": {
       "name": "Cloverdale",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2060,
       "coord": [-86.7938969, 39.5147682],
@@ -14580,7 +14580,7 @@
     "place": {
       "name": "Cloverport",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1119,
       "coord": [-86.6327615, 37.8333902],
@@ -14599,7 +14599,7 @@
     "place": {
       "name": "Clovis",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 38567,
       "coord": [-103.2050709, 34.405472],
@@ -14618,7 +14618,7 @@
     "place": {
       "name": "Clyman",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 396,
       "coord": [-88.7201032, 43.3113852],
@@ -14637,7 +14637,7 @@
     "place": {
       "name": "Coal City",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5705,
       "coord": [-88.2856185, 41.2878097],
@@ -14664,7 +14664,7 @@
     "place": {
       "name": "Coatesville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13350,
       "coord": [-75.8238355, 39.9831616],
@@ -14683,7 +14683,7 @@
     "place": {
       "name": "Cobalt",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 989,
       "coord": [-79.6856668, 47.3962288],
@@ -14702,7 +14702,7 @@
     "place": {
       "name": "Cody",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10066,
       "coord": [-109.056392, 44.5263107],
@@ -14721,7 +14721,7 @@
     "place": {
       "name": "Coffeyville",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8826,
       "coord": [-95.6163634, 37.0372999],
@@ -14748,7 +14748,7 @@
     "place": {
       "name": "Cohasset",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2689,
       "coord": [-93.620215, 47.263556],
@@ -14767,7 +14767,7 @@
     "place": {
       "name": "Cohoes",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18174,
       "coord": [-73.7001187, 42.7742446],
@@ -14820,7 +14820,7 @@
     "place": {
       "name": "Cokato",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2799,
       "coord": [-94.1903675, 45.075043],
@@ -14839,7 +14839,7 @@
     "place": {
       "name": "Colby",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5570,
       "coord": [-101.0526881, 39.3959655],
@@ -14858,7 +14858,7 @@
     "place": {
       "name": "Cold Spring",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4164,
       "coord": [-94.4288849, 45.4557973],
@@ -14877,7 +14877,7 @@
     "place": {
       "name": "Colfax",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1181,
       "coord": [-91.7273032, 44.9987625],
@@ -14896,7 +14896,7 @@
     "place": {
       "name": "College Station",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 117911,
       "coord": [-96.3071042, 30.5955289],
@@ -14915,7 +14915,7 @@
     "place": {
       "name": "Collegeville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5043,
       "coord": [-75.451571, 40.1856597],
@@ -14942,7 +14942,7 @@
     "place": {
       "name": "Collierville",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 51324,
       "coord": [-89.6645266, 35.042036],
@@ -14969,7 +14969,7 @@
     "place": {
       "name": "Collingwood",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 24811,
       "coord": [-80.2172379, 44.5027226],
@@ -14988,7 +14988,7 @@
     "place": {
       "name": "Collins",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 495,
       "coord": [-93.3063381, 41.9028032],
@@ -15007,7 +15007,7 @@
     "place": {
       "name": "Collinsville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2059,
       "coord": [-85.8608643, 34.2648308],
@@ -15026,7 +15026,7 @@
     "place": {
       "name": "Collinsville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24366,
       "coord": [-89.9845476, 38.6703267],
@@ -15045,7 +15045,7 @@
     "place": {
       "name": "Collinsville",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7881,
       "coord": [-95.8398108, 36.3661205],
@@ -15064,7 +15064,7 @@
     "place": {
       "name": "Colman",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 634,
       "coord": [-96.814497, 43.982472],
@@ -15083,7 +15083,7 @@
     "place": {
       "name": "Coloma",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1465,
       "coord": [-86.308356, 42.1861494],
@@ -15102,7 +15102,7 @@
     "place": {
       "name": "Coloma",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 450,
       "coord": [-89.5215116, 44.0355294],
@@ -15121,7 +15121,7 @@
     "place": {
       "name": "Colona",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5307,
       "coord": [-90.3603496, 41.4754634],
@@ -15140,7 +15140,7 @@
     "place": {
       "name": "Colorado City",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2478,
       "coord": [-112.9765425, 36.9899107],
@@ -15159,7 +15159,7 @@
     "place": {
       "name": "Colorado Springs",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 478221,
       "coord": [-104.8253485, 38.8339578],
@@ -15186,7 +15186,7 @@
     "place": {
       "name": "Colorado",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "state",
       "pop": 5773714,
       "coord": [-105.471708, 38.90589],
@@ -15205,7 +15205,7 @@
     "place": {
       "name": "Colton",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 54824,
       "coord": [-117.3136547, 34.0739016],
@@ -15224,7 +15224,7 @@
     "place": {
       "name": "Colton",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 738,
       "coord": [-96.927556, 43.786086],
@@ -15243,7 +15243,7 @@
     "place": {
       "name": "Columbia City",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9892,
       "coord": [-85.4884616, 41.156928],
@@ -15262,7 +15262,7 @@
     "place": {
       "name": "Columbia Falls",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5308,
       "coord": [-114.191582, 48.3697168],
@@ -15281,7 +15281,7 @@
     "place": {
       "name": "Columbia Heights",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21973,
       "coord": [-93.2517802, 45.0460458],
@@ -15300,7 +15300,7 @@
     "place": {
       "name": "Columbia",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 126254,
       "coord": [-92.3337366, 38.951883],
@@ -15319,7 +15319,7 @@
     "place": {
       "name": "Columbia",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10222,
       "coord": [-76.502584, 40.031916],
@@ -15338,7 +15338,7 @@
     "place": {
       "name": "Columbia",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 136632,
       "coord": [-81.0331309, 34.0003117],
@@ -15378,7 +15378,7 @@
     "place": {
       "name": "Columbus",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 206922,
       "coord": [-84.9880449, 32.4610708],
@@ -15413,7 +15413,7 @@
     "place": {
       "name": "Columbus",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 50474,
       "coord": [-85.9213796, 39.2014405],
@@ -15440,7 +15440,7 @@
     "place": {
       "name": "Columbus",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24084,
       "coord": [-88.4272627, 33.4956744],
@@ -15459,7 +15459,7 @@
     "place": {
       "name": "Columbus",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1857,
       "coord": [-109.252154, 45.6366114],
@@ -15478,7 +15478,7 @@
     "place": {
       "name": "Columbus",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24028,
       "coord": [-97.3581439, 41.4292988],
@@ -15497,7 +15497,7 @@
     "place": {
       "name": "Columbus",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 898553,
       "coord": [-83.0007065, 39.9622601],
@@ -15522,7 +15522,7 @@
     "place": {
       "name": "Colville",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4832,
       "coord": [-117.905537, 48.5465695],
@@ -15541,7 +15541,7 @@
     "place": {
       "name": "Colwich",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1455,
       "coord": [-97.5364351, 37.7791785],
@@ -15560,7 +15560,7 @@
     "place": {
       "name": "Combined Locks",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3634,
       "coord": [-88.314273, 44.2658205],
@@ -15579,7 +15579,7 @@
     "place": {
       "name": "Commerce Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43058,
       "coord": [-83.4907721, 42.5911431],
@@ -15598,7 +15598,7 @@
     "place": {
       "name": "Commerce City",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 62418,
       "coord": [-104.9338675, 39.8083196],
@@ -15617,7 +15617,7 @@
     "place": {
       "name": "Comstock Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15231,
       "coord": [-85.479930020154, 42.2888445],
@@ -15650,7 +15650,7 @@
     "place": {
       "name": "Concord",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 125410,
       "coord": [-122.0335624, 37.9768525],
@@ -15685,7 +15685,7 @@
     "place": {
       "name": "Concord",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 105240,
       "coord": [-80.5800049, 35.4094178],
@@ -15718,7 +15718,7 @@
     "place": {
       "name": "Concord",
       "state": "NH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43976,
       "coord": [-71.537476, 43.207178],
@@ -15737,7 +15737,7 @@
     "place": {
       "name": "Concordia",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5111,
       "coord": [-97.661141, 39.571543],
@@ -15756,7 +15756,7 @@
     "place": {
       "name": "Concordia",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2371,
       "coord": [-93.5685013, 38.9824542],
@@ -15775,7 +15775,7 @@
     "place": {
       "name": "Connecticut",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "state",
       "pop": 3552821,
       "coord": [-72.568378, 41.612502],
@@ -15802,7 +15802,7 @@
     "place": {
       "name": "Connellsville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7031,
       "coord": [-79.5894828, 40.0178522],
@@ -15837,7 +15837,7 @@
     "place": {
       "name": "Connersville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13324,
       "coord": [-85.1410748, 39.6411589],
@@ -15856,7 +15856,7 @@
     "place": {
       "name": "Constantine",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1947,
       "coord": [-85.6686026, 41.8411603],
@@ -15875,7 +15875,7 @@
     "place": {
       "name": "Conway",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 66127,
       "coord": [-92.4421011, 35.0886963],
@@ -15902,7 +15902,7 @@
     "place": {
       "name": "Cook Islands",
       "state": null,
-      "country": "CK",
+      "country": "Cook Islands",
       "type": "country",
       "pop": 15040,
       "coord": [-157.78587140620786, -19.99697155],
@@ -15921,7 +15921,7 @@
     "place": {
       "name": "Coolidge",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13218,
       "coord": [-111.517624, 32.977839],
@@ -15940,7 +15940,7 @@
     "place": {
       "name": "Coon Valley",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 758,
       "coord": [-91.0131863, 43.7021922],
@@ -15959,7 +15959,7 @@
     "place": {
       "name": "Coopersburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2447,
       "coord": [-75.3903376, 40.51146],
@@ -15978,7 +15978,7 @@
     "place": {
       "name": "Cooperstown",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 983,
       "coord": [-98.1239843, 47.4444384],
@@ -15997,7 +15997,7 @@
     "place": {
       "name": "Coopersville",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4828,
       "coord": [-85.9347667, 43.0639112],
@@ -16024,7 +16024,7 @@
     "place": {
       "name": "Coos Bay",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15985,
       "coord": [-124.2174647, 43.3678937],
@@ -16051,7 +16051,7 @@
     "place": {
       "name": "Copemish",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 195,
       "coord": [-85.922581, 44.481669],
@@ -16070,7 +16070,7 @@
     "place": {
       "name": "Coraopolis",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5559,
       "coord": [-80.1643232, 40.5175351],
@@ -16089,7 +16089,7 @@
     "place": {
       "name": "Corinth",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14622,
       "coord": [-88.5223353, 34.9343599],
@@ -16108,7 +16108,7 @@
     "place": {
       "name": "Cork",
       "state": "County Cork",
-      "country": "IE",
+      "country": "Ireland",
       "type": "city",
       "pop": 224004,
       "coord": [-8.4654674, 51.897077],
@@ -16135,7 +16135,7 @@
     "place": {
       "name": "Cornelius",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31412,
       "coord": [-80.8590006, 35.481705],
@@ -16162,7 +16162,7 @@
     "place": {
       "name": "Corning",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1534,
       "coord": [-94.7347831, 40.9901625],
@@ -16181,7 +16181,7 @@
     "place": {
       "name": "Corona",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 157136,
       "coord": [-117.566444, 33.8752945],
@@ -16208,7 +16208,7 @@
     "place": {
       "name": "Corpus Christi",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 317863,
       "coord": [-97.4033191, 27.7635302],
@@ -16235,7 +16235,7 @@
     "place": {
       "name": "Cortez",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8766,
       "coord": [-108.584073, 37.3494528],
@@ -16259,7 +16259,7 @@
     "place": {
       "name": "Cortland",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17515,
       "coord": [-76.18054214267319, 42.60125676442263],
@@ -16286,7 +16286,7 @@
     "place": {
       "name": "Cortland",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7105,
       "coord": [-80.7252433, 41.3301374],
@@ -16305,7 +16305,7 @@
     "place": {
       "name": "Corunna",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3046,
       "coord": [-84.1177451, 42.9819728],
@@ -16324,7 +16324,7 @@
     "place": {
       "name": "Corvallis",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 58028,
       "coord": [-123.2620435, 44.5645659],
@@ -16343,7 +16343,7 @@
     "place": {
       "name": "Corwin",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 484,
       "coord": [-84.0782673, 39.5250603],
@@ -16362,7 +16362,7 @@
     "place": {
       "name": "Coshocton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11050,
       "coord": [-81.865298, 40.273638],
@@ -16381,7 +16381,7 @@
     "place": {
       "name": "Cottage Grove",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7303,
       "coord": [-89.1988571, 43.0785747],
@@ -16400,7 +16400,7 @@
     "place": {
       "name": "Cottbus",
       "state": "BB",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 98359,
       "coord": [14.3357307, 51.7567447],
@@ -16419,7 +16419,7 @@
     "place": {
       "name": "Cottonwood",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12029,
       "coord": [-112.009793, 34.739489],
@@ -16446,7 +16446,7 @@
     "place": {
       "name": "Council Bluffs",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 62265,
       "coord": [-95.8613912, 41.2621283],
@@ -16465,7 +16465,7 @@
     "place": {
       "name": "Council Grove",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2140,
       "coord": [-96.491958, 38.6609239],
@@ -16484,7 +16484,7 @@
     "place": {
       "name": "Council",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 867,
       "coord": [-116.438198, 44.7298876],
@@ -16503,7 +16503,7 @@
     "place": {
       "name": "Country Club Hills",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16775,
       "coord": [-87.7203257, 41.5680898],
@@ -16522,7 +16522,7 @@
     "place": {
       "name": "Countryside",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6420,
       "coord": [-87.872974798069, 41.7771605],
@@ -16541,7 +16541,7 @@
     "place": {
       "name": "Covington",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40961,
       "coord": [-84.508371, 39.0836224],
@@ -16596,7 +16596,7 @@
     "place": {
       "name": "Covington",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11564,
       "coord": [-90.1009108, 30.4754702],
@@ -16615,7 +16615,7 @@
     "place": {
       "name": "Covington",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8663,
       "coord": [-89.646286, 35.564564],
@@ -16634,7 +16634,7 @@
     "place": {
       "name": "Cowley",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 771,
       "coord": [-108.469565, 44.883286],
@@ -16653,7 +16653,7 @@
     "place": {
       "name": "Cozad",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3988,
       "coord": [-99.9858546, 40.8595822],
@@ -16672,7 +16672,7 @@
     "place": {
       "name": "Craig",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 202,
       "coord": [-96.3639109, 41.7855467],
@@ -16691,7 +16691,7 @@
     "place": {
       "name": "Cramerton",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5296,
       "coord": [-81.0750757, 35.2387504],
@@ -16710,7 +16710,7 @@
     "place": {
       "name": "Creede",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 257,
       "coord": [-106.925476, 37.8483224],
@@ -16729,7 +16729,7 @@
     "place": {
       "name": "Creighton",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1147,
       "coord": [-97.9061783, 42.4666706],
@@ -16748,7 +16748,7 @@
     "place": {
       "name": "Crescent Springs",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4319,
       "coord": [-84.5816106, 39.0514492],
@@ -16767,7 +16767,7 @@
     "place": {
       "name": "Cresco",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3888,
       "coord": [-92.1161444, 43.3736148],
@@ -16786,7 +16786,7 @@
     "place": {
       "name": "Crested Butte",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1639,
       "coord": [-106.984043, 38.8698201],
@@ -16805,7 +16805,7 @@
     "place": {
       "name": "Creston",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7536,
       "coord": [-94.361397, 41.0585878],
@@ -16824,7 +16824,7 @@
     "place": {
       "name": "Creston",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 627,
       "coord": [-88.9645382, 41.9308618],
@@ -16843,7 +16843,7 @@
     "place": {
       "name": "Crestview Hills",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3246,
       "coord": [-84.5849438, 39.0272829],
@@ -16862,7 +16862,7 @@
     "place": {
       "name": "Crestwood",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12404,
       "coord": [-90.3757777162534, 38.558816],
@@ -16895,7 +16895,7 @@
     "place": {
       "name": "Crete",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7099,
       "coord": [-96.961372, 40.628143],
@@ -16914,7 +16914,7 @@
     "place": {
       "name": "Cripple Creek",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1155,
       "coord": [-105.1783149, 38.7466555],
@@ -16933,7 +16933,7 @@
     "place": {
       "name": "Crofton",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 756,
       "coord": [-97.496068, 42.732448],
@@ -16952,7 +16952,7 @@
     "place": {
       "name": "Cromwell",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14225,
       "coord": [-72.6455665, 41.5949942],
@@ -16979,7 +16979,7 @@
     "place": {
       "name": "Crooks",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1362,
       "coord": [-96.8097577, 43.6592661],
@@ -16998,7 +16998,7 @@
     "place": {
       "name": "Crosby",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2314,
       "coord": [-93.9577612, 46.4821848],
@@ -17017,7 +17017,7 @@
     "place": {
       "name": "Cross Plains",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4104,
       "coord": [-89.6452197, 43.1116968],
@@ -17050,7 +17050,7 @@
     "place": {
       "name": "Crossville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1830,
       "coord": [-85.99414, 34.2875925],
@@ -17069,7 +17069,7 @@
     "place": {
       "name": "Crowley",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11710,
       "coord": [-92.3745761, 30.2140928],
@@ -17088,7 +17088,7 @@
     "place": {
       "name": "Crown Point",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 33899,
       "coord": [-87.3653136, 41.4169806],
@@ -17107,7 +17107,7 @@
     "place": {
       "name": "Crystal Lake",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40269,
       "coord": [-88.3161965, 42.2411344],
@@ -17134,7 +17134,7 @@
     "place": {
       "name": "Crystal",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23330,
       "coord": [-93.3606072, 45.031823],
@@ -17161,7 +17161,7 @@
     "place": {
       "name": "Cuba",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1517,
       "coord": [-78.2752927, 42.2175668],
@@ -17180,7 +17180,7 @@
     "place": {
       "name": "Cullman",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18213,
       "coord": [-86.8437095211558, 34.17492256493664],
@@ -17207,7 +17207,7 @@
     "place": {
       "name": "Culver City",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 39970,
       "coord": [-118.396466, 34.0211224],
@@ -17226,7 +17226,7 @@
     "place": {
       "name": "Cumberland",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19076,
       "coord": [-78.762383, 39.6526498],
@@ -17245,7 +17245,7 @@
     "place": {
       "name": "Cumberland",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36405,
       "coord": [-71.4328363, 41.9667656],
@@ -17264,7 +17264,7 @@
     "place": {
       "name": "Cumberland",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2274,
       "coord": [-92.0213472, 45.5326798],
@@ -17283,7 +17283,7 @@
     "place": {
       "name": "Cunningham",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 444,
       "coord": [-98.4311883, 37.6439067],
@@ -17302,7 +17302,7 @@
     "place": {
       "name": "Curtiss",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 292,
       "coord": [-90.4345795, 44.9552462],
@@ -17321,7 +17321,7 @@
     "place": {
       "name": "Cutler Bay",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 44291,
       "coord": [-80.3377, 25.5783],
@@ -17340,7 +17340,7 @@
     "place": {
       "name": "Cuyahoga Falls",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 51114,
       "coord": [-81.4828123, 41.1362729],
@@ -17367,7 +17367,7 @@
     "place": {
       "name": "Dagsboro",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 870,
       "coord": [-75.2457443, 38.5492801],
@@ -17386,7 +17386,7 @@
     "place": {
       "name": "Daleville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1651,
       "coord": [-85.5580301, 40.1211546],
@@ -17405,7 +17405,7 @@
     "place": {
       "name": "Dallas Center",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1901,
       "coord": [-93.9622388, 41.6844045],
@@ -17424,7 +17424,7 @@
     "place": {
       "name": "Dallas",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2692,
       "coord": [-75.9632636, 41.33617],
@@ -17443,7 +17443,7 @@
     "place": {
       "name": "Dallas",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1343573,
       "coord": [-96.7968559, 32.7762719],
@@ -17480,7 +17480,7 @@
     "place": {
       "name": "Danbury",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 86518,
       "coord": [-73.4540111, 41.394817],
@@ -17499,7 +17499,7 @@
     "place": {
       "name": "Danby",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3425,
       "coord": [-76.4807737, 42.3522956],
@@ -17518,7 +17518,7 @@
     "place": {
       "name": "Dane",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1117,
       "coord": [-89.5015088, 43.2505472],
@@ -17537,7 +17537,7 @@
     "place": {
       "name": "Dansville",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4433,
       "coord": [-77.6961817, 42.5611258],
@@ -17556,7 +17556,7 @@
     "place": {
       "name": "Danville",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43582,
       "coord": [-122.0008254, 37.8225892],
@@ -17575,7 +17575,7 @@
     "place": {
       "name": "Danville",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 927,
       "coord": [-91.314942, 40.865624],
@@ -17594,7 +17594,7 @@
     "place": {
       "name": "Danville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 33027,
       "coord": [-87.6304614, 40.125222],
@@ -17621,7 +17621,7 @@
     "place": {
       "name": "Danville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10559,
       "coord": [-86.5263879, 39.7606013],
@@ -17648,7 +17648,7 @@
     "place": {
       "name": "Danville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4221,
       "coord": [-76.6131474, 40.9664806],
@@ -17675,7 +17675,7 @@
     "place": {
       "name": "Danville",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40668,
       "coord": [-79.3950228, 36.5859718],
@@ -17694,7 +17694,7 @@
     "place": {
       "name": "Daphne",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27462,
       "coord": [-87.9036047, 30.6035255],
@@ -17713,7 +17713,7 @@
     "place": {
       "name": "Darby",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10715,
       "coord": [-75.2590721, 39.9184461],
@@ -17732,7 +17732,7 @@
     "place": {
       "name": "Dardanelle",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4517,
       "coord": [-93.1579532, 35.2231408],
@@ -17751,7 +17751,7 @@
     "place": {
       "name": "Darien",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1573,
       "coord": [-88.7076041, 42.6016814],
@@ -17770,7 +17770,7 @@
     "place": {
       "name": "Dassel",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1472,
       "coord": [-94.3069284, 45.0816298],
@@ -17789,7 +17789,7 @@
     "place": {
       "name": "Dauphin Island",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1778,
       "coord": [-88.1124817, 30.2542022],
@@ -17808,7 +17808,7 @@
     "place": {
       "name": "Davenport",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 102169,
       "coord": [-90.5776368, 41.5236436],
@@ -17827,7 +17827,7 @@
     "place": {
       "name": "David City",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2995,
       "coord": [-97.1300668, 41.2527355],
@@ -17846,7 +17846,7 @@
     "place": {
       "name": "Davidson",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15106,
       "coord": [-80.2115053, 35.7902384],
@@ -17873,7 +17873,7 @@
     "place": {
       "name": "Davis",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2823,
       "coord": [-97.1188924, 34.5034796],
@@ -17900,7 +17900,7 @@
     "place": {
       "name": "Davison",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5143,
       "coord": [-83.5180155, 43.0346872],
@@ -17919,7 +17919,7 @@
     "place": {
       "name": "Dawn-Euphemia",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1968,
       "coord": [-82.03907375849955, 42.693970500000006],
@@ -17938,7 +17938,7 @@
     "place": {
       "name": "Dawson City",
       "state": "YT",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1577,
       "coord": [-139.431695, 64.0606605],
@@ -17957,7 +17957,7 @@
     "place": {
       "name": "Dayton",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7262,
       "coord": [-93.5149576, 45.243854],
@@ -17976,7 +17976,7 @@
     "place": {
       "name": "Dayton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 140407,
       "coord": [-84.1916069, 39.7589478],
@@ -18003,7 +18003,7 @@
     "place": {
       "name": "De Pere",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25410,
       "coord": [-88.0599986, 44.4493584],
@@ -18030,7 +18030,7 @@
     "place": {
       "name": "De Soto",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 915,
       "coord": [-94.0085214, 41.5318591],
@@ -18049,7 +18049,7 @@
     "place": {
       "name": "De Soto",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6118,
       "coord": [-94.9685784, 38.9791708],
@@ -18068,7 +18068,7 @@
     "place": {
       "name": "De Soto",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6449,
       "coord": [-90.5551259, 38.1394978],
@@ -18087,7 +18087,7 @@
     "place": {
       "name": "De Soto",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 309,
       "coord": [-91.1990204, 43.4230306],
@@ -18106,7 +18106,7 @@
     "place": {
       "name": "DeForest",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10811,
       "coord": [-89.3437277, 43.2477691],
@@ -18133,7 +18133,7 @@
     "place": {
       "name": "DeKalb",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40290,
       "coord": [-88.7503776, 41.9295371],
@@ -18152,7 +18152,7 @@
     "place": {
       "name": "DeMotte",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4168,
       "coord": [-87.1986403, 41.1950369],
@@ -18171,7 +18171,7 @@
     "place": {
       "name": "DeRidder",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9852,
       "coord": [-93.289281, 30.846201],
@@ -18190,7 +18190,7 @@
     "place": {
       "name": "DeTour Village",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 263,
       "coord": [-83.9019487, 45.9935112],
@@ -18209,7 +18209,7 @@
     "place": {
       "name": "DeWitt Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15073,
       "coord": [-84.5427843, 42.8132169],
@@ -18228,7 +18228,7 @@
     "place": {
       "name": "DeWitt County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 15516,
       "coord": [-88.9003733, 40.1734773],
@@ -18247,7 +18247,7 @@
     "place": {
       "name": "DeWitt",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4776,
       "coord": [-84.5697965, 42.8424784],
@@ -18266,7 +18266,7 @@
     "place": {
       "name": "Deadwood",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1156,
       "coord": [-103.729642, 44.376651],
@@ -18285,7 +18285,7 @@
     "place": {
       "name": "Dearborn Heights",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 63292,
       "coord": [-83.2732627, 42.3369816],
@@ -18309,7 +18309,7 @@
     "place": {
       "name": "Dearborn",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 94328,
       "coord": [-83.1763145, 42.3222599],
@@ -18328,7 +18328,7 @@
     "place": {
       "name": "Decatur",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 57938,
       "coord": [-86.98245499377428, 34.60997287495394],
@@ -18347,7 +18347,7 @@
     "place": {
       "name": "Decatur",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25696,
       "coord": [-84.296069, 33.7737582],
@@ -18366,7 +18366,7 @@
     "place": {
       "name": "Decatur",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 70522,
       "coord": [-88.9524151, 39.8454163],
@@ -18385,7 +18385,7 @@
     "place": {
       "name": "Decatur",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9913,
       "coord": [-84.924341, 40.831353],
@@ -18404,7 +18404,7 @@
     "place": {
       "name": "Decatur",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1651,
       "coord": [-85.9744569, 42.1080979],
@@ -18431,7 +18431,7 @@
     "place": {
       "name": "Decatur",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6538,
       "coord": [-97.5861393, 33.2342834],
@@ -18450,7 +18450,7 @@
     "place": {
       "name": "Decorah",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7576,
       "coord": [-91.7859098, 43.3041609],
@@ -18469,7 +18469,7 @@
     "place": {
       "name": "Deep River",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4415,
       "coord": [-72.4356422, 41.3856546],
@@ -18502,7 +18502,7 @@
     "place": {
       "name": "Deer Lodge",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2938,
       "coord": [-112.735224, 46.39893],
@@ -18521,7 +18521,7 @@
     "place": {
       "name": "Deerfield",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19196,
       "coord": [-87.8445119, 42.1711365],
@@ -18540,7 +18540,7 @@
     "place": {
       "name": "Deerfield",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2540,
       "coord": [-89.0749153, 43.0538156],
@@ -18559,7 +18559,7 @@
     "place": {
       "name": "Defiance",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17066,
       "coord": [-84.362101, 41.286718],
@@ -18592,7 +18592,7 @@
     "place": {
       "name": "Del Norte",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1458,
       "coord": [-106.353368, 37.6788919],
@@ -18611,7 +18611,7 @@
     "place": {
       "name": "Del Rio",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 34673,
       "coord": [-100.8987707, 29.357515],
@@ -18630,7 +18630,7 @@
     "place": {
       "name": "Delano",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6484,
       "coord": [-93.7891331, 45.0419073],
@@ -18649,7 +18649,7 @@
     "place": {
       "name": "Delavan",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8505,
       "coord": [-88.6437138, 42.6330703],
@@ -18668,7 +18668,7 @@
     "place": {
       "name": "Delaware Water Gap",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 675,
       "coord": [-75.1199241, 40.9677508],
@@ -18695,7 +18695,7 @@
     "place": {
       "name": "Delaware",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 41302,
       "coord": [-83.067655, 40.300184],
@@ -18714,7 +18714,7 @@
     "place": {
       "name": "Delhi",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 420,
       "coord": [-91.3309112, 42.4297057],
@@ -18741,7 +18741,7 @@
     "place": {
       "name": "Delhi",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2622,
       "coord": [-91.4931736, 32.4576421],
@@ -18760,7 +18760,7 @@
     "place": {
       "name": "Dell Rapids",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3996,
       "coord": [-96.7118751, 43.823403],
@@ -18779,7 +18779,7 @@
     "place": {
       "name": "Delmar",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3798,
       "coord": [-75.5776007, 38.4558814],
@@ -18798,7 +18798,7 @@
     "place": {
       "name": "Delmont",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2592,
       "coord": [-79.5703201, 40.4131233],
@@ -18817,7 +18817,7 @@
     "place": {
       "name": "Delta Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 33119,
       "coord": [-84.6619957, 42.7265577],
@@ -18836,7 +18836,7 @@
     "place": {
       "name": "Delta",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9035,
       "coord": [-108.070827, 38.741679],
@@ -18863,7 +18863,7 @@
     "place": {
       "name": "Denison",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8373,
       "coord": [-95.3553286, 42.0177718],
@@ -18882,7 +18882,7 @@
     "place": {
       "name": "Denmark",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2408,
       "coord": [-87.8269868, 44.3479362],
@@ -18915,7 +18915,7 @@
     "place": {
       "name": "Dennis",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14674,
       "coord": [-70.1939087, 41.7353872],
@@ -18942,7 +18942,7 @@
     "place": {
       "name": "Denton",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4848,
       "coord": [-75.8271564, 38.8845583],
@@ -18961,7 +18961,7 @@
     "place": {
       "name": "Denton",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 139869,
       "coord": [-97.133069, 33.214678],
@@ -18980,7 +18980,7 @@
     "place": {
       "name": "Denver",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 715522,
       "coord": [-104.984862, 39.7392364],
@@ -19007,7 +19007,7 @@
     "place": {
       "name": "Denver",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3794,
       "coord": [-76.1371684, 40.2331483],
@@ -19026,7 +19026,7 @@
     "place": {
       "name": "Deposit",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1387,
       "coord": [-75.4276769, 42.0600834],
@@ -19045,7 +19045,7 @@
     "place": {
       "name": "Derby",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12325,
       "coord": [-73.0890324, 41.3223611],
@@ -19072,7 +19072,7 @@
     "place": {
       "name": "Derby",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25625,
       "coord": [-97.2689331, 37.5455735],
@@ -19099,7 +19099,7 @@
     "place": {
       "name": "Derry",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2637,
       "coord": [-79.2997573, 40.3339589],
@@ -19123,7 +19123,7 @@
     "place": {
       "name": "Derwent Valley",
       "state": "TAS",
-      "country": "AU",
+      "country": "Australia",
       "type": "city",
       "pop": 10290,
       "coord": [146.54404049209268, -42.803101999999996],
@@ -19142,7 +19142,7 @@
     "place": {
       "name": "Des Moines",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 214133,
       "coord": [-93.6046655, 41.5910323],
@@ -19177,7 +19177,7 @@
     "place": {
       "name": "Des Plaines",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 58316,
       "coord": [-87.8873916, 42.0415823],
@@ -19196,7 +19196,7 @@
     "place": {
       "name": "Deshler",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1588,
       "coord": [-83.9056436865497, 41.20766145],
@@ -19215,7 +19215,7 @@
     "place": {
       "name": "Detroit Lakes",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9869,
       "coord": [-95.845325, 46.817181],
@@ -19234,7 +19234,7 @@
     "place": {
       "name": "Detroit",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 670031,
       "coord": [-83.0466403, 42.3315509],
@@ -19253,7 +19253,7 @@
     "place": {
       "name": "Dewey Beach",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 353,
       "coord": [-75.0752724, 38.691184],
@@ -19272,7 +19272,7 @@
     "place": {
       "name": "Dewey-Humboldt",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4326,
       "coord": [-112.2425051, 34.5032243],
@@ -19291,7 +19291,7 @@
     "place": {
       "name": "Dexter",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 640,
       "coord": [-94.2282377, 41.5165588],
@@ -19310,7 +19310,7 @@
     "place": {
       "name": "Dexter",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4500,
       "coord": [-83.8842, 42.3372998],
@@ -19351,7 +19351,7 @@
     "place": {
       "name": "Dexter",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 324,
       "coord": [-92.7045548, 43.7197096],
@@ -19370,7 +19370,7 @@
     "place": {
       "name": "Diamondhead",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9529,
       "coord": [-89.3639378, 30.3946392],
@@ -19397,7 +19397,7 @@
     "place": {
       "name": "Dickinson",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25679,
       "coord": [-102.7896242, 46.8791756],
@@ -19416,7 +19416,7 @@
     "place": {
       "name": "Dietzenbach",
       "state": "HE",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 35590,
       "coord": [8.784277, 50.0171926],
@@ -19435,7 +19435,7 @@
     "place": {
       "name": "Dillon",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1064,
       "coord": [-106.0433023, 39.6302657],
@@ -19454,7 +19454,7 @@
     "place": {
       "name": "Dillsburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2643,
       "coord": [-77.0358059, 40.1109413],
@@ -19473,7 +19473,7 @@
     "place": {
       "name": "Divernon",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1139,
       "coord": [-89.6573192, 39.5656082],
@@ -19492,7 +19492,7 @@
     "place": {
       "name": "Dixon",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15274,
       "coord": [-89.4814291, 41.8425197],
@@ -19511,7 +19511,7 @@
     "place": {
       "name": "Dodge City",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27788,
       "coord": [-100.0170787, 37.7527982],
@@ -19530,7 +19530,7 @@
     "place": {
       "name": "Dodge County",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 89396,
       "coord": [-88.7177834, 43.413614],
@@ -19549,7 +19549,7 @@
     "place": {
       "name": "Dodgeville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4984,
       "coord": [-90.1304461, 42.9600059],
@@ -19568,7 +19568,7 @@
     "place": {
       "name": "Dolores",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 885,
       "coord": [-108.503883, 37.473852],
@@ -19595,7 +19595,7 @@
     "place": {
       "name": "Donnelly",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 249,
       "coord": [-116.0775155, 44.7325107],
@@ -19614,7 +19614,7 @@
     "place": {
       "name": "Door County",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 30066,
       "coord": [-87.5329747, 44.7615925],
@@ -19633,7 +19633,7 @@
     "place": {
       "name": "Dorchester",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 849,
       "coord": [-90.3356913, 45.0030238],
@@ -19652,7 +19652,7 @@
     "place": {
       "name": "Dormont",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8244,
       "coord": [-80.0372926, 40.3941094],
@@ -19671,7 +19671,7 @@
     "place": {
       "name": "Dorset",
       "state": "TAS",
-      "country": "AU",
+      "country": "Australia",
       "type": "city",
       "pop": 6652,
       "coord": [147.6579004278306, -41.0591915],
@@ -19690,7 +19690,7 @@
     "place": {
       "name": "Dothan",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 71072,
       "coord": [-85.3934375, 31.2237285],
@@ -19714,7 +19714,7 @@
     "place": {
       "name": "Douglas",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16531,
       "coord": [-109.5545036, 31.3447174],
@@ -19733,7 +19733,7 @@
     "place": {
       "name": "Douglas",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1378,
       "coord": [-86.2005933, 42.6433584],
@@ -19752,7 +19752,7 @@
     "place": {
       "name": "Douglas",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6386,
       "coord": [-105.382624, 42.7595708],
@@ -19771,7 +19771,7 @@
     "place": {
       "name": "Douglass Hills",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5456,
       "coord": [-85.5527377, 38.2378484],
@@ -19810,7 +19810,7 @@
     "place": {
       "name": "Dover",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1337,
       "coord": [-93.1142982, 35.4004413],
@@ -19829,7 +19829,7 @@
     "place": {
       "name": "Dover",
       "state": "NH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32191,
       "coord": [-70.8739761, 43.1981117],
@@ -19856,7 +19856,7 @@
     "place": {
       "name": "Dover",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13112,
       "coord": [-81.4741475, 40.5213381],
@@ -19875,7 +19875,7 @@
     "place": {
       "name": "Downers Grove",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 50247,
       "coord": [-88.0102281, 41.7936822],
@@ -19910,7 +19910,7 @@
     "place": {
       "name": "Downingtown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7898,
       "coord": [-75.7032742, 40.0064958],
@@ -19929,7 +19929,7 @@
     "place": {
       "name": "Doylestown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8300,
       "coord": [-75.1304588, 40.3100446],
@@ -19956,7 +19956,7 @@
     "place": {
       "name": "Draper",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 51017,
       "coord": [-111.8627989, 40.5247777],
@@ -19983,7 +19983,7 @@
     "place": {
       "name": "Dresden",
       "state": "SN",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 555351,
       "coord": [13.7381437, 51.0493286],
@@ -20002,7 +20002,7 @@
     "place": {
       "name": "Dry Ridge",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2102,
       "coord": [-84.5899426, 38.6820123],
@@ -20021,7 +20021,7 @@
     "place": {
       "name": "Dryden",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 7388,
       "coord": [-92.835846, 49.785698],
@@ -20040,7 +20040,7 @@
     "place": {
       "name": "Du Quoin",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5761,
       "coord": [-89.2361935, 38.0114393],
@@ -20059,7 +20059,7 @@
     "place": {
       "name": "DuPage County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 932877,
       "coord": [-88.0906873, 41.8603735],
@@ -20078,7 +20078,7 @@
     "place": {
       "name": "Dublin",
       "state": "County Dublin",
-      "country": "IE",
+      "country": "Ireland",
       "type": "city",
       "pop": 592713,
       "coord": [-6.267769, 53.34407],
@@ -20105,7 +20105,7 @@
     "place": {
       "name": "Dublin",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 49328,
       "coord": [-83.1135563, 40.0996009],
@@ -20132,7 +20132,7 @@
     "place": {
       "name": "Dublin",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2177,
       "coord": [-75.2016245, 40.3715883],
@@ -20151,7 +20151,7 @@
     "place": {
       "name": "Dubuque",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 59667,
       "coord": [-90.6647985, 42.5006243],
@@ -20190,7 +20190,7 @@
     "place": {
       "name": "Duluth",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31873,
       "coord": [-84.1441046, 34.0028569],
@@ -20225,7 +20225,7 @@
     "place": {
       "name": "Duluth",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 86697,
       "coord": [-92.1251218, 46.7729322],
@@ -20252,7 +20252,7 @@
     "place": {
       "name": "Duncan",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 392,
       "coord": [-97.4932293, 41.3894897],
@@ -20271,7 +20271,7 @@
     "place": {
       "name": "Duncan",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4041,
       "coord": [-82.1451096, 34.9378962],
@@ -20290,7 +20290,7 @@
     "place": {
       "name": "Dundee",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5323,
       "coord": [-83.6596596, 41.9572676],
@@ -20317,7 +20317,7 @@
     "place": {
       "name": "Dunkirk",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12743,
       "coord": [-79.333932, 42.479502],
@@ -20336,7 +20336,7 @@
     "place": {
       "name": "Dunwoody",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 49356,
       "coord": [-84.3342686, 33.9463786],
@@ -20363,7 +20363,7 @@
     "place": {
       "name": "Durand",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3507,
       "coord": [-83.9845777, 42.9120239],
@@ -20382,7 +20382,7 @@
     "place": {
       "name": "Durand",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1854,
       "coord": [-91.965726, 44.6263543],
@@ -20401,7 +20401,7 @@
     "place": {
       "name": "Durango",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19071,
       "coord": [-107.881439, 37.271268],
@@ -20425,7 +20425,7 @@
     "place": {
       "name": "Durant",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1871,
       "coord": [-90.9107038, 41.5997498],
@@ -20444,7 +20444,7 @@
     "place": {
       "name": "Durham County",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 324833,
       "coord": [-78.8751582, 36.0181316],
@@ -20463,7 +20463,7 @@
     "place": {
       "name": "Durham",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 278993,
       "coord": [-78.9018053, 35.996653],
@@ -20490,7 +20490,7 @@
     "place": {
       "name": "Dyersburg",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16164,
       "coord": [-89.3857496, 36.0346393],
@@ -20509,7 +20509,7 @@
     "place": {
       "name": "Dyersville",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4477,
       "coord": [-91.1211058, 42.4844602],
@@ -20528,7 +20528,7 @@
     "place": {
       "name": "Dysart",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1281,
       "coord": [-92.3062052, 42.1709373],
@@ -20547,7 +20547,7 @@
     "place": {
       "name": "Eagan",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 68855,
       "coord": [-93.1659179, 44.818173],
@@ -20566,7 +20566,7 @@
     "place": {
       "name": "Eagle Grove",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3601,
       "coord": [-93.9046225, 42.6641418],
@@ -20585,7 +20585,7 @@
     "place": {
       "name": "Eagle",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7511,
       "coord": [-106.827893, 39.655268],
@@ -20614,7 +20614,7 @@
     "place": {
       "name": "Eagle",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30346,
       "coord": [-116.3540138, 43.6954424],
@@ -20633,7 +20633,7 @@
     "place": {
       "name": "Eagle",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2071,
       "coord": [-88.474265, 42.8794563],
@@ -20652,7 +20652,7 @@
     "place": {
       "name": "Eagles Mere",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 151,
       "coord": [-76.5842439, 41.4109919],
@@ -20676,7 +20676,7 @@
     "place": {
       "name": "Early",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 587,
       "coord": [-95.1523131, 42.4613432],
@@ -20695,7 +20695,7 @@
     "place": {
       "name": "East Alton",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5786,
       "coord": [-90.1112184, 38.8803256],
@@ -20714,7 +20714,7 @@
     "place": {
       "name": "East Aurora",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5998,
       "coord": [-78.6177611, 42.7689141],
@@ -20741,7 +20741,7 @@
     "place": {
       "name": "East Dundee",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3152,
       "coord": [-88.2714689, 42.0989145],
@@ -20760,7 +20760,7 @@
     "place": {
       "name": "East Granby",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5214,
       "coord": [-72.7273158, 41.9412081],
@@ -20779,7 +20779,7 @@
     "place": {
       "name": "East Grand Forks",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9176,
       "coord": [-97.0175792, 47.9317013],
@@ -20798,7 +20798,7 @@
     "place": {
       "name": "East Grand Rapids",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11371,
       "coord": [-85.6097309, 42.9412024],
@@ -20817,7 +20817,7 @@
     "place": {
       "name": "East Greenville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3166,
       "coord": [-75.5018479, 40.4064882],
@@ -20844,7 +20844,7 @@
     "place": {
       "name": "East Greenwich",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14312,
       "coord": [-71.4558911, 41.6603788],
@@ -20863,7 +20863,7 @@
     "place": {
       "name": "East Haddam",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8875,
       "coord": [-72.4613902, 41.4529215],
@@ -20890,7 +20890,7 @@
     "place": {
       "name": "East Hampton",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12717,
       "coord": [-72.5024804, 41.5758442],
@@ -20923,7 +20923,7 @@
     "place": {
       "name": "East Hartford",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 51045,
       "coord": [-72.644512, 41.767914],
@@ -20942,7 +20942,7 @@
     "place": {
       "name": "East Haven",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27923,
       "coord": [-72.8684337, 41.2762081],
@@ -20961,7 +20961,7 @@
     "place": {
       "name": "East Helena",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1944,
       "coord": [-111.914593, 46.5895782],
@@ -20980,7 +20980,7 @@
     "place": {
       "name": "East Lansdowne",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2714,
       "coord": [-75.2612943, 39.9456683],
@@ -20999,7 +20999,7 @@
     "place": {
       "name": "East Lansing",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 47741,
       "coord": [-84.4721678, 42.7320307],
@@ -21034,7 +21034,7 @@
     "place": {
       "name": "East Liverpool",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9958,
       "coord": [-80.5772928, 40.6186756],
@@ -21053,7 +21053,7 @@
     "place": {
       "name": "East Lyme",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18693,
       "coord": [-72.2258709, 41.3569909],
@@ -21092,7 +21092,7 @@
     "place": {
       "name": "East Moline",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21374,
       "coord": [-90.4420411, 41.5152157],
@@ -21111,7 +21111,7 @@
     "place": {
       "name": "East Palestine",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4761,
       "coord": [-80.5403469, 40.8339509],
@@ -21130,7 +21130,7 @@
     "place": {
       "name": "East Palo Alto",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30034,
       "coord": [-122.141075, 37.4688273],
@@ -21165,7 +21165,7 @@
     "place": {
       "name": "East Peoria",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22484,
       "coord": [-89.5800978, 40.666149],
@@ -21184,7 +21184,7 @@
     "place": {
       "name": "East Pittsburgh",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1927,
       "coord": [-79.8384391, 40.3957108],
@@ -21211,7 +21211,7 @@
     "place": {
       "name": "East Providence",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 47139,
       "coord": [-71.376257, 41.8194081],
@@ -21230,7 +21230,7 @@
     "place": {
       "name": "East Rochester",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6334,
       "coord": [-77.483559, 43.112157],
@@ -21249,7 +21249,7 @@
     "place": {
       "name": "East St. Louis",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18469,
       "coord": [-90.14629, 38.6133731],
@@ -21268,7 +21268,7 @@
     "place": {
       "name": "East Stroudsburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9847,
       "coord": [-75.1812913, 40.9995386],
@@ -21295,7 +21295,7 @@
     "place": {
       "name": "East Tawas",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2663,
       "coord": [-83.490252, 44.279461],
@@ -21314,7 +21314,7 @@
     "place": {
       "name": "East Troy",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5673,
       "coord": [-88.4054374, 42.7851871],
@@ -21347,7 +21347,7 @@
     "place": {
       "name": "East Washington",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1858,
       "coord": [-80.23756, 40.1736822],
@@ -21366,7 +21366,7 @@
     "place": {
       "name": "East Windsor",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11190,
       "coord": [-72.6130726, 41.9156316],
@@ -21385,7 +21385,7 @@
     "place": {
       "name": "Easton",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7605,
       "coord": [-73.2973394, 41.2528738],
@@ -21404,7 +21404,7 @@
     "place": {
       "name": "Easton",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17101,
       "coord": [-76.0763065, 38.7744952],
@@ -21437,7 +21437,7 @@
     "place": {
       "name": "Easton",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28127,
       "coord": [-75.2099866, 40.6916081],
@@ -21464,7 +21464,7 @@
     "place": {
       "name": "Eastpointe",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 34318,
       "coord": [-82.9554746, 42.4683698],
@@ -21505,7 +21505,7 @@
     "place": {
       "name": "Eaton Rapids",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5203,
       "coord": [-84.655814, 42.5092039],
@@ -21524,7 +21524,7 @@
     "place": {
       "name": "Eau Claire",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 69421,
       "coord": [-91.4984941, 44.811349],
@@ -21551,7 +21551,7 @@
     "place": {
       "name": "Ebensburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3404,
       "coord": [-78.7248434, 40.4852783],
@@ -21578,7 +21578,7 @@
     "place": {
       "name": "Ecorse",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9512,
       "coord": [-83.145757, 42.2444833],
@@ -21605,7 +21605,7 @@
     "place": {
       "name": "Eden Prairie",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 64198,
       "coord": [-93.470786, 44.8546856],
@@ -21624,7 +21624,7 @@
     "place": {
       "name": "Eden Valley",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1027,
       "coord": [-94.5461074, 45.3260745],
@@ -21643,7 +21643,7 @@
     "place": {
       "name": "Edgerton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1881,
       "coord": [-84.7480123, 41.4486619],
@@ -21662,7 +21662,7 @@
     "place": {
       "name": "Edgerton",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5945,
       "coord": [-89.06949, 42.8334738],
@@ -21681,7 +21681,7 @@
     "place": {
       "name": "Edgewood",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6174,
       "coord": [-106.1911055, 35.0613019],
@@ -21700,7 +21700,7 @@
     "place": {
       "name": "Edgewood",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3145,
       "coord": [-79.8814386, 40.4320133],
@@ -21719,7 +21719,7 @@
     "place": {
       "name": "Edina",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 53494,
       "coord": [-93.3501222, 44.8897027],
@@ -21746,7 +21746,7 @@
     "place": {
       "name": "Edinboro",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4920,
       "coord": [-80.1317236, 41.8742225],
@@ -21765,7 +21765,7 @@
     "place": {
       "name": "Edison",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 422,
       "coord": [-82.862403, 40.5575598],
@@ -21784,7 +21784,7 @@
     "place": {
       "name": "Edisto Beach",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1033,
       "coord": [-80.31028938, 32.50739515],
@@ -21803,7 +21803,7 @@
     "place": {
       "name": "Edmond",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 94428,
       "coord": [-97.4649038, 35.6571367],
@@ -21822,7 +21822,7 @@
     "place": {
       "name": "Edmonton",
       "state": "AB",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 981280,
       "coord": [-113.507996, 53.535411],
@@ -21841,7 +21841,7 @@
     "place": {
       "name": "Edwardsville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26808,
       "coord": [-89.953157, 38.8114364],
@@ -21860,7 +21860,7 @@
     "place": {
       "name": "Effingham",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12221,
       "coord": [-88.54348, 39.1201433],
@@ -21879,7 +21879,7 @@
     "place": {
       "name": "Egg Harbor",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 359,
       "coord": [-87.2970501, 45.0463808],
@@ -21898,7 +21898,7 @@
     "place": {
       "name": "El Dorado",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12870,
       "coord": [-96.8622524, 37.81724],
@@ -21917,7 +21917,7 @@
     "place": {
       "name": "El Mirage",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35805,
       "coord": [-112.324486, 33.6130338],
@@ -21936,7 +21936,7 @@
     "place": {
       "name": "El Paso",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 678815,
       "coord": [-106.4882345, 31.7550511],
@@ -21955,7 +21955,7 @@
     "place": {
       "name": "El Reno",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16989,
       "coord": [-97.9550578, 35.532198],
@@ -21974,7 +21974,7 @@
     "place": {
       "name": "Elba",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3508,
       "coord": [-86.0677243, 31.4146108],
@@ -21993,7 +21993,7 @@
     "place": {
       "name": "Elberta",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 329,
       "coord": [-86.226484, 44.619443],
@@ -22012,7 +22012,7 @@
     "place": {
       "name": "Elburn",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6175,
       "coord": [-88.4723014, 41.8922499],
@@ -22039,7 +22039,7 @@
     "place": {
       "name": "Eldora",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2663,
       "coord": [-93.099609, 42.3606883],
@@ -22058,7 +22058,7 @@
     "place": {
       "name": "Elgin",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 114797,
       "coord": [-88.2810994, 42.03726],
@@ -22077,7 +22077,7 @@
     "place": {
       "name": "Elgin",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1115,
       "coord": [-92.2380006414966, 44.12911325],
@@ -22096,7 +22096,7 @@
     "place": {
       "name": "Elgin",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1717,
       "coord": [-117.9175706, 45.5649887],
@@ -22123,7 +22123,7 @@
     "place": {
       "name": "Elgin",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9784,
       "coord": [-97.371118, 30.3495084],
@@ -22150,7 +22150,7 @@
     "place": {
       "name": "Elizabeth",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1675,
       "coord": [-104.59687, 39.3602863],
@@ -22169,7 +22169,7 @@
     "place": {
       "name": "Elizabeth",
       "state": "NJ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 137298,
       "coord": [-74.2107006, 40.6639916],
@@ -22188,7 +22188,7 @@
     "place": {
       "name": "Elizabethtown",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31394,
       "coord": [-85.8591285, 37.693952],
@@ -22207,7 +22207,7 @@
     "place": {
       "name": "Elizabethtown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11639,
       "coord": [-76.6042521, 40.153364],
@@ -22226,7 +22226,7 @@
     "place": {
       "name": "Elk Grove",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 176124,
       "coord": [-121.3716178, 38.4087993],
@@ -22253,7 +22253,7 @@
     "place": {
       "name": "Elk Point",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2149,
       "coord": [-96.6827096, 42.6860746],
@@ -22272,7 +22272,7 @@
     "place": {
       "name": "Elk Rapids",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1529,
       "coord": [-85.416461, 44.895558],
@@ -22299,7 +22299,7 @@
     "place": {
       "name": "Elk River",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25835,
       "coord": [-93.5671825, 45.3038538],
@@ -22318,7 +22318,7 @@
     "place": {
       "name": "Elkader",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1209,
       "coord": [-91.4040921, 42.854533],
@@ -22337,7 +22337,7 @@
     "place": {
       "name": "Elkhart",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 53923,
       "coord": [-85.972773, 41.685894],
@@ -22372,7 +22372,7 @@
     "place": {
       "name": "Elkhorn",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10247,
       "coord": [-88.5445447, 42.6727927],
@@ -22391,7 +22391,7 @@
     "place": {
       "name": "Elkins",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6950,
       "coord": [-79.8466552, 38.925927],
@@ -22410,7 +22410,7 @@
     "place": {
       "name": "Elko",
       "state": "NV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20564,
       "coord": [-115.762181, 40.831984],
@@ -22429,7 +22429,7 @@
     "place": {
       "name": "Elkton",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15807,
       "coord": [-75.8330934, 39.6065073],
@@ -22448,7 +22448,7 @@
     "place": {
       "name": "Elkton",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 796,
       "coord": [-83.1810514, 43.8182836],
@@ -22467,7 +22467,7 @@
     "place": {
       "name": "Ellendale",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 676,
       "coord": [-93.3010744, 43.8728443],
@@ -22486,7 +22486,7 @@
     "place": {
       "name": "Ellinwood",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2011,
       "coord": [-98.5809106, 38.3555675],
@@ -22505,7 +22505,7 @@
     "place": {
       "name": "Elliot Lake",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 11372,
       "coord": [-82.652893, 46.373464],
@@ -22524,7 +22524,7 @@
     "place": {
       "name": "Ellisville",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9985,
       "coord": [-90.584838, 38.5946373],
@@ -22551,7 +22551,7 @@
     "place": {
       "name": "Ellsworth",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 184,
       "coord": [-88.7167336, 40.4503125],
@@ -22570,7 +22570,7 @@
     "place": {
       "name": "Ellsworth",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3066,
       "coord": [-98.2281126, 38.7305648],
@@ -22589,7 +22589,7 @@
     "place": {
       "name": "Ellsworth",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 367,
       "coord": [-85.2461821, 45.165391],
@@ -22622,7 +22622,7 @@
     "place": {
       "name": "Ellwood City",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7642,
       "coord": [-80.2864515, 40.8617303],
@@ -22641,7 +22641,7 @@
     "place": {
       "name": "Elmhurst",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 45786,
       "coord": [-87.9403418, 41.8994745],
@@ -22660,7 +22660,7 @@
     "place": {
       "name": "Elmira Heights",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3916,
       "coord": [-76.8213544, 42.1296903],
@@ -22679,7 +22679,7 @@
     "place": {
       "name": "Elmira",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26523,
       "coord": [-76.8077338, 42.0897965],
@@ -22698,7 +22698,7 @@
     "place": {
       "name": "Elmore",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1370,
       "coord": [-83.2957584, 41.4761621],
@@ -22717,7 +22717,7 @@
     "place": {
       "name": "Elmwood",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2058,
       "coord": [-89.9665017, 40.7778151],
@@ -22736,7 +22736,7 @@
     "place": {
       "name": "Elmwood",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 654,
       "coord": [-96.2920245, 40.8447737],
@@ -22755,7 +22755,7 @@
     "place": {
       "name": "Eloy",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15635,
       "coord": [-111.553493, 32.7551703],
@@ -22774,7 +22774,7 @@
     "place": {
       "name": "Elsie",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 930,
       "coord": [-84.386926, 43.088639],
@@ -22793,7 +22793,7 @@
     "place": {
       "name": "Elsmere",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9159,
       "coord": [-84.6046663, 39.0125608],
@@ -22812,7 +22812,7 @@
     "place": {
       "name": "Elverson",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1332,
       "coord": [-75.8327088, 40.1567641],
@@ -22839,7 +22839,7 @@
     "place": {
       "name": "Elwood",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1173,
       "coord": [-112.1410625, 41.6904847],
@@ -22858,7 +22858,7 @@
     "place": {
       "name": "Ely",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2328,
       "coord": [-91.5854027, 41.8726859],
@@ -22877,7 +22877,7 @@
     "place": {
       "name": "Elyria",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 52656,
       "coord": [-82.1073583, 41.3673191],
@@ -22896,7 +22896,7 @@
     "place": {
       "name": "Emeryville",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12000,
       "coord": [-122.2865266, 37.8314089],
@@ -22923,7 +22923,7 @@
     "place": {
       "name": "Emily",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 843,
       "coord": [-93.9580296, 46.7310714],
@@ -22950,7 +22950,7 @@
     "place": {
       "name": "Emmaus",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11652,
       "coord": [-75.4968502, 40.5395421],
@@ -22977,7 +22977,7 @@
     "place": {
       "name": "Emmitsburg",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2776,
       "coord": [-77.3269307, 39.7045417],
@@ -22996,7 +22996,7 @@
     "place": {
       "name": "Emporia",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24139,
       "coord": [-96.181623, 38.4040054],
@@ -23015,7 +23015,7 @@
     "place": {
       "name": "Endicott",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13667,
       "coord": [-76.0493684, 42.098408],
@@ -23042,7 +23042,7 @@
     "place": {
       "name": "Enfield",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 42141,
       "coord": [-72.5755109, 41.9789387],
@@ -23069,7 +23069,7 @@
     "place": {
       "name": "Englewood",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 33659,
       "coord": [-104.9879641, 39.6482059],
@@ -23110,7 +23110,7 @@
     "place": {
       "name": "Enid",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 51308,
       "coord": [-97.8791341, 36.3967623],
@@ -23129,7 +23129,7 @@
     "place": {
       "name": "Ennis",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 917,
       "coord": [-111.729697, 45.348817],
@@ -23148,7 +23148,7 @@
     "place": {
       "name": "Enniskillen",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 2825,
       "coord": [-82.12092093321893, 42.84490035],
@@ -23167,7 +23167,7 @@
     "place": {
       "name": "Enterprise",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28711,
       "coord": [-85.8552161, 31.3151708],
@@ -23186,7 +23186,7 @@
     "place": {
       "name": "Ephrata",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13818,
       "coord": [-76.1789242, 40.1799111],
@@ -23213,7 +23213,7 @@
     "place": {
       "name": "Epworth",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2023,
       "coord": [-90.9320766, 42.4450016],
@@ -23232,7 +23232,7 @@
     "place": {
       "name": "Erie",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30038,
       "coord": [-105.103950959155, 40.0146297],
@@ -23251,7 +23251,7 @@
     "place": {
       "name": "Erie",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1518,
       "coord": [-90.0790166, 41.6563287],
@@ -23270,7 +23270,7 @@
     "place": {
       "name": "Erie",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 94831,
       "coord": [-80.0852695, 42.1294712],
@@ -23297,7 +23297,7 @@
     "place": {
       "name": "Erlanger",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19611,
       "coord": [-84.6007773, 39.0167275],
@@ -23316,7 +23316,7 @@
     "place": {
       "name": "Escanaba",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12450,
       "coord": [-87.0647434, 45.7455707],
@@ -23335,7 +23335,7 @@
     "place": {
       "name": "Escondido",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 151038,
       "coord": [-117.0814849, 33.1216751],
@@ -23354,7 +23354,7 @@
     "place": {
       "name": "Essex",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6733,
       "coord": [-72.3906406, 41.353432],
@@ -23373,7 +23373,7 @@
     "place": {
       "name": "Essex",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 21216,
       "coord": [-82.7120106, 42.2354142],
@@ -23392,7 +23392,7 @@
     "place": {
       "name": "Estancia",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1242,
       "coord": [-106.05585, 34.7583935],
@@ -23411,7 +23411,7 @@
     "place": {
       "name": "Estes Park",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5904,
       "coord": [-105.52161, 40.376618],
@@ -23430,7 +23430,7 @@
     "place": {
       "name": "Estherville",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5904,
       "coord": [-94.8363599, 43.4026638],
@@ -23449,7 +23449,7 @@
     "place": {
       "name": "Etna",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3437,
       "coord": [-79.9484404, 40.5035986],
@@ -23476,7 +23476,7 @@
     "place": {
       "name": "Eugene",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 172622,
       "coord": [-123.0950506, 44.0505054],
@@ -23509,7 +23509,7 @@
     "place": {
       "name": "Eunice",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9422,
       "coord": [-92.4176324, 30.4943669],
@@ -23528,7 +23528,7 @@
     "place": {
       "name": "Eupora",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2018,
       "coord": [-89.2670124, 33.5406769],
@@ -23547,7 +23547,7 @@
     "place": {
       "name": "Eureka Springs",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2166,
       "coord": [-93.7392419, 36.4000796],
@@ -23566,7 +23566,7 @@
     "place": {
       "name": "Eureka",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26512,
       "coord": [-124.1673746, 40.7906871],
@@ -23610,7 +23610,7 @@
     "place": {
       "name": "Eureka",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2332,
       "coord": [-96.2891703, 37.8239167],
@@ -23629,7 +23629,7 @@
     "place": {
       "name": "Evanston",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 73979,
       "coord": [-87.6930459, 42.0447388],
@@ -23656,7 +23656,7 @@
     "place": {
       "name": "Evanston",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11747,
       "coord": [-110.963758, 41.2682462],
@@ -23683,7 +23683,7 @@
     "place": {
       "name": "Evansville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 118414,
       "coord": [-87.5558483, 37.9747645],
@@ -23710,7 +23710,7 @@
     "place": {
       "name": "Evansville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5703,
       "coord": [-89.2992249, 42.7803486],
@@ -23735,7 +23735,7 @@
     "place": {
       "name": "Evart",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1742,
       "coord": [-85.258097, 43.900575],
@@ -23768,7 +23768,7 @@
     "place": {
       "name": "Evergreen Park",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19943,
       "coord": [-87.7013258, 41.720136],
@@ -23787,7 +23787,7 @@
     "place": {
       "name": "Everly",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 575,
       "coord": [-95.3271691, 43.1602693],
@@ -23806,7 +23806,7 @@
     "place": {
       "name": "Excelsior Springs",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10553,
       "coord": [-94.2223507, 39.3417244],
@@ -23825,7 +23825,7 @@
     "place": {
       "name": "Excelsior",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2414,
       "coord": [-93.5663455, 44.9032963],
@@ -23852,7 +23852,7 @@
     "place": {
       "name": "Eyota",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2006,
       "coord": [-92.2292396, 43.9887507],
@@ -23871,7 +23871,7 @@
     "place": {
       "name": "Factoryville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1146,
       "coord": [-75.7826932, 41.5631327],
@@ -23890,7 +23890,7 @@
     "place": {
       "name": "Fair Grove",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1582,
       "coord": [-93.1512961, 37.3839335],
@@ -23909,7 +23909,7 @@
     "place": {
       "name": "Fairborn",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 34620,
       "coord": [-84.0193858, 39.8208998],
@@ -23942,7 +23942,7 @@
     "place": {
       "name": "Fairbury",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3633,
       "coord": [-88.5147789, 40.7472566],
@@ -23961,7 +23961,7 @@
     "place": {
       "name": "Fairbury",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3970,
       "coord": [-97.180591, 40.137225],
@@ -23980,7 +23980,7 @@
     "place": {
       "name": "Fairfax County",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 1150309,
       "coord": [-77.2836849, 38.8156356],
@@ -24007,7 +24007,7 @@
     "place": {
       "name": "Fairfax",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2828,
       "coord": [-91.7810132, 41.9194471],
@@ -24026,7 +24026,7 @@
     "place": {
       "name": "Fairfield",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10000,
       "coord": [-86.9150283, 33.4916836],
@@ -24045,7 +24045,7 @@
     "place": {
       "name": "Fairfield",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 61512,
       "coord": [-73.2637258, 41.1412078],
@@ -24068,7 +24068,7 @@
     "place": {
       "name": "Fairfield",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4778,
       "coord": [-88.3597684, 38.378937],
@@ -24087,7 +24087,7 @@
     "place": {
       "name": "Fairhope",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22477,
       "coord": [-87.9028458, 30.5231647],
@@ -24122,7 +24122,7 @@
     "place": {
       "name": "Fairmont",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18313,
       "coord": [-80.1425781, 39.4850848],
@@ -24149,7 +24149,7 @@
     "place": {
       "name": "Fairview",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10424,
       "coord": [-122.4330512, 45.5385457],
@@ -24168,7 +24168,7 @@
     "place": {
       "name": "Fairwater",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 350,
       "coord": [-88.8670556, 43.7438722],
@@ -24187,7 +24187,7 @@
     "place": {
       "name": "Falcon Heights",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5369,
       "coord": [-93.1762507, 44.9898128],
@@ -24206,7 +24206,7 @@
     "place": {
       "name": "Falconer",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2284,
       "coord": [-79.19838, 42.11867],
@@ -24225,7 +24225,7 @@
     "place": {
       "name": "Falkville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1197,
       "coord": [-86.908616, 34.3684295],
@@ -24244,7 +24244,7 @@
     "place": {
       "name": "Fallon",
       "state": "NV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9327,
       "coord": [-118.777895, 39.4745166],
@@ -24263,7 +24263,7 @@
     "place": {
       "name": "Falls City",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4133,
       "coord": [-95.6019294, 40.0608352],
@@ -24282,7 +24282,7 @@
     "place": {
       "name": "Fallston",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 259,
       "coord": [-80.3156183, 40.7256212],
@@ -24301,7 +24301,7 @@
     "place": {
       "name": "Fargo",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 124662,
       "coord": [-96.789821, 46.877229],
@@ -24320,7 +24320,7 @@
     "place": {
       "name": "Faribault",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24453,
       "coord": [-93.268319, 44.290589],
@@ -24339,7 +24339,7 @@
     "place": {
       "name": "Farley",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1766,
       "coord": [-91.0063067, 42.4428009],
@@ -24358,7 +24358,7 @@
     "place": {
       "name": "Farmerville",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3366,
       "coord": [-92.4056986, 32.7734728],
@@ -24377,7 +24377,7 @@
     "place": {
       "name": "Farmington",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26712,
       "coord": [-72.8320435, 41.7198216],
@@ -24396,7 +24396,7 @@
     "place": {
       "name": "Farmington",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11594,
       "coord": [-83.3763219, 42.4644795],
@@ -24415,7 +24415,7 @@
     "place": {
       "name": "Farmington",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23632,
       "coord": [-93.1435497, 44.6402434],
@@ -24434,7 +24434,7 @@
     "place": {
       "name": "Farmington",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 46624,
       "coord": [-108.205445, 36.7291152],
@@ -24453,7 +24453,7 @@
     "place": {
       "name": "Farmington",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24531,
       "coord": [-111.8874688, 40.9804423],
@@ -24472,7 +24472,7 @@
     "place": {
       "name": "Faro",
       "state": "YT",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 440,
       "coord": [-133.355315, 62.2295409],
@@ -24491,7 +24491,7 @@
     "place": {
       "name": "Fayette",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4285,
       "coord": [-87.8309399444082, 33.68464047847105],
@@ -24510,7 +24510,7 @@
     "place": {
       "name": "Fayetteville",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 87590,
       "coord": [-94.1574328, 36.0625843],
@@ -24545,7 +24545,7 @@
     "place": {
       "name": "Fayetteville",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 208501,
       "coord": [-78.878292, 35.0525759],
@@ -24580,7 +24580,7 @@
     "place": {
       "name": "Fayetteville",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2887,
       "coord": [-81.1039858, 38.0531294],
@@ -24599,7 +24599,7 @@
     "place": {
       "name": "Federalsburg",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2833,
       "coord": [-75.7731132, 38.6940347],
@@ -24618,7 +24618,7 @@
     "place": {
       "name": "Fenton",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12050,
       "coord": [-83.7049498, 42.7978061],
@@ -24645,7 +24645,7 @@
     "place": {
       "name": "Fergus Falls",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14119,
       "coord": [-96.077558, 46.283015],
@@ -24664,7 +24664,7 @@
     "place": {
       "name": "Ferguson Township",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19009,
       "coord": [-77.9264336035163, 40.75351635],
@@ -24683,7 +24683,7 @@
     "place": {
       "name": "Ferguson",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18527,
       "coord": [-90.3038975, 38.744707],
@@ -24702,7 +24702,7 @@
     "place": {
       "name": "Fernandina Beach",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13169,
       "coord": [-81.4625919, 30.6696818],
@@ -24721,7 +24721,7 @@
     "place": {
       "name": "Ferndale",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19190,
       "coord": [-83.1346478, 42.4605917],
@@ -24748,7 +24748,7 @@
     "place": {
       "name": "Ferndale",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14043,
       "coord": [-122.589723, 48.8466698],
@@ -24788,7 +24788,7 @@
     "place": {
       "name": "Ferrysburg",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2952,
       "coord": [-86.21818, 43.080764],
@@ -24815,7 +24815,7 @@
     "place": {
       "name": "Findlay",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40313,
       "coord": [-83.6503982, 41.0413873],
@@ -24842,7 +24842,7 @@
     "place": {
       "name": "Firestone",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16381,
       "coord": [-104.933109288812, 40.1420303],
@@ -24861,7 +24861,7 @@
     "place": {
       "name": "Firth",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 649,
       "coord": [-96.606415, 40.532789],
@@ -24880,7 +24880,7 @@
     "place": {
       "name": "Fishers",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 98977,
       "coord": [-86.0138729, 39.9555928],
@@ -24899,7 +24899,7 @@
     "place": {
       "name": "Fishkill",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2166,
       "coord": [-73.898702, 41.5355745],
@@ -24918,7 +24918,7 @@
     "place": {
       "name": "Fitchburg",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29609,
       "coord": [-89.423817, 43.0020919],
@@ -24937,7 +24937,7 @@
     "place": {
       "name": "Flagstaff",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 76831,
       "coord": [-111.651822, 35.1987522],
@@ -24956,7 +24956,7 @@
     "place": {
       "name": "Flandreau",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2372,
       "coord": [-96.595324, 44.049416],
@@ -24975,7 +24975,7 @@
     "place": {
       "name": "Flemington",
       "state": "NJ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4601,
       "coord": [-74.8591333, 40.5130953],
@@ -24994,7 +24994,7 @@
     "place": {
       "name": "Flensburg",
       "state": "SH",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 92550,
       "coord": [9.4333264, 54.7833021],
@@ -25013,7 +25013,7 @@
     "place": {
       "name": "Flint Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31447,
       "coord": [-83.7749155430448, 43.00198765],
@@ -25032,7 +25032,7 @@
     "place": {
       "name": "Flint",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 95999,
       "coord": [-83.6900211, 43.0161693],
@@ -25067,7 +25067,7 @@
     "place": {
       "name": "Flora",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4803,
       "coord": [-88.4856042, 38.6689364],
@@ -25086,7 +25086,7 @@
     "place": {
       "name": "Florence",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40797,
       "coord": [-87.677251, 34.79981],
@@ -25105,7 +25105,7 @@
     "place": {
       "name": "Florence",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26785,
       "coord": [-111.387343, 33.0314508],
@@ -25140,7 +25140,7 @@
     "place": {
       "name": "Florence",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3822,
       "coord": [-105.1185988, 38.3902777],
@@ -25167,7 +25167,7 @@
     "place": {
       "name": "Florida",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "state",
       "pop": 21538187,
       "coord": [-81.5859, 27.9014],
@@ -25194,7 +25194,7 @@
     "place": {
       "name": "Florissant",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 52533,
       "coord": [-90.3227803, 38.7919683],
@@ -25213,7 +25213,7 @@
     "place": {
       "name": "Flushing",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8411,
       "coord": [-83.8510732, 43.0630834],
@@ -25232,7 +25232,7 @@
     "place": {
       "name": "Folcroft",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6792,
       "coord": [-75.279725, 39.9005526],
@@ -25251,7 +25251,7 @@
     "place": {
       "name": "Foley",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20335,
       "coord": [-87.6835974, 30.4065868],
@@ -25270,7 +25270,7 @@
     "place": {
       "name": "Foley",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2711,
       "coord": [-93.9137277, 45.663512],
@@ -25289,7 +25289,7 @@
     "place": {
       "name": "Fond du Lac",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 44678,
       "coord": [-88.4458033, 43.7748763],
@@ -25322,7 +25322,7 @@
     "place": {
       "name": "Fontana",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 212704,
       "coord": [-117.4343301, 34.0922947],
@@ -25341,7 +25341,7 @@
     "place": {
       "name": "Fontana-on-Geneva Lake",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3120,
       "coord": [-88.5751007, 42.5514056],
@@ -25365,7 +25365,7 @@
     "place": {
       "name": "Ford City",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2859,
       "coord": [-79.5317734, 40.7694379],
@@ -25392,7 +25392,7 @@
     "place": {
       "name": "Ford Heights",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1813,
       "coord": [-87.5917092, 41.506424],
@@ -25419,7 +25419,7 @@
     "place": {
       "name": "Forest Grove",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26225,
       "coord": [-123.1110551, 45.5190404],
@@ -25460,7 +25460,7 @@
     "place": {
       "name": "Forest Hills",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6429,
       "coord": [-79.8500487, 40.4197911],
@@ -25487,7 +25487,7 @@
     "place": {
       "name": "Forest Lake",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20611,
       "coord": [-92.9851629, 45.279106],
@@ -25506,7 +25506,7 @@
     "place": {
       "name": "Forest Park",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14339,
       "coord": [-87.8136997, 41.8794989],
@@ -25525,7 +25525,7 @@
     "place": {
       "name": "Forest View",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 792,
       "coord": [-87.7803976, 41.8103241],
@@ -25544,7 +25544,7 @@
     "place": {
       "name": "Forman",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 509,
       "coord": [-97.636486, 46.107742],
@@ -25563,7 +25563,7 @@
     "place": {
       "name": "Forrest City",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13015,
       "coord": [-90.7898342, 35.0081474],
@@ -25582,7 +25582,7 @@
     "place": {
       "name": "Forsyth",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1647,
       "coord": [-106.677812, 46.266384],
@@ -25601,7 +25601,7 @@
     "place": {
       "name": "Fort Atkinson",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12579,
       "coord": [-88.8370509, 42.9288944],
@@ -25634,7 +25634,7 @@
     "place": {
       "name": "Fort Bragg",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6983,
       "coord": [-123.8057607, 39.4436579],
@@ -25668,7 +25668,7 @@
     "place": {
       "name": "Fort Calhoun",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1108,
       "coord": [-96.0264024, 41.4558282],
@@ -25687,7 +25687,7 @@
     "place": {
       "name": "Fort Collins",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 169810,
       "coord": [-105.0770113, 40.5871782],
@@ -25720,7 +25720,7 @@
     "place": {
       "name": "Fort Dodge",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24871,
       "coord": [-94.1910044, 42.5044017],
@@ -25739,7 +25739,7 @@
     "place": {
       "name": "Fort Frances",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 7470,
       "coord": [-93.3967615, 48.6114425],
@@ -25758,7 +25758,7 @@
     "place": {
       "name": "Fort Lauderdale",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 182437,
       "coord": [-80.1433786, 26.1223084],
@@ -25785,7 +25785,7 @@
     "place": {
       "name": "Fort Lupton",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7955,
       "coord": [-104.813027, 40.0847055],
@@ -25820,7 +25820,7 @@
     "place": {
       "name": "Fort Madison",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10270,
       "coord": [-91.3084007, 40.6311415],
@@ -25839,7 +25839,7 @@
     "place": {
       "name": "Fort Mill",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24521,
       "coord": [-80.9450759, 35.0073697],
@@ -25866,7 +25866,7 @@
     "place": {
       "name": "Fort Mitchell",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8702,
       "coord": [-84.5474432, 39.0595047],
@@ -25885,7 +25885,7 @@
     "place": {
       "name": "Fort Morgan",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11597,
       "coord": [-103.799951, 40.2502582],
@@ -25904,7 +25904,7 @@
     "place": {
       "name": "Fort Myers",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 86395,
       "coord": [-81.8723084, 26.640628],
@@ -25931,7 +25931,7 @@
     "place": {
       "name": "Fort Payne",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14877,
       "coord": [-85.7196893, 34.4442547],
@@ -25950,7 +25950,7 @@
     "place": {
       "name": "Fort Recovery",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1501,
       "coord": [-84.7763511, 40.4128241],
@@ -25969,7 +25969,7 @@
     "place": {
       "name": "Fort Simpson",
       "state": "NT",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1100,
       "coord": [-121.354276, 61.8631427],
@@ -25988,7 +25988,7 @@
     "place": {
       "name": "Fort Smith",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 89142,
       "coord": [-94.3996456, 35.3784666],
@@ -26023,7 +26023,7 @@
     "place": {
       "name": "Fort St. John",
       "state": "BC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 21465,
       "coord": [-120.846943, 56.2524039],
@@ -26050,7 +26050,7 @@
     "place": {
       "name": "Fort Stockton",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8466,
       "coord": [-102.883662, 30.891901],
@@ -26069,7 +26069,7 @@
     "place": {
       "name": "Fort Wayne",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 263886,
       "coord": [-85.1386015, 41.0799898],
@@ -26104,7 +26104,7 @@
     "place": {
       "name": "Fort Worth",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 909585,
       "coord": [-97.3327459, 32.753177],
@@ -26131,7 +26131,7 @@
     "place": {
       "name": "Fort Wright",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5851,
       "coord": [-84.5341096, 39.0517272],
@@ -26150,7 +26150,7 @@
     "place": {
       "name": "Fostoria",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13046,
       "coord": [-83.4141061, 41.1574297],
@@ -26169,7 +26169,7 @@
     "place": {
       "name": "Fountain Hills",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23820,
       "coord": [-111.717361, 33.6117105],
@@ -26196,7 +26196,7 @@
     "place": {
       "name": "Fountain Inn",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10441,
       "coord": [-82.19889996, 34.6912995],
@@ -26222,7 +26222,7 @@
     "place": {
       "name": "Fowlerville",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2951,
       "coord": [-84.0730142, 42.6605894],
@@ -26241,7 +26241,7 @@
     "place": {
       "name": "Fox Crossing",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18974,
       "coord": [-88.4700616, 44.2234752],
@@ -26260,7 +26260,7 @@
     "place": {
       "name": "Fox Lake",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10978,
       "coord": [-88.1836965, 42.3966874],
@@ -26279,7 +26279,7 @@
     "place": {
       "name": "Fox Lake",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1604,
       "coord": [-88.9064984, 43.565543],
@@ -26298,7 +26298,7 @@
     "place": {
       "name": "Fox River Grove",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4702,
       "coord": [-88.2145259, 42.2008575],
@@ -26325,7 +26325,7 @@
     "place": {
       "name": "Framingham",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 74416,
       "coord": [-71.4413097, 42.3095704],
@@ -26344,7 +26344,7 @@
     "place": {
       "name": "France",
       "state": null,
-      "country": "FR",
+      "country": "France",
       "type": "country",
       "pop": 68373433,
       "coord": [1.8883335, 46.603354],
@@ -26363,7 +26363,7 @@
     "place": {
       "name": "Frankenmuth",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4987,
       "coord": [-83.7392288, 43.3323684],
@@ -26382,7 +26382,7 @@
     "place": {
       "name": "Frankfort",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20296,
       "coord": [-87.8486613, 41.4958665],
@@ -26401,7 +26401,7 @@
     "place": {
       "name": "Frankfort",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27755,
       "coord": [-84.8732836, 38.2009055],
@@ -26420,7 +26420,7 @@
     "place": {
       "name": "Frankfurt",
       "state": "HE",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 773068,
       "coord": [8.6820917, 50.1106444],
@@ -26447,7 +26447,7 @@
     "place": {
       "name": "Franklin Park",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18467,
       "coord": [-87.865618, 41.9353084],
@@ -26474,7 +26474,7 @@
     "place": {
       "name": "Franklin",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 590,
       "coord": [-85.79493023785146, 32.44536618144399],
@@ -26493,7 +26493,7 @@
     "place": {
       "name": "Franklin",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25313,
       "coord": [-86.055198, 39.480528],
@@ -26512,7 +26512,7 @@
     "place": {
       "name": "Franklin",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6728,
       "coord": [-91.500636, 29.792515],
@@ -26531,7 +26531,7 @@
     "place": {
       "name": "Franklin",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 941,
       "coord": [-98.952581, 40.096124],
@@ -26550,7 +26550,7 @@
     "place": {
       "name": "Franklin",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6097,
       "coord": [-79.829305, 41.397661],
@@ -26569,7 +26569,7 @@
     "place": {
       "name": "Franklin",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36816,
       "coord": [-88.0384183, 42.888627],
@@ -26596,7 +26596,7 @@
     "place": {
       "name": "Franklinville",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1652,
       "coord": [-78.4580762, 42.3370091],
@@ -26615,7 +26615,7 @@
     "place": {
       "name": "Frazee",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1335,
       "coord": [-95.7001391, 46.7278049],
@@ -26634,7 +26634,7 @@
     "place": {
       "name": "Frazeysburg",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1354,
       "coord": [-82.1193076, 40.1172905],
@@ -26653,7 +26653,7 @@
     "place": {
       "name": "Frederic",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1154,
       "coord": [-92.4671434, 45.6591194],
@@ -26672,7 +26672,7 @@
     "place": {
       "name": "Frederica",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1073,
       "coord": [-75.4657542, 39.0090017],
@@ -26691,7 +26691,7 @@
     "place": {
       "name": "Frederick",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 78171,
       "coord": [-77.4127562, 39.415779],
@@ -26731,7 +26731,7 @@
     "place": {
       "name": "Fredericktown",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2648,
       "coord": [-82.5407213, 40.4811721],
@@ -26750,7 +26750,7 @@
     "place": {
       "name": "Fredonia",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2151,
       "coord": [-95.8266483, 37.5339386],
@@ -26769,7 +26769,7 @@
     "place": {
       "name": "Fredonia",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9871,
       "coord": [-79.331711, 42.440058],
@@ -26788,7 +26788,7 @@
     "place": {
       "name": "Fredonia",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2280,
       "coord": [-87.9470232, 43.4705105],
@@ -26807,7 +26807,7 @@
     "place": {
       "name": "Freeland",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3833,
       "coord": [-75.8971431, 41.0167508],
@@ -26826,7 +26826,7 @@
     "place": {
       "name": "Freeport",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23930,
       "coord": [-89.6212271, 42.2966861],
@@ -26845,7 +26845,7 @@
     "place": {
       "name": "Freeport",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 542,
       "coord": [-85.3133439, 42.7661449],
@@ -26864,7 +26864,7 @@
     "place": {
       "name": "Freeport",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10696,
       "coord": [-95.3596617, 28.9541368],
@@ -26883,7 +26883,7 @@
     "place": {
       "name": "Fremantle",
       "state": "WA",
-      "country": "AU",
+      "country": "Australia",
       "type": "city",
       "pop": 31930,
       "coord": [115.7586172, -32.0534086],
@@ -26902,7 +26902,7 @@
     "place": {
       "name": "Fremont",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 241110,
       "coord": [-121.988571, 37.5482697],
@@ -26929,7 +26929,7 @@
     "place": {
       "name": "Fremont",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4516,
       "coord": [-85.942001, 43.467517],
@@ -26956,7 +26956,7 @@
     "place": {
       "name": "Fremont",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27141,
       "coord": [-96.4960449, 41.4338363],
@@ -26975,7 +26975,7 @@
     "place": {
       "name": "Fremont",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15930,
       "coord": [-83.1134972, 41.3473413],
@@ -26994,7 +26994,7 @@
     "place": {
       "name": "French River",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 2828,
       "coord": [-80.478969, 46.137975],
@@ -27013,7 +27013,7 @@
     "place": {
       "name": "Frenchtown Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21609,
       "coord": [-83.3576325, 41.9620784],
@@ -27032,7 +27032,7 @@
     "place": {
       "name": "Frenchtown",
       "state": "NJ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1370,
       "coord": [-75.0616084, 40.5264167],
@@ -27051,7 +27051,7 @@
     "place": {
       "name": "Fresno",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 531576,
       "coord": [-119.790012, 36.735788],
@@ -27070,7 +27070,7 @@
     "place": {
       "name": "Fridley",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29590,
       "coord": [-93.2590388, 45.0838291],
@@ -27097,7 +27097,7 @@
     "place": {
       "name": "Friesland",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 320,
       "coord": [-89.067335, 43.5885954],
@@ -27116,7 +27116,7 @@
     "place": {
       "name": "Frisco",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2913,
       "coord": [-106.105633869449, 39.58296495],
@@ -27155,7 +27155,7 @@
     "place": {
       "name": "Frisco",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 200509,
       "coord": [-96.8238183, 33.1505998],
@@ -27174,7 +27174,7 @@
     "place": {
       "name": "Frostburg",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7027,
       "coord": [-78.928357, 39.6581425],
@@ -27201,7 +27201,7 @@
     "place": {
       "name": "Fruita",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13478,
       "coord": [-108.7289883, 39.1588697],
@@ -27220,7 +27220,7 @@
     "place": {
       "name": "Fullerton",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 143617,
       "coord": [-117.929416, 33.8708215],
@@ -27239,7 +27239,7 @@
     "place": {
       "name": "Fullerton",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1244,
       "coord": [-97.968862, 41.3633844],
@@ -27258,7 +27258,7 @@
     "place": {
       "name": "Fulton",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12600,
       "coord": [-91.9479586, 38.8467082],
@@ -27277,7 +27277,7 @@
     "place": {
       "name": "Gadsden",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 33945,
       "coord": [-86.0030251, 34.0128323],
@@ -27296,7 +27296,7 @@
     "place": {
       "name": "Gaines Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28812,
       "coord": [-85.6049383, 42.8119453],
@@ -27315,7 +27315,7 @@
     "place": {
       "name": "Gaines",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 377,
       "coord": [-83.9141254, 42.8725303],
@@ -27334,7 +27334,7 @@
     "place": {
       "name": "Gainesville",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 140398,
       "coord": [-82.3249846, 29.6519684],
@@ -27353,7 +27353,7 @@
     "place": {
       "name": "Gaithersburg",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 67742,
       "coord": [-77.1929215, 39.1399187],
@@ -27372,7 +27372,7 @@
     "place": {
       "name": "Galena",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3168,
       "coord": [-90.4294726, 42.4157304],
@@ -27391,7 +27391,7 @@
     "place": {
       "name": "Galena",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2761,
       "coord": [-94.6390414, 37.0741519],
@@ -27410,7 +27410,7 @@
     "place": {
       "name": "Galesburg",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30052,
       "coord": [-90.3712169, 40.9475652],
@@ -27429,7 +27429,7 @@
     "place": {
       "name": "Galesburg",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2049,
       "coord": [-85.418056, 42.2886529],
@@ -27448,7 +27448,7 @@
     "place": {
       "name": "Galion",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10453,
       "coord": [-82.7896471, 40.733795],
@@ -27467,7 +27467,7 @@
     "place": {
       "name": "Gallipolis",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3313,
       "coord": [-82.2023691, 38.809803],
@@ -27486,7 +27486,7 @@
     "place": {
       "name": "Gallup",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21899,
       "coord": [-108.743907, 35.5283506],
@@ -27505,7 +27505,7 @@
     "place": {
       "name": "Galva",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2470,
       "coord": [-90.0455662, 41.1660682],
@@ -27524,7 +27524,7 @@
     "place": {
       "name": "Galveston",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 53695,
       "coord": [-94.79617956555118, 29.304782576375622],
@@ -27559,7 +27559,7 @@
     "place": {
       "name": "Gambier",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2213,
       "coord": [-82.3970994, 40.375643],
@@ -27586,7 +27586,7 @@
     "place": {
       "name": "Garden City",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28151,
       "coord": [-100.8726618, 37.9716898],
@@ -27605,7 +27605,7 @@
     "place": {
       "name": "Garden Grove",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 171949,
       "coord": [-117.9463717, 33.7746292],
@@ -27624,7 +27624,7 @@
     "place": {
       "name": "Garden Plain",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 948,
       "coord": [-97.6837167, 37.6585594],
@@ -27643,7 +27643,7 @@
     "place": {
       "name": "Gardner",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23287,
       "coord": [-94.9272958, 38.8109254],
@@ -27678,7 +27678,7 @@
     "place": {
       "name": "Garfield Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19499,
       "coord": [-85.644947, 44.713587],
@@ -27697,7 +27697,7 @@
     "place": {
       "name": "Garland",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 246018,
       "coord": [-96.6388833, 32.912624],
@@ -27716,7 +27716,7 @@
     "place": {
       "name": "Garnavillo",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 763,
       "coord": [-91.2359075, 42.8685683],
@@ -27735,7 +27735,7 @@
     "place": {
       "name": "Garrett",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6542,
       "coord": [-85.1355271, 41.3494927],
@@ -27754,7 +27754,7 @@
     "place": {
       "name": "Garrettsville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2449,
       "coord": [-81.096486, 41.284222],
@@ -27773,7 +27773,7 @@
     "place": {
       "name": "Gary",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 69093,
       "coord": [-87.3370647, 41.6020962],
@@ -27808,7 +27808,7 @@
     "place": {
       "name": "Gas City",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6157,
       "coord": [-85.6125667, 40.4880229],
@@ -27827,7 +27827,7 @@
     "place": {
       "name": "Gastonia",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 80411,
       "coord": [-81.1838186, 35.2622654],
@@ -27854,7 +27854,7 @@
     "place": {
       "name": "Gaylord",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2273,
       "coord": [-94.220531, 44.5530201],
@@ -27873,7 +27873,7 @@
     "place": {
       "name": "Gays Mills",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 523,
       "coord": [-90.8448502, 43.3174788],
@@ -27892,7 +27892,7 @@
     "place": {
       "name": "Gem Lake",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 528,
       "coord": [-93.0324403, 45.057466],
@@ -27911,7 +27911,7 @@
     "place": {
       "name": "Geneva",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21393,
       "coord": [-88.3053525, 41.8875281],
@@ -27930,7 +27930,7 @@
     "place": {
       "name": "Geneva",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12812,
       "coord": [-76.9786122, 42.8690271],
@@ -27949,7 +27949,7 @@
     "place": {
       "name": "Genoa Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20692,
       "coord": [-83.8528919, 42.5567513],
@@ -27976,7 +27976,7 @@
     "place": {
       "name": "Genoa City",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2982,
       "coord": [-88.3281487, 42.4983517],
@@ -27995,7 +27995,7 @@
     "place": {
       "name": "Genoa",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5298,
       "coord": [-88.6928688, 42.097248],
@@ -28014,7 +28014,7 @@
     "place": {
       "name": "Genoa",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 894,
       "coord": [-97.7307364, 41.4486334],
@@ -28033,7 +28033,7 @@
     "place": {
       "name": "Genoa",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2232,
       "coord": [-83.359094, 41.5181064],
@@ -28052,7 +28052,7 @@
     "place": {
       "name": "George",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1077,
       "coord": [-96.0022965, 43.3436751],
@@ -28071,7 +28071,7 @@
     "place": {
       "name": "Georgetown Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 54091,
       "coord": [-85.8421530691749, 42.90567255],
@@ -28090,7 +28090,7 @@
     "place": {
       "name": "Georgetown",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1118,
       "coord": [-105.697125, 39.7062268],
@@ -28109,7 +28109,7 @@
     "place": {
       "name": "Georgetown",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 503,
       "coord": [-111.3703902, 42.4764425],
@@ -28128,7 +28128,7 @@
     "place": {
       "name": "Georgian Bay",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 3441,
       "coord": [-79.849792, 45.001216],
@@ -28147,7 +28147,7 @@
     "place": {
       "name": "Georgian Bluffs",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 11100,
       "coord": [-81.00872535041186, 44.68872225],
@@ -28166,7 +28166,7 @@
     "place": {
       "name": "Gerald",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1361,
       "coord": [-91.3307094, 38.3997711],
@@ -28185,7 +28185,7 @@
     "place": {
       "name": "Gering",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8564,
       "coord": [-103.66037, 41.8226927],
@@ -28220,7 +28220,7 @@
     "place": {
       "name": "Germantown",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 41333,
       "coord": [-89.8100858, 35.0867577],
@@ -28247,7 +28247,7 @@
     "place": {
       "name": "Gettysburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7106,
       "coord": [-77.231012, 39.8308973],
@@ -28274,7 +28274,7 @@
     "place": {
       "name": "Gibsonburg",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2452,
       "coord": [-83.3199072, 41.384702],
@@ -28293,7 +28293,7 @@
     "place": {
       "name": "Gilbert",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 267918,
       "coord": [-111.789037, 33.3527632],
@@ -28312,7 +28312,7 @@
     "place": {
       "name": "Gillette",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 33403,
       "coord": [-105.501876, 44.290635],
@@ -28331,7 +28331,7 @@
     "place": {
       "name": "Gilman",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 444,
       "coord": [-90.8076338, 45.1666382],
@@ -28350,7 +28350,7 @@
     "place": {
       "name": "Gladwin",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3069,
       "coord": [-84.3873235, 43.9747774],
@@ -28383,7 +28383,7 @@
     "place": {
       "name": "Glasford",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 866,
       "coord": [-89.813442, 40.5725386],
@@ -28402,7 +28402,7 @@
     "place": {
       "name": "Glastonbury",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35159,
       "coord": [-72.608146, 41.7123218],
@@ -28421,7 +28421,7 @@
     "place": {
       "name": "Glen Carbon",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13842,
       "coord": [-89.983158, 38.7483814],
@@ -28440,7 +28440,7 @@
     "place": {
       "name": "Glen Dale",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1514,
       "coord": [-80.7542517, 39.9492409],
@@ -28459,7 +28459,7 @@
     "place": {
       "name": "Glen Ellyn",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28846,
       "coord": [-88.0670118, 41.8775293],
@@ -28478,7 +28478,7 @@
     "place": {
       "name": "Glencoe",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8849,
       "coord": [-87.7581188, 42.1350268],
@@ -28497,7 +28497,7 @@
     "place": {
       "name": "Glencoe",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5744,
       "coord": [-94.1515671, 44.7691886],
@@ -28521,7 +28521,7 @@
     "place": {
       "name": "Glendale",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 248325,
       "coord": [-112.185994, 33.5386858],
@@ -28540,7 +28540,7 @@
     "place": {
       "name": "Glendale",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 196543,
       "coord": [-118.2478471, 34.1469416],
@@ -28567,7 +28567,7 @@
     "place": {
       "name": "Glendale",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4613,
       "coord": [-104.933508, 39.7048155],
@@ -28586,7 +28586,7 @@
     "place": {
       "name": "Glendale",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2298,
       "coord": [-84.4593871, 39.2706134],
@@ -28605,7 +28605,7 @@
     "place": {
       "name": "Glendale",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13357,
       "coord": [-87.9285922, 43.1250236],
@@ -28624,7 +28624,7 @@
     "place": {
       "name": "Glendive",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4873,
       "coord": [-104.71246, 47.10529],
@@ -28643,7 +28643,7 @@
     "place": {
       "name": "Glenfield",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 212,
       "coord": [-80.130335, 40.5181237],
@@ -28662,7 +28662,7 @@
     "place": {
       "name": "Glenrock",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2420,
       "coord": [-105.8720412, 42.8614825],
@@ -28681,7 +28681,7 @@
     "place": {
       "name": "Glenview",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 48705,
       "coord": [-87.8114044, 42.0700662],
@@ -28700,7 +28700,7 @@
     "place": {
       "name": "Glenwood Springs",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9963,
       "coord": [-107.3255001, 39.5507448],
@@ -28735,7 +28735,7 @@
     "place": {
       "name": "Glenwood",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5073,
       "coord": [-95.7425055, 41.0469437],
@@ -28754,7 +28754,7 @@
     "place": {
       "name": "Glenwood",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8662,
       "coord": [-87.6022765, 41.5424867],
@@ -28781,7 +28781,7 @@
     "place": {
       "name": "Glidden",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1151,
       "coord": [-94.72887, 42.0569297],
@@ -28800,7 +28800,7 @@
     "place": {
       "name": "Globe",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7249,
       "coord": [-110.7871744, 33.3959139],
@@ -28819,7 +28819,7 @@
     "place": {
       "name": "Goddard",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5084,
       "coord": [-97.5753256, 37.6597363],
@@ -28838,7 +28838,7 @@
     "place": {
       "name": "Goderich",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 7881,
       "coord": [-81.7110949, 43.7430924],
@@ -28857,7 +28857,7 @@
     "place": {
       "name": "Goehner",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 181,
       "coord": [-97.2208576, 40.8334535],
@@ -28876,7 +28876,7 @@
     "place": {
       "name": "Gold Hill",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1335,
       "coord": [-123.050601, 42.431785],
@@ -28895,7 +28895,7 @@
     "place": {
       "name": "Golden Valley",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22552,
       "coord": [-93.3784618, 44.9861176],
@@ -28922,7 +28922,7 @@
     "place": {
       "name": "Golden",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20399,
       "coord": [-105.22058, 39.7546349],
@@ -28941,7 +28941,7 @@
     "place": {
       "name": "Golf",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 514,
       "coord": [-87.7899876, 42.0570448],
@@ -28960,7 +28960,7 @@
     "place": {
       "name": "Gonzales",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12231,
       "coord": [-90.9200987, 30.2385294],
@@ -28987,7 +28987,7 @@
     "place": {
       "name": "Good Thunder",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 560,
       "coord": [-94.0657885, 44.0046863],
@@ -29006,7 +29006,7 @@
     "place": {
       "name": "Goodfield",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 936,
       "coord": [-89.2748084, 40.6297593],
@@ -29030,7 +29030,7 @@
     "place": {
       "name": "Goodhue",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1250,
       "coord": [-92.623957, 44.3997031],
@@ -29049,7 +29049,7 @@
     "place": {
       "name": "Goodland",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4465,
       "coord": [-101.710172, 39.350833],
@@ -29068,7 +29068,7 @@
     "place": {
       "name": "Goodrich",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2022,
       "coord": [-83.501656, 42.91708],
@@ -29087,7 +29087,7 @@
     "place": {
       "name": "Goodyear",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 95294,
       "coord": [-112.3842224, 33.4674695],
@@ -29111,7 +29111,7 @@
     "place": {
       "name": "Gore Bay",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 808,
       "coord": [-82.4640868, 45.9167876],
@@ -29130,7 +29130,7 @@
     "place": {
       "name": "Gothenburg",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3478,
       "coord": [-100.1619896, 40.9277324],
@@ -29149,7 +29149,7 @@
     "place": {
       "name": "Gowrie",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 952,
       "coord": [-94.2908304, 42.2804998],
@@ -29168,7 +29168,7 @@
     "place": {
       "name": "Grafton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5895,
       "coord": [-82.0545892, 41.2725522],
@@ -29187,7 +29187,7 @@
     "place": {
       "name": "Grafton",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12094,
       "coord": [-87.9534226, 43.3197265],
@@ -29220,7 +29220,7 @@
     "place": {
       "name": "Graham",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15646,
       "coord": [-79.4005756, 36.0690258],
@@ -29247,7 +29247,7 @@
     "place": {
       "name": "Grain Valley",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15627,
       "coord": [-94.1976452, 39.0187651],
@@ -29266,7 +29266,7 @@
     "place": {
       "name": "Gramercy",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2932,
       "coord": [-90.6898128, 30.0474239],
@@ -29285,7 +29285,7 @@
     "place": {
       "name": "Granby",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2079,
       "coord": [-105.93836, 40.085318],
@@ -29304,7 +29304,7 @@
     "place": {
       "name": "Granby",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10903,
       "coord": [-72.789313, 41.9538298],
@@ -29323,7 +29323,7 @@
     "place": {
       "name": "Grand Blanc Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 39846,
       "coord": [-83.6664998627187, 42.91625695],
@@ -29342,7 +29342,7 @@
     "place": {
       "name": "Grand Forks",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 59166,
       "coord": [-97.0592028, 47.9078244],
@@ -29361,7 +29361,7 @@
     "place": {
       "name": "Grand Haven Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18004,
       "coord": [-86.1873361292366, 43.0029082],
@@ -29388,7 +29388,7 @@
     "place": {
       "name": "Grand Haven",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11011,
       "coord": [-86.2283864, 43.0630734],
@@ -29415,7 +29415,7 @@
     "place": {
       "name": "Grand Island",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 51267,
       "coord": [-98.338685, 40.924271],
@@ -29434,7 +29434,7 @@
     "place": {
       "name": "Grand Junction",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 65560,
       "coord": [-108.56448, 39.0672568],
@@ -29461,7 +29461,7 @@
     "place": {
       "name": "Grand Lake",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 410,
       "coord": [-105.823067, 40.2522073],
@@ -29480,7 +29480,7 @@
     "place": {
       "name": "Grand Ledge",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7784,
       "coord": [-84.7463572, 42.7524401],
@@ -29521,7 +29521,7 @@
     "place": {
       "name": "Grand Marais",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1337,
       "coord": [-90.334675, 47.750467],
@@ -29540,7 +29540,7 @@
     "place": {
       "name": "Grand Prairie",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 196100,
       "coord": [-96.9977846, 32.7459645],
@@ -29567,7 +29567,7 @@
     "place": {
       "name": "Grand Rapids",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 201013,
       "coord": [-85.6678639, 42.9632405],
@@ -29602,7 +29602,7 @@
     "place": {
       "name": "Grand Rapids",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11126,
       "coord": [-93.530214, 47.237166],
@@ -29621,7 +29621,7 @@
     "place": {
       "name": "Grand Rapids",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 925,
       "coord": [-83.8643852, 41.4119963],
@@ -29640,7 +29640,7 @@
     "place": {
       "name": "Grandview",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25844,
       "coord": [-94.5313816, 38.8898478],
@@ -29667,7 +29667,7 @@
     "place": {
       "name": "Grandville",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16083,
       "coord": [-85.7630956, 42.909598],
@@ -29694,7 +29694,7 @@
     "place": {
       "name": "Granger",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1654,
       "coord": [-93.8243925, 41.7610984],
@@ -29713,7 +29713,7 @@
     "place": {
       "name": "Granite Falls",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2737,
       "coord": [-95.5455752, 44.8099575],
@@ -29732,7 +29732,7 @@
     "place": {
       "name": "Granite Quarry",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2984,
       "coord": [-80.4467263, 35.6123617],
@@ -29751,7 +29751,7 @@
     "place": {
       "name": "Grant",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 952,
       "coord": [-85.810882, 43.336132],
@@ -29770,7 +29770,7 @@
     "place": {
       "name": "Grants Pass",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 39189,
       "coord": [-123.3272489, 42.4393707],
@@ -29789,7 +29789,7 @@
     "place": {
       "name": "Grantsville",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12617,
       "coord": [-112.463531, 40.6000817],
@@ -29808,7 +29808,7 @@
     "place": {
       "name": "Granville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5946,
       "coord": [-82.5196037, 40.0681192],
@@ -29835,7 +29835,7 @@
     "place": {
       "name": "Grass Lake Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6069,
       "coord": [-84.1902694219487, 42.24629875],
@@ -29854,7 +29854,7 @@
     "place": {
       "name": "Grass Lake",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1105,
       "coord": [-84.2130083, 42.2508691],
@@ -29873,7 +29873,7 @@
     "place": {
       "name": "Gravenhurst",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 13157,
       "coord": [-79.373131, 44.91741],
@@ -29900,7 +29900,7 @@
     "place": {
       "name": "Grayling Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5642,
       "coord": [-84.6067491730165, 44.68475225],
@@ -29919,7 +29919,7 @@
     "place": {
       "name": "Grayling",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1867,
       "coord": [-84.714637, 44.661517],
@@ -29946,7 +29946,7 @@
     "place": {
       "name": "Graymoor-Devondale",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2853,
       "coord": [-85.6159137, 38.2702877],
@@ -29985,7 +29985,7 @@
     "place": {
       "name": "Grayslake",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21248,
       "coord": [-88.0412192, 42.3433518],
@@ -30004,7 +30004,7 @@
     "place": {
       "name": "Grayson",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4730,
       "coord": [-83.95574, 33.8942729],
@@ -30031,7 +30031,7 @@
     "place": {
       "name": "Great Falls",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 60422,
       "coord": [-111.29189, 47.5048851],
@@ -30058,7 +30058,7 @@
     "place": {
       "name": "Greeley",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 108795,
       "coord": [-104.7091322, 40.4233142],
@@ -30093,7 +30093,7 @@
     "place": {
       "name": "Green Bay",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 104578,
       "coord": [-88.0125794, 44.5126379],
@@ -30112,7 +30112,7 @@
     "place": {
       "name": "Green Forest",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2972,
       "coord": [-93.4360189, 36.3353472],
@@ -30131,7 +30131,7 @@
     "place": {
       "name": "Green Mountain Falls",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 646,
       "coord": [-105.026694347603, 38.9339225],
@@ -30150,7 +30150,7 @@
     "place": {
       "name": "Green Oaks",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4128,
       "coord": [-87.91311828063661, 42.2979712],
@@ -30169,7 +30169,7 @@
     "place": {
       "name": "Green River",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11825,
       "coord": [-109.466473, 41.5290933],
@@ -30188,7 +30188,7 @@
     "place": {
       "name": "Green Springs",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1233,
       "coord": [-83.051583, 41.2561649],
@@ -30207,7 +30207,7 @@
     "place": {
       "name": "Greencastle",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4251,
       "coord": [-77.7277714, 39.790371],
@@ -30226,7 +30226,7 @@
     "place": {
       "name": "Greendale",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4602,
       "coord": [-84.851040775, 39.13130615],
@@ -30245,7 +30245,7 @@
     "place": {
       "name": "Greendale",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14854,
       "coord": [-87.9959191, 42.9405711],
@@ -30272,7 +30272,7 @@
     "place": {
       "name": "Greenfield",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23488,
       "coord": [-85.7681979, 39.7855096],
@@ -30299,7 +30299,7 @@
     "place": {
       "name": "Greenfield",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4339,
       "coord": [-83.3826928, 39.3520084],
@@ -30340,7 +30340,7 @@
     "place": {
       "name": "Greensboro",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 299035,
       "coord": [-79.7919754, 36.0726355],
@@ -30372,7 +30372,7 @@
     "place": {
       "name": "Greensburg",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12312,
       "coord": [-85.483581, 39.3372722],
@@ -30391,7 +30391,7 @@
     "place": {
       "name": "Greensburg",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 740,
       "coord": [-99.2929639, 37.6031884],
@@ -30410,7 +30410,7 @@
     "place": {
       "name": "Greensburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14976,
       "coord": [-79.5389289, 40.3014581],
@@ -30429,7 +30429,7 @@
     "place": {
       "name": "Greenville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7374,
       "coord": [-86.6177517, 31.8295972],
@@ -30448,7 +30448,7 @@
     "place": {
       "name": "Greenville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6507,
       "coord": [-89.4131356, 38.8922687],
@@ -30489,7 +30489,7 @@
     "place": {
       "name": "Greenville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12786,
       "coord": [-84.6332986, 40.1023909],
@@ -30508,7 +30508,7 @@
     "place": {
       "name": "Greenville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5541,
       "coord": [-80.3910015, 41.4042616],
@@ -30527,7 +30527,7 @@
     "place": {
       "name": "Greenville",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 70635,
       "coord": [-82.3984882, 34.851354],
@@ -30546,7 +30546,7 @@
     "place": {
       "name": "Greenwich",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 63518,
       "coord": [-73.6284598, 41.0264862],
@@ -30565,7 +30565,7 @@
     "place": {
       "name": "Greenwood",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 63830,
       "coord": [-86.109555, 39.6137049],
@@ -30584,7 +30584,7 @@
     "place": {
       "name": "Greenwood",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 595,
       "coord": [-96.4435021236087, 40.960239],
@@ -30603,7 +30603,7 @@
     "place": {
       "name": "Grenada",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12700,
       "coord": [-89.8084192, 33.7690049],
@@ -30622,7 +30622,7 @@
     "place": {
       "name": "Gretna",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17814,
       "coord": [-90.0539604, 29.9146493],
@@ -30641,7 +30641,7 @@
     "place": {
       "name": "Grey Highlands",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 10424,
       "coord": [-80.46038959610259, 44.35654685],
@@ -30660,7 +30660,7 @@
     "place": {
       "name": "Gridley",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1456,
       "coord": [-88.8814578, 40.7433682],
@@ -30679,7 +30679,7 @@
     "place": {
       "name": "Grimes",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15392,
       "coord": [-93.7910575, 41.6883214],
@@ -30706,7 +30706,7 @@
     "place": {
       "name": "Grinnell",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9564,
       "coord": [-92.7239637, 41.7430237],
@@ -30725,7 +30725,7 @@
     "place": {
       "name": "Griswold",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 994,
       "coord": [-95.1415002, 41.2347873],
@@ -30744,7 +30744,7 @@
     "place": {
       "name": "Grosse Pointe",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5678,
       "coord": [-82.9118591, 42.3861485],
@@ -30763,7 +30763,7 @@
     "place": {
       "name": "Groton",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1380,
       "coord": [-98.098779, 45.447313],
@@ -30782,7 +30782,7 @@
     "place": {
       "name": "Grove City",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7894,
       "coord": [-80.0886631, 41.1579008],
@@ -30801,7 +30801,7 @@
     "place": {
       "name": "Grundy Center",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2796,
       "coord": [-92.7685327, 42.3616501],
@@ -30820,7 +30820,7 @@
     "place": {
       "name": "Guilford",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22073,
       "coord": [-72.6816365, 41.2827593],
@@ -30847,7 +30847,7 @@
     "place": {
       "name": "Gulf Shores",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15014,
       "coord": [-87.6893826, 30.2711224],
@@ -30874,7 +30874,7 @@
     "place": {
       "name": "Gulfport",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 72926,
       "coord": [-89.0928155, 30.3674198],
@@ -30893,7 +30893,7 @@
     "place": {
       "name": "Gunnison",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6560,
       "coord": [-106.926903, 38.545555],
@@ -30912,7 +30912,7 @@
     "place": {
       "name": "Guntersville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8553,
       "coord": [-86.2947041, 34.3581474],
@@ -30931,7 +30931,7 @@
     "place": {
       "name": "Gurley",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 816,
       "coord": [-86.3758201, 34.7017558],
@@ -30950,7 +30950,7 @@
     "place": {
       "name": "Gurnee",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30706,
       "coord": [-87.9020186, 42.3702996],
@@ -30969,7 +30969,7 @@
     "place": {
       "name": "Guthrie Center",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1593,
       "coord": [-94.5020027, 41.6782701],
@@ -30988,7 +30988,7 @@
     "place": {
       "name": "Guthrie",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1330,
       "coord": [-87.1661261, 36.6485623],
@@ -31007,7 +31007,7 @@
     "place": {
       "name": "Guthrie",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10749,
       "coord": [-97.4252772, 35.8789231],
@@ -31026,7 +31026,7 @@
     "place": {
       "name": "Guttenberg",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1817,
       "coord": [-91.0995735, 42.7858231],
@@ -31045,7 +31045,7 @@
     "place": {
       "name": "Hagerstown",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43527,
       "coord": [-77.7191081, 39.6430455],
@@ -31064,7 +31064,7 @@
     "place": {
       "name": "Hainesville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3546,
       "coord": [-88.067858, 42.3450219],
@@ -31083,7 +31083,7 @@
     "place": {
       "name": "Haleyville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4361,
       "coord": [-87.6214133, 34.226488],
@@ -31102,7 +31102,7 @@
     "place": {
       "name": "Halifax",
       "state": "NS",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 431479,
       "coord": [-63.5859487, 44.648618],
@@ -31121,7 +31121,7 @@
     "place": {
       "name": "Halifax",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 795,
       "coord": [-76.9314571, 40.4691049],
@@ -31156,7 +31156,7 @@
     "place": {
       "name": "Hallsville",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1614,
       "coord": [-92.220735, 39.1169851],
@@ -31175,7 +31175,7 @@
     "place": {
       "name": "Haltom City",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 46073,
       "coord": [-97.2691817, 32.7995738],
@@ -31194,7 +31194,7 @@
     "place": {
       "name": "Hamburg",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9696,
       "coord": [-78.828717, 42.716293],
@@ -31227,7 +31227,7 @@
     "place": {
       "name": "Hamden",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 61169,
       "coord": [-72.8968574, 41.3959302],
@@ -31246,7 +31246,7 @@
     "place": {
       "name": "Hamilton",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7042,
       "coord": [-87.9890206, 34.1420861],
@@ -31265,7 +31265,7 @@
     "place": {
       "name": "Hamilton",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1529,
       "coord": [-84.913002, 41.53345],
@@ -31284,7 +31284,7 @@
     "place": {
       "name": "Hamilton",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4659,
       "coord": [-114.154642435142, 46.2561815],
@@ -31311,7 +31311,7 @@
     "place": {
       "name": "Hamilton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 63399,
       "coord": [-84.561977, 39.399824],
@@ -31330,7 +31330,7 @@
     "place": {
       "name": "Hammond",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 77879,
       "coord": [-87.500043, 41.5833658],
@@ -31357,7 +31357,7 @@
     "place": {
       "name": "Hammond",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19584,
       "coord": [-90.4611995, 30.5043583],
@@ -31384,7 +31384,7 @@
     "place": {
       "name": "Hampden",
       "state": "ME",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7709,
       "coord": [-68.836982, 44.7445159],
@@ -31417,7 +31417,7 @@
     "place": {
       "name": "Hampshire",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7667,
       "coord": [-88.5303643, 42.0978028],
@@ -31436,7 +31436,7 @@
     "place": {
       "name": "Hampton",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 744,
       "coord": [-93.0001355, 44.61078],
@@ -31455,7 +31455,7 @@
     "place": {
       "name": "Hampton",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 137148,
       "coord": [-76.3452057, 37.0300969],
@@ -31496,7 +31496,7 @@
     "place": {
       "name": "Hamtramck",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21704,
       "coord": [-83.0496438, 42.3928151],
@@ -31515,7 +31515,7 @@
     "place": {
       "name": "Hancock",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4501,
       "coord": [-88.580648, 47.126937],
@@ -31534,7 +31534,7 @@
     "place": {
       "name": "Hannibal",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17312,
       "coord": [-91.3587413, 39.7082498],
@@ -31553,7 +31553,7 @@
     "place": {
       "name": "Hanover Park",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 37470,
       "coord": [-88.1450735, 41.9994722],
@@ -31572,7 +31572,7 @@
     "place": {
       "name": "Hanover",
       "state": "NH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11870,
       "coord": [-72.2892164, 43.7023545],
@@ -31605,7 +31605,7 @@
     "place": {
       "name": "Hanover",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 7967,
       "coord": [-81.0279572, 44.1520712],
@@ -31624,7 +31624,7 @@
     "place": {
       "name": "Hanover",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16429,
       "coord": [-76.9832568, 39.8005316],
@@ -31643,7 +31643,7 @@
     "place": {
       "name": "Harford County",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 260924,
       "coord": [-76.3048991, 39.548545],
@@ -31662,7 +31662,7 @@
     "place": {
       "name": "Haring Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3556,
       "coord": [-85.394484, 44.290651],
@@ -31686,7 +31686,7 @@
     "place": {
       "name": "Harmony",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 942,
       "coord": [-80.1280528, 40.8027772],
@@ -31705,7 +31705,7 @@
     "place": {
       "name": "Harrington",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3774,
       "coord": [-75.5777033, 38.9237244],
@@ -31732,7 +31732,7 @@
     "place": {
       "name": "Harrisburg",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18967,
       "coord": [-80.6454979, 35.3258295],
@@ -31773,7 +31773,7 @@
     "place": {
       "name": "Harrisburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 49271,
       "coord": [-76.8861122, 40.2663107],
@@ -31792,7 +31792,7 @@
     "place": {
       "name": "Harrison Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24314,
       "coord": [-82.8217131, 42.5886235],
@@ -31811,7 +31811,7 @@
     "place": {
       "name": "Harrison",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13069,
       "coord": [-93.1076765, 36.2297936],
@@ -31838,7 +31838,7 @@
     "place": {
       "name": "Harrison",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2150,
       "coord": [-84.7997872, 44.0192188],
@@ -31876,7 +31876,7 @@
     "place": {
       "name": "Harrison",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12563,
       "coord": [-84.792702, 39.251753],
@@ -31895,7 +31895,7 @@
     "place": {
       "name": "Harrisonburg",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 51814,
       "coord": [-78.8688833, 38.4493315],
@@ -31914,7 +31914,7 @@
     "place": {
       "name": "Harrisonville",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10121,
       "coord": [-94.3471072, 38.655124],
@@ -31933,7 +31933,7 @@
     "place": {
       "name": "Harristown",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1310,
       "coord": [-89.0839704, 39.8539279],
@@ -31952,7 +31952,7 @@
     "place": {
       "name": "Harrisville",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 437,
       "coord": [-83.294689, 44.656402],
@@ -31985,7 +31985,7 @@
     "place": {
       "name": "Hart",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2053,
       "coord": [-86.363965, 43.698341],
@@ -32004,7 +32004,7 @@
     "place": {
       "name": "Hartford",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 122105,
       "coord": [-72.6908547, 41.764582],
@@ -32031,7 +32031,7 @@
     "place": {
       "name": "Hartford",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 733,
       "coord": [-93.4030702, 41.45938],
@@ -32050,7 +32050,7 @@
     "place": {
       "name": "Hartford",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2515,
       "coord": [-86.1666876, 42.2067051],
@@ -32069,7 +32069,7 @@
     "place": {
       "name": "Hartford",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3354,
       "coord": [-96.9455849, 43.6228858],
@@ -32088,7 +32088,7 @@
     "place": {
       "name": "Hartford",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16000,
       "coord": [-88.3788508, 43.317744],
@@ -32123,7 +32123,7 @@
     "place": {
       "name": "Hartland",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9501,
       "coord": [-88.3420398, 43.105008],
@@ -32142,7 +32142,7 @@
     "place": {
       "name": "Hartley",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1605,
       "coord": [-95.4769635, 43.1800215],
@@ -32161,7 +32161,7 @@
     "place": {
       "name": "Hartselle",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15455,
       "coord": [-86.9352842, 34.4434282],
@@ -32180,7 +32180,7 @@
     "place": {
       "name": "Harvard",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9469,
       "coord": [-88.6137101, 42.422241],
@@ -32207,7 +32207,7 @@
     "place": {
       "name": "Harvey",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20324,
       "coord": [-87.6467132, 41.6100344],
@@ -32226,7 +32226,7 @@
     "place": {
       "name": "Harveysburg",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 554,
       "coord": [-84.0104877, 39.5036719],
@@ -32245,7 +32245,7 @@
     "place": {
       "name": "Harwood Heights",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9065,
       "coord": [-87.8076726, 41.9669615],
@@ -32272,7 +32272,7 @@
     "place": {
       "name": "Haskell",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3956,
       "coord": [-92.636552, 34.5014817],
@@ -32299,7 +32299,7 @@
     "place": {
       "name": "Hastings",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22154,
       "coord": [-92.8518697, 44.7426933],
@@ -32318,7 +32318,7 @@
     "place": {
       "name": "Hastings",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25152,
       "coord": [-98.3898883, 40.5861322],
@@ -32337,7 +32337,7 @@
     "place": {
       "name": "Hatfield",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3496,
       "coord": [-75.2995777, 40.2796371],
@@ -32356,7 +32356,7 @@
     "place": {
       "name": "Hattiesburg",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 48730,
       "coord": [-89.2903392, 31.3271189],
@@ -32375,7 +32375,7 @@
     "place": {
       "name": "Haubstadt",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1638,
       "coord": [-87.5741876, 38.2050442],
@@ -32394,7 +32394,7 @@
     "place": {
       "name": "Havana",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2963,
       "coord": [-90.0633625, 40.3014316],
@@ -32413,7 +32413,7 @@
     "place": {
       "name": "Hawarden",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2700,
       "coord": [-96.485317, 42.9956607],
@@ -32432,7 +32432,7 @@
     "place": {
       "name": "Hawley",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2219,
       "coord": [-96.316731, 46.880793],
@@ -32451,7 +32451,7 @@
     "place": {
       "name": "Hawley",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1229,
       "coord": [-75.1821189, 41.4759224],
@@ -32470,7 +32470,7 @@
     "place": {
       "name": "Hays",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21116,
       "coord": [-99.3267702, 38.8791783],
@@ -32489,7 +32489,7 @@
     "place": {
       "name": "Haysville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 100,
       "coord": [-80.1554425, 40.5255055],
@@ -32508,7 +32508,7 @@
     "place": {
       "name": "Hayward",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 162954,
       "coord": [-122.080796, 37.6688205],
@@ -32535,7 +32535,7 @@
     "place": {
       "name": "Hayward",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2512,
       "coord": [-91.4848728, 46.0129676],
@@ -32554,7 +32554,7 @@
     "place": {
       "name": "Hazel Park",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14983,
       "coord": [-83.1035688, 42.4620142],
@@ -32573,7 +32573,7 @@
     "place": {
       "name": "Hazen",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1481,
       "coord": [-91.5789815, 34.7813665],
@@ -32592,7 +32592,7 @@
     "place": {
       "name": "Hazleton",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29963,
       "coord": [-75.9852789, 40.9646867],
@@ -32625,7 +32625,7 @@
     "place": {
       "name": "Headland",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4973,
       "coord": [-85.3421559, 31.351284],
@@ -32644,7 +32644,7 @@
     "place": {
       "name": "Healdsburg",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11845,
       "coord": [-122.870138, 38.6106812],
@@ -32663,7 +32663,7 @@
     "place": {
       "name": "Hearst",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 4794,
       "coord": [-83.666382, 49.690732],
@@ -32682,7 +32682,7 @@
     "place": {
       "name": "Hebron",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9098,
       "coord": [-72.3659161, 41.6578767],
@@ -32709,7 +32709,7 @@
     "place": {
       "name": "Hebron",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3755,
       "coord": [-87.2003091, 41.3186482],
@@ -32728,7 +32728,7 @@
     "place": {
       "name": "Heflin",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3431,
       "coord": [-85.5874584, 33.6489948],
@@ -32747,7 +32747,7 @@
     "place": {
       "name": "Heidelberg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1288,
       "coord": [-80.0910519, 40.3921671],
@@ -32771,7 +32771,7 @@
     "place": {
       "name": "Helena",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20914,
       "coord": [-86.8436004, 33.296224],
@@ -32798,7 +32798,7 @@
     "place": {
       "name": "Helena",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32091,
       "coord": [-112.036277, 46.5927425],
@@ -32825,7 +32825,7 @@
     "place": {
       "name": "Helper",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2112,
       "coord": [-110.854605, 39.6841305],
@@ -32844,7 +32844,7 @@
     "place": {
       "name": "Helsinki",
       "state": "Uusimaa",
-      "country": "FI",
+      "country": "Finland",
       "type": "city",
       "pop": 686595,
       "coord": [24.9427473, 60.1674881],
@@ -32863,7 +32863,7 @@
     "place": {
       "name": "Henderson County",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 44793,
       "coord": [-87.5573742, 37.76721],
@@ -32882,7 +32882,7 @@
     "place": {
       "name": "Henderson",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29781,
       "coord": [-87.591705, 37.840803],
@@ -32901,7 +32901,7 @@
     "place": {
       "name": "Henderson",
       "state": "NV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 317610,
       "coord": [-114.9826194, 36.0301134],
@@ -32920,7 +32920,7 @@
     "place": {
       "name": "Hendricks",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 616,
       "coord": [-96.424213, 44.507186],
@@ -32939,7 +32939,7 @@
     "place": {
       "name": "Hennepin",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 769,
       "coord": [-89.3423112, 41.2542033],
@@ -32958,7 +32958,7 @@
     "place": {
       "name": "Henry",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2320,
       "coord": [-89.355468, 41.110684],
@@ -32977,7 +32977,7 @@
     "place": {
       "name": "Herington",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2109,
       "coord": [-96.9425139, 38.671119],
@@ -32996,7 +32996,7 @@
     "place": {
       "name": "Hermann",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2185,
       "coord": [-91.4373845, 38.7042119],
@@ -33015,7 +33015,7 @@
     "place": {
       "name": "Hermitage",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16230,
       "coord": [-80.44868, 41.2333897],
@@ -33034,7 +33034,7 @@
     "place": {
       "name": "Hermosa",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 382,
       "coord": [-103.191374, 43.839867],
@@ -33053,7 +33053,7 @@
     "place": {
       "name": "Hesston",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3505,
       "coord": [-97.4314857, 38.1385315],
@@ -33072,7 +33072,7 @@
     "place": {
       "name": "Heyworth",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2791,
       "coord": [-88.9736633, 40.313378],
@@ -33091,7 +33091,7 @@
     "place": {
       "name": "Hialeah",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 223109,
       "coord": [-80.2781057, 25.8575963],
@@ -33110,7 +33110,7 @@
     "place": {
       "name": "Hiawatha",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3280,
       "coord": [-95.5364966, 39.8524033],
@@ -33129,7 +33129,7 @@
     "place": {
       "name": "Hibbing",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16214,
       "coord": [-92.937689, 47.427155],
@@ -33148,7 +33148,7 @@
     "place": {
       "name": "Hickman",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2607,
       "coord": [-96.6323776, 40.6199714],
@@ -33167,7 +33167,7 @@
     "place": {
       "name": "Hickory",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 41171,
       "coord": [-81.3442915, 35.7333312],
@@ -33186,7 +33186,7 @@
     "place": {
       "name": "Higginsville",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4817,
       "coord": [-93.7172567, 39.0752352],
@@ -33205,7 +33205,7 @@
     "place": {
       "name": "High River",
       "state": "AB",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 13584,
       "coord": [-113.8569213, 50.5797079],
@@ -33224,7 +33224,7 @@
     "place": {
       "name": "Highland Park",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30176,
       "coord": [-87.8003438, 42.1816919],
@@ -33243,7 +33243,7 @@
     "place": {
       "name": "Highland Park",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8977,
       "coord": [-83.0965829, 42.4055981],
@@ -33274,7 +33274,7 @@
     "place": {
       "name": "Highland",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9991,
       "coord": [-89.6712008, 38.7394918],
@@ -33293,7 +33293,7 @@
     "place": {
       "name": "Highland",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23984,
       "coord": [-87.4520484, 41.5536529],
@@ -33320,7 +33320,7 @@
     "place": {
       "name": "Highland",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 872,
       "coord": [-90.3798465, 43.0466579],
@@ -33339,7 +33339,7 @@
     "place": {
       "name": "Highspire",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2741,
       "coord": [-76.7902453, 40.2111133],
@@ -33358,7 +33358,7 @@
     "place": {
       "name": "Highwood",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5074,
       "coord": [-87.8093247, 42.1998879],
@@ -33377,7 +33377,7 @@
     "place": {
       "name": "Hillcrest",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1224,
       "coord": [-89.0645413, 41.9511398],
@@ -33396,7 +33396,7 @@
     "place": {
       "name": "Hilliard",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 37114,
       "coord": [-83.1596108, 40.033814],
@@ -33428,7 +33428,7 @@
     "place": {
       "name": "Hillman",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 605,
       "coord": [-83.901106, 45.059177],
@@ -33455,7 +33455,7 @@
     "place": {
       "name": "Hillsboro",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2732,
       "coord": [-97.2047316, 38.3533075],
@@ -33474,7 +33474,7 @@
     "place": {
       "name": "Hillsboro",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6481,
       "coord": [-83.611587, 39.2022866],
@@ -33493,7 +33493,7 @@
     "place": {
       "name": "Hillsboro",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 106447,
       "coord": [-122.989827, 45.5228939],
@@ -33526,7 +33526,7 @@
     "place": {
       "name": "Hillsdale",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8036,
       "coord": [-84.631969, 41.922545],
@@ -33553,7 +33553,7 @@
     "place": {
       "name": "Hilton Beach",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 198,
       "coord": [-83.888585, 46.256732],
@@ -33572,7 +33572,7 @@
     "place": {
       "name": "Hinckley",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1904,
       "coord": [-92.9443707, 46.0113409],
@@ -33591,7 +33591,7 @@
     "place": {
       "name": "Hinsdale",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17395,
       "coord": [-87.9299841, 41.8024604],
@@ -33610,7 +33610,7 @@
     "place": {
       "name": "Hixton",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 455,
       "coord": [-91.0143157, 44.3857944],
@@ -33629,7 +33629,7 @@
     "place": {
       "name": "Hobart",
       "state": "TAS",
-      "country": "AU",
+      "country": "Australia",
       "type": "city",
       "pop": 53684,
       "coord": [147.3281233, -42.8825088],
@@ -33656,7 +33656,7 @@
     "place": {
       "name": "Holdrege",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5515,
       "coord": [-99.3698995, 40.4379956],
@@ -33675,7 +33675,7 @@
     "place": {
       "name": "Holland",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 34378,
       "coord": [-86.1090828, 42.7876022],
@@ -33694,7 +33694,7 @@
     "place": {
       "name": "Hollandale",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 307,
       "coord": [-89.93527, 42.8762721],
@@ -33713,7 +33713,7 @@
     "place": {
       "name": "Holly",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5997,
       "coord": [-83.6277255, 42.7919727],
@@ -33740,7 +33740,7 @@
     "place": {
       "name": "Hollywood",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 153067,
       "coord": [-80.1494901, 26.0112014],
@@ -33775,7 +33775,7 @@
     "place": {
       "name": "Holmen",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10661,
       "coord": [-91.2562539, 43.9632962],
@@ -33794,7 +33794,7 @@
     "place": {
       "name": "Homer",
       "state": "AK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5522,
       "coord": [-151.540147, 59.6440876],
@@ -33813,7 +33813,7 @@
     "place": {
       "name": "Homestead",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2884,
       "coord": [-79.9119948, 40.4059025],
@@ -33840,7 +33840,7 @@
     "place": {
       "name": "Homewood",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19463,
       "coord": [-87.6651467, 41.5574046],
@@ -33859,7 +33859,7 @@
     "place": {
       "name": "Honesdale",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4458,
       "coord": [-75.2580212, 41.5771005],
@@ -33878,7 +33878,7 @@
     "place": {
       "name": "Hong Kong",
       "state": "HK",
-      "country": "CN",
+      "country": "China",
       "type": "state",
       "pop": 7413070,
       "coord": [114.1628131, 22.2793278],
@@ -33897,7 +33897,7 @@
     "place": {
       "name": "Honolulu",
       "state": "HI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 345064,
       "coord": [-157.855676, 21.304547],
@@ -33916,7 +33916,7 @@
     "place": {
       "name": "Hoover",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 92606,
       "coord": [-86.80658186185164, 33.387754551602434],
@@ -33935,7 +33935,7 @@
     "place": {
       "name": "Hopkins",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19079,
       "coord": [-93.4074945, 44.9271194],
@@ -33981,7 +33981,7 @@
     "place": {
       "name": "Hopkinsville",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31180,
       "coord": [-87.4889532, 36.8657651],
@@ -34000,7 +34000,7 @@
     "place": {
       "name": "Horseheads",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6606,
       "coord": [-76.8202973, 42.1669832],
@@ -34019,7 +34019,7 @@
     "place": {
       "name": "Hortonville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3028,
       "coord": [-88.639343, 44.3350374],
@@ -34038,7 +34038,7 @@
     "place": {
       "name": "Hot Springs",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 38797,
       "coord": [-93.0552437, 34.5038393],
@@ -34057,7 +34057,7 @@
     "place": {
       "name": "Hot Springs",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3395,
       "coord": [-103.474363, 43.431646],
@@ -34076,7 +34076,7 @@
     "place": {
       "name": "Hotchkiss",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 875,
       "coord": [-107.719503, 38.799707],
@@ -34095,7 +34095,7 @@
     "place": {
       "name": "Houghton",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8386,
       "coord": [-88.569012, 47.121872],
@@ -34114,7 +34114,7 @@
     "place": {
       "name": "Houston",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2320268,
       "coord": [-95.3676974, 29.7589382],
@@ -34133,7 +34133,7 @@
     "place": {
       "name": "Howard County",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 334529,
       "coord": [-76.9166241, 39.2305289],
@@ -34152,7 +34152,7 @@
     "place": {
       "name": "Howell",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9610,
       "coord": [-83.9293952, 42.6072552],
@@ -34171,7 +34171,7 @@
     "place": {
       "name": "Howick",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 4045,
       "coord": [-81.06960637633733, 43.89460115],
@@ -34190,7 +34190,7 @@
     "place": {
       "name": "Huachuca City",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1626,
       "coord": [-110.333967, 31.6278703],
@@ -34209,7 +34209,7 @@
     "place": {
       "name": "Hubbard",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 860,
       "coord": [-93.2973812, 42.3056338],
@@ -34228,7 +34228,7 @@
     "place": {
       "name": "Hubbard",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 153,
       "coord": [-96.5896917, 42.3864022],
@@ -34247,7 +34247,7 @@
     "place": {
       "name": "Hudson",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1753,
       "coord": [-88.9872965, 40.6058688],
@@ -34266,7 +34266,7 @@
     "place": {
       "name": "Hudson",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6072,
       "coord": [-73.790959, 42.2528649],
@@ -34285,7 +34285,7 @@
     "place": {
       "name": "Hudson",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23110,
       "coord": [-81.440667, 41.240056],
@@ -34312,7 +34312,7 @@
     "place": {
       "name": "Hudson",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14755,
       "coord": [-92.7556281, 44.9751273],
@@ -34331,7 +34331,7 @@
     "place": {
       "name": "Hudsonville",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7629,
       "coord": [-85.865235, 42.870889],
@@ -34358,7 +34358,7 @@
     "place": {
       "name": "Hugo",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 787,
       "coord": [-103.471403, 39.1346297],
@@ -34377,7 +34377,7 @@
     "place": {
       "name": "Hugoton",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3747,
       "coord": [-101.349602, 37.1753025],
@@ -34396,7 +34396,7 @@
     "place": {
       "name": "Hummelstown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4535,
       "coord": [-76.7083033, 40.2653681],
@@ -34415,7 +34415,7 @@
     "place": {
       "name": "Humphrey",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 857,
       "coord": [-97.4844907, 41.6916753],
@@ -34434,7 +34434,7 @@
     "place": {
       "name": "Huntersville",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 61376,
       "coord": [-80.8429304, 35.4108278],
@@ -34461,7 +34461,7 @@
     "place": {
       "name": "Huntertown",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9141,
       "coord": [-85.1724741, 41.2283821],
@@ -34488,7 +34488,7 @@
     "place": {
       "name": "Huntingburg",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6362,
       "coord": [-86.9549972, 38.2989422],
@@ -34507,7 +34507,7 @@
     "place": {
       "name": "Huntingdon",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6827,
       "coord": [-78.010655, 40.484427],
@@ -34526,7 +34526,7 @@
     "place": {
       "name": "Huntington Beach",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 198711,
       "coord": [-118.0000166, 33.6783336],
@@ -34553,7 +34553,7 @@
     "place": {
       "name": "Huntington Woods",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6238,
       "coord": [-83.1668713, 42.4805913],
@@ -34572,7 +34572,7 @@
     "place": {
       "name": "Huntington",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 45110,
       "coord": [-82.445154, 38.4192496],
@@ -34591,7 +34591,7 @@
     "place": {
       "name": "Huntsville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 215006,
       "coord": [-86.5859011, 34.729847],
@@ -34610,7 +34610,7 @@
     "place": {
       "name": "Huntsville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 408,
       "coord": [-83.8049353, 40.4433848],
@@ -34629,7 +34629,7 @@
     "place": {
       "name": "Huntsville",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 21147,
       "coord": [-79.218434, 45.3263919],
@@ -34648,7 +34648,7 @@
     "place": {
       "name": "Hurley",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 379,
       "coord": [-97.08922, 43.28304],
@@ -34667,7 +34667,7 @@
     "place": {
       "name": "Huron Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16944,
       "coord": [-83.3634084, 42.1372282],
@@ -34686,7 +34686,7 @@
     "place": {
       "name": "Huron East",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 9512,
       "coord": [-81.29221638447679, 43.6213738],
@@ -34705,7 +34705,7 @@
     "place": {
       "name": "Huron",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6922,
       "coord": [-82.555009, 41.394656],
@@ -34732,7 +34732,7 @@
     "place": {
       "name": "Hurstbourne",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4683,
       "coord": [-85.5882937, 38.2381263],
@@ -34771,7 +34771,7 @@
     "place": {
       "name": "Hustisford",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1090,
       "coord": [-88.6006572, 43.3461089],
@@ -34790,7 +34790,7 @@
     "place": {
       "name": "Hutchinson",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40006,
       "coord": [-97.9297743, 38.0608444],
@@ -34809,7 +34809,7 @@
     "place": {
       "name": "Huxley",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4244,
       "coord": [-93.6065898, 41.8946126],
@@ -34828,7 +34828,7 @@
     "place": {
       "name": "Ida Grove",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2051,
       "coord": [-95.4713576, 42.3449751],
@@ -34847,7 +34847,7 @@
     "place": {
       "name": "Idaho Springs",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1782,
       "coord": [-105.5136365, 39.7425969],
@@ -34866,7 +34866,7 @@
     "place": {
       "name": "Illinois",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12812508,
       "coord": [-89.756643, 40.288802],
@@ -34885,7 +34885,7 @@
     "place": {
       "name": "Imlay City",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3707,
       "coord": [-83.0777153, 43.0247496],
@@ -34912,7 +34912,7 @@
     "place": {
       "name": "Imperial",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2068,
       "coord": [-101.6430784, 40.5170211],
@@ -34931,7 +34931,7 @@
     "place": {
       "name": "Independence",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8548,
       "coord": [-95.7083131, 37.2242358],
@@ -34950,7 +34950,7 @@
     "place": {
       "name": "Independence",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28676,
       "coord": [-84.544109, 38.9431183],
@@ -34969,7 +34969,7 @@
     "place": {
       "name": "Independence",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 123011,
       "coord": [-94.4137923, 39.0924792],
@@ -34988,7 +34988,7 @@
     "place": {
       "name": "Independence",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7584,
       "coord": [-81.6406872, 41.3816571],
@@ -35007,7 +35007,7 @@
     "place": {
       "name": "Indian Hills",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2860,
       "coord": [-85.6627394, 38.2725704],
@@ -35034,7 +35034,7 @@
     "place": {
       "name": "Indian Trail",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 39997,
       "coord": [-80.6692352, 35.0768141],
@@ -35061,7 +35061,7 @@
     "place": {
       "name": "Indiana",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14044,
       "coord": [-79.152067, 40.622934],
@@ -35080,7 +35080,7 @@
     "place": {
       "name": "Indianapolis",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 876384,
       "coord": [-86.1583502, 39.7683331],
@@ -35099,7 +35099,7 @@
     "place": {
       "name": "Indianola",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15833,
       "coord": [-93.5613292, 41.3604966],
@@ -35118,7 +35118,7 @@
     "place": {
       "name": "Ingolstadt",
       "state": "BY",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 141029,
       "coord": [11.4250395, 48.7630165],
@@ -35137,7 +35137,7 @@
     "place": {
       "name": "Inman",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1341,
       "coord": [-97.7733809, 38.2319537],
@@ -35156,7 +35156,7 @@
     "place": {
       "name": "Innisfil",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 43326,
       "coord": [-79.5461073, 44.3150892],
@@ -35175,7 +35175,7 @@
     "place": {
       "name": "Inola",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1890,
       "coord": [-95.5094195, 36.1512098],
@@ -35210,7 +35210,7 @@
     "place": {
       "name": "Iola",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5396,
       "coord": [-95.3999814, 37.9244799],
@@ -35229,7 +35229,7 @@
     "place": {
       "name": "Iola",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1236,
       "coord": [-89.1306665, 44.5080338],
@@ -35248,7 +35248,7 @@
     "place": {
       "name": "Ionia",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13378,
       "coord": [-85.066744, 42.982444],
@@ -35267,7 +35267,7 @@
     "place": {
       "name": "Iowa City",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 74596,
       "coord": [-91.5299106, 41.6612561],
@@ -35294,7 +35294,7 @@
     "place": {
       "name": "Ipswich",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 928,
       "coord": [-99.029278, 45.444419],
@@ -35313,7 +35313,7 @@
     "place": {
       "name": "Iron Ridge",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 898,
       "coord": [-88.5326008, 43.3997196],
@@ -35332,7 +35332,7 @@
     "place": {
       "name": "Iron River",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3007,
       "coord": [-88.642355, 46.092732],
@@ -35351,7 +35351,7 @@
     "place": {
       "name": "Ironwood",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5045,
       "coord": [-90.1684371, 46.4555673],
@@ -35370,7 +35370,7 @@
     "place": {
       "name": "Irvine",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 307670,
       "coord": [-117.8259819, 33.6856969],
@@ -35389,7 +35389,7 @@
     "place": {
       "name": "Irving",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 256684,
       "coord": [-96.9442177, 32.8295183],
@@ -35408,7 +35408,7 @@
     "place": {
       "name": "Irvington",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1231,
       "coord": [-86.2838622, 37.8803429],
@@ -35427,7 +35427,7 @@
     "place": {
       "name": "Irwin",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3902,
       "coord": [-79.7093339, 40.3301738],
@@ -35446,7 +35446,7 @@
     "place": {
       "name": "Ishpeming",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6140,
       "coord": [-87.667636, 46.488547],
@@ -35465,7 +35465,7 @@
     "place": {
       "name": "Israel",
       "state": null,
-      "country": "IL",
+      "country": "Israel",
       "type": "country",
       "pop": 7412200,
       "coord": [34.8594762, 30.8124247],
@@ -35492,7 +35492,7 @@
     "place": {
       "name": "Ithaca",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30837,
       "coord": [-76.4968019, 42.4396039],
@@ -35521,7 +35521,7 @@
     "place": {
       "name": "Jackson",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4748,
       "coord": [-87.89440041842762, 31.508942038956448],
@@ -35540,7 +35540,7 @@
     "place": {
       "name": "Jackson",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31309,
       "coord": [-84.425589, 42.2416466],
@@ -35575,7 +35575,7 @@
     "place": {
       "name": "Jackson",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15481,
       "coord": [-89.6684487, 37.3828316],
@@ -35594,7 +35594,7 @@
     "place": {
       "name": "Jackson",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 153701,
       "coord": [-90.1830408, 32.2998686],
@@ -35613,7 +35613,7 @@
     "place": {
       "name": "Jackson",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 68205,
       "coord": [-88.8177418, 35.6144446],
@@ -35632,7 +35632,7 @@
     "place": {
       "name": "Jacksonville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14385,
       "coord": [-85.7612872, 33.8137919],
@@ -35659,7 +35659,7 @@
     "place": {
       "name": "Jacksonville",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29477,
       "coord": [-92.1101458, 34.8662005],
@@ -35678,7 +35678,7 @@
     "place": {
       "name": "Jacksonville",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 911507,
       "coord": [-81.655651, 30.3321838],
@@ -35697,7 +35697,7 @@
     "place": {
       "name": "Jacksonville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17616,
       "coord": [-90.2288356, 39.7343037],
@@ -35716,7 +35716,7 @@
     "place": {
       "name": "Jacobus",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1829,
       "coord": [-76.7105245, 39.8831558],
@@ -35735,7 +35735,7 @@
     "place": {
       "name": "Jamestown",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 942,
       "coord": [-86.6222078444641, 39.9306998],
@@ -35754,7 +35754,7 @@
     "place": {
       "name": "Jamestown",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15849,
       "coord": [-98.708436, 46.910544],
@@ -35773,7 +35773,7 @@
     "place": {
       "name": "Jamestown",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28712,
       "coord": [-79.2380322, 42.0965167],
@@ -35792,7 +35792,7 @@
     "place": {
       "name": "Jamestown",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5559,
       "coord": [-71.3672755, 41.4970465],
@@ -35811,7 +35811,7 @@
     "place": {
       "name": "Janesville",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2421,
       "coord": [-93.7080044, 44.116078],
@@ -35830,7 +35830,7 @@
     "place": {
       "name": "Janesville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 65615,
       "coord": [-89.0226793, 42.6829765],
@@ -35849,7 +35849,7 @@
     "place": {
       "name": "Jasper County",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 32918,
       "coord": [-87.1066598, 41.0321808],
@@ -35868,7 +35868,7 @@
     "place": {
       "name": "Jasper",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16703,
       "coord": [-86.9308719, 38.3914228],
@@ -35903,7 +35903,7 @@
     "place": {
       "name": "Jeannette",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8780,
       "coord": [-79.6153198, 40.3281247],
@@ -35944,7 +35944,7 @@
     "place": {
       "name": "Jefferson City",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43228,
       "coord": [-92.1724265, 38.577359],
@@ -35963,7 +35963,7 @@
     "place": {
       "name": "Jefferson County",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 226739,
       "coord": [-90.5721889, 38.267166],
@@ -35982,7 +35982,7 @@
     "place": {
       "name": "Jefferson",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4182,
       "coord": [-94.3741093, 42.016055],
@@ -36001,7 +36001,7 @@
     "place": {
       "name": "Jefferson",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7793,
       "coord": [-88.8073273, 43.0055594],
@@ -36028,7 +36028,7 @@
     "place": {
       "name": "Jeffersontown",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28474,
       "coord": [-85.5644033, 38.1942356],
@@ -36067,7 +36067,7 @@
     "place": {
       "name": "Jeffersonville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 49447,
       "coord": [-85.7371604, 38.2770227],
@@ -36108,7 +36108,7 @@
     "place": {
       "name": "Jemison",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2642,
       "coord": [-86.7452105, 32.9596424],
@@ -36141,7 +36141,7 @@
     "place": {
       "name": "Jenkintown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4719,
       "coord": [-75.1256812, 40.0959385],
@@ -36168,7 +36168,7 @@
     "place": {
       "name": "Jenks",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25949,
       "coord": [-95.9683278, 36.0228734],
@@ -36192,7 +36192,7 @@
     "place": {
       "name": "Jennings County",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 27613,
       "coord": [-85.6359201, 38.9957749],
@@ -36219,7 +36219,7 @@
     "place": {
       "name": "Jennings",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12895,
       "coord": [-90.2611199, 38.719184],
@@ -36238,7 +36238,7 @@
     "place": {
       "name": "Jerome",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1692,
       "coord": [-89.6775561336782, 39.7673609],
@@ -36257,7 +36257,7 @@
     "place": {
       "name": "Jersey City",
       "state": "NJ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 262075,
       "coord": [-74.047455, 40.7215682],
@@ -36292,7 +36292,7 @@
     "place": {
       "name": "Jerseyville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8289,
       "coord": [-90.3284479, 39.1200471],
@@ -36311,7 +36311,7 @@
     "place": {
       "name": "Jessup",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4532,
       "coord": [-75.5621309, 41.4686924],
@@ -36330,7 +36330,7 @@
     "place": {
       "name": "Jim Thorpe",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4507,
       "coord": [-75.7192387169002, 40.8701902],
@@ -36357,7 +36357,7 @@
     "place": {
       "name": "Jocelyn",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 314,
       "coord": [-83.93914730776659, 46.1394948],
@@ -36376,7 +36376,7 @@
     "place": {
       "name": "Johannesburg",
       "state": "GP",
-      "country": "ZA",
+      "country": "South Africa",
       "type": "city",
       "pop": 4803262,
       "coord": [28.049722, -26.205],
@@ -36403,7 +36403,7 @@
     "place": {
       "name": "Johnson City",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15343,
       "coord": [-75.9587873, 42.1157038],
@@ -36430,7 +36430,7 @@
     "place": {
       "name": "Johnson City",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 71046,
       "coord": [-82.3534728, 36.3134398],
@@ -36449,7 +36449,7 @@
     "place": {
       "name": "Johnson Creek",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3318,
       "coord": [-88.7742707, 43.076113],
@@ -36468,7 +36468,7 @@
     "place": {
       "name": "Johnson",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3609,
       "coord": [-94.162957, 36.133483],
@@ -36495,7 +36495,7 @@
     "place": {
       "name": "Johnston City",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3348,
       "coord": [-88.9275695, 37.8206053],
@@ -36514,7 +36514,7 @@
     "place": {
       "name": "Johnston",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29568,
       "coord": [-71.5412101, 41.8310404],
@@ -36541,7 +36541,7 @@
     "place": {
       "name": "Johnstown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18411,
       "coord": [-78.9219698, 40.3267407],
@@ -36560,7 +36560,7 @@
     "place": {
       "name": "Joliet",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 150362,
       "coord": [-88.0840212, 41.5263603],
@@ -36579,7 +36579,7 @@
     "place": {
       "name": "Jonesboro",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 78576,
       "coord": [-90.6949871, 35.8272257],
@@ -36598,7 +36598,7 @@
     "place": {
       "name": "Jonesboro",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1711,
       "coord": [-89.2681402, 37.4517163],
@@ -36617,7 +36617,7 @@
     "place": {
       "name": "Jonesboro",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4106,
       "coord": [-92.7154376, 32.241538],
@@ -36636,7 +36636,7 @@
     "place": {
       "name": "Joplin",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 50925,
       "coord": [-94.51323, 37.08418],
@@ -36671,7 +36671,7 @@
     "place": {
       "name": "Joy",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 372,
       "coord": [-90.8804201, 41.1967002],
@@ -36690,7 +36690,7 @@
     "place": {
       "name": "Junction City",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22932,
       "coord": [-96.8313978, 39.0286093],
@@ -36709,7 +36709,7 @@
     "place": {
       "name": "Juneau",
       "state": "AK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32255,
       "coord": [-134.419734, 58.3019496],
@@ -36736,7 +36736,7 @@
     "place": {
       "name": "Juneau",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2658,
       "coord": [-88.7051037, 43.4055504],
@@ -36755,7 +36755,7 @@
     "place": {
       "name": "Jönköping",
       "state": "Jönköping",
-      "country": "SE",
+      "country": "Sweden",
       "type": "city",
       "pop": 112766,
       "coord": [14.165719, 57.7825634],
@@ -36774,7 +36774,7 @@
     "place": {
       "name": "Kalamazoo Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22777,
       "coord": [-85.6247849922262, 42.3108233],
@@ -36798,7 +36798,7 @@
     "place": {
       "name": "Kalamazoo",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 73598,
       "coord": [-85.5872286, 42.291707],
@@ -36832,7 +36832,7 @@
     "place": {
       "name": "Kaleva",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 507,
       "coord": [-86.01036, 44.373337],
@@ -36851,7 +36851,7 @@
     "place": {
       "name": "Kalispell",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24558,
       "coord": [-114.315321, 48.202158],
@@ -36878,7 +36878,7 @@
     "place": {
       "name": "Kalkaska",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2132,
       "coord": [-85.177927, 44.731332],
@@ -36905,7 +36905,7 @@
     "place": {
       "name": "Kanab",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4683,
       "coord": [-112.5285237, 37.0481715],
@@ -36924,7 +36924,7 @@
     "place": {
       "name": "Kane",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3612,
       "coord": [-78.8111427, 41.6628394],
@@ -36943,7 +36943,7 @@
     "place": {
       "name": "Kankakee County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 107502,
       "coord": [-87.848682, 41.1253903],
@@ -36962,7 +36962,7 @@
     "place": {
       "name": "Kankakee",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24052,
       "coord": [-87.8611531, 41.1200325],
@@ -36981,7 +36981,7 @@
     "place": {
       "name": "Kansas City",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 156607,
       "coord": [-94.626497, 39.1134562],
@@ -37018,7 +37018,7 @@
     "place": {
       "name": "Kansas City",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 495327,
       "coord": [-94.5781416, 39.100105],
@@ -37037,7 +37037,7 @@
     "place": {
       "name": "Kassel",
       "state": "HE",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 204202,
       "coord": [9.4924096, 51.3154546],
@@ -37056,7 +37056,7 @@
     "place": {
       "name": "Kasson",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6851,
       "coord": [-92.7503451, 44.0297055],
@@ -37075,7 +37075,7 @@
     "place": {
       "name": "Kaysville",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32945,
       "coord": [-111.9383931, 41.0349847],
@@ -37094,7 +37094,7 @@
     "place": {
       "name": "Kearney",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 33790,
       "coord": [-99.081858, 40.699478],
@@ -37113,7 +37113,7 @@
     "place": {
       "name": "Keego Harbor",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2764,
       "coord": [-83.3438248, 42.6080884],
@@ -37132,7 +37132,7 @@
     "place": {
       "name": "Kemmerer",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2415,
       "coord": [-110.537711, 41.7924606],
@@ -37159,7 +37159,7 @@
     "place": {
       "name": "Kempten",
       "state": "BY",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 70713,
       "coord": [10.3168835, 47.7267063],
@@ -37178,7 +37178,7 @@
     "place": {
       "name": "Kenilworth",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2514,
       "coord": [-87.7149295, 42.0894728],
@@ -37205,7 +37205,7 @@
     "place": {
       "name": "Kenner",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 66448,
       "coord": [-90.2417806, 29.9942265],
@@ -37224,7 +37224,7 @@
     "place": {
       "name": "Kenora",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 14967,
       "coord": [-94.490911, 49.766424],
@@ -37243,7 +37243,7 @@
     "place": {
       "name": "Kenosha",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 99986,
       "coord": [-87.8212263, 42.5846773],
@@ -37270,7 +37270,7 @@
     "place": {
       "name": "Kent County",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 181851,
       "coord": [-75.484116, 39.1156594],
@@ -37289,7 +37289,7 @@
     "place": {
       "name": "Kent",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28215,
       "coord": [-81.3578047, 41.1513108],
@@ -37308,7 +37308,7 @@
     "place": {
       "name": "Kent",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 136588,
       "coord": [-122.2270272, 47.3826903],
@@ -37343,7 +37343,7 @@
     "place": {
       "name": "Kenton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7947,
       "coord": [-83.6089968, 40.6478171],
@@ -37362,7 +37362,7 @@
     "place": {
       "name": "Kenyon",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1894,
       "coord": [-92.9854841, 44.2721868],
@@ -37381,7 +37381,7 @@
     "place": {
       "name": "Keokuk",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9900,
       "coord": [-91.385202, 40.3973423],
@@ -37400,7 +37400,7 @@
     "place": {
       "name": "Ketchum",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2855,
       "coord": [-114.363662, 43.680741],
@@ -37419,7 +37419,7 @@
     "place": {
       "name": "Ketchum",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 471,
       "coord": [-95.0238513, 36.5245268],
@@ -37438,7 +37438,7 @@
     "place": {
       "name": "Kettering",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 57377,
       "coord": [-84.1688274, 39.6895036],
@@ -37457,7 +37457,7 @@
     "place": {
       "name": "Kewanee",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12509,
       "coord": [-89.9248303, 41.2455927],
@@ -37476,7 +37476,7 @@
     "place": {
       "name": "Kewaskum",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4309,
       "coord": [-88.2278645, 43.5213798],
@@ -37495,7 +37495,7 @@
     "place": {
       "name": "Keyport",
       "state": "NJ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6977,
       "coord": [-74.1995883, 40.4331631],
@@ -37514,7 +37514,7 @@
     "place": {
       "name": "Kilkenny",
       "state": "County Kilkenny",
-      "country": "IE",
+      "country": "Ireland",
       "type": "city",
       "pop": 27184,
       "coord": [-7.2514438, 52.6506255],
@@ -37549,7 +37549,7 @@
     "place": {
       "name": "Killarney",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 397,
       "coord": [-81.41292673215838, 46.1020936],
@@ -37568,7 +37568,7 @@
     "place": {
       "name": "Killeen",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 153095,
       "coord": [-97.727796, 31.1171441],
@@ -37587,7 +37587,7 @@
     "place": {
       "name": "Killingworth",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6174,
       "coord": [-72.5637023, 41.3581545],
@@ -37606,7 +37606,7 @@
     "place": {
       "name": "Kimball",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2290,
       "coord": [-103.6629577, 41.2371713],
@@ -37625,7 +37625,7 @@
     "place": {
       "name": "Kimberly",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7320,
       "coord": [-88.3400807, 44.2717086],
@@ -37644,7 +37644,7 @@
     "place": {
       "name": "Kincardine",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 12268,
       "coord": [-81.6348713, 44.1776378],
@@ -37663,7 +37663,7 @@
     "place": {
       "name": "King City",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5184,
       "coord": [-122.804109, 45.4028329],
@@ -37696,7 +37696,7 @@
     "place": {
       "name": "Kingman",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32689,
       "coord": [-114.0530065, 35.189443],
@@ -37741,7 +37741,7 @@
     "place": {
       "name": "Kings Mountain",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11142,
       "coord": [-81.3410516, 35.2450607],
@@ -37776,7 +37776,7 @@
     "place": {
       "name": "Kingsford",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5139,
       "coord": [-88.072071, 45.794956],
@@ -37795,7 +37795,7 @@
     "place": {
       "name": "Kingston",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24069,
       "coord": [-74.0023702, 41.9287812],
@@ -37814,7 +37814,7 @@
     "place": {
       "name": "Kingston",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 136685,
       "coord": [-76.481323, 44.230687],
@@ -37841,7 +37841,7 @@
     "place": {
       "name": "Kingston",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13349,
       "coord": [-75.897197, 41.2620137],
@@ -37860,7 +37860,7 @@
     "place": {
       "name": "Kingsville",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 22119,
       "coord": [-82.7396606, 42.0378963],
@@ -37879,7 +37879,7 @@
     "place": {
       "name": "Kiowa",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 902,
       "coord": [-98.4853539, 37.0172493],
@@ -37898,7 +37898,7 @@
     "place": {
       "name": "Kirkland Lake",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 7750,
       "coord": [-80.031281, 48.154177],
@@ -37917,7 +37917,7 @@
     "place": {
       "name": "Kirkland",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1650,
       "coord": [-88.8512063, 42.0925258],
@@ -37936,7 +37936,7 @@
     "place": {
       "name": "Kirksville",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17530,
       "coord": [-92.5833939, 40.1948848],
@@ -37955,7 +37955,7 @@
     "place": {
       "name": "Kirkwood",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29461,
       "coord": [-90.4069177, 38.5800713],
@@ -37988,7 +37988,7 @@
     "place": {
       "name": "Kissimmee",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 72410,
       "coord": [-81.4075838, 28.2918995],
@@ -38007,7 +38007,7 @@
     "place": {
       "name": "Kitchener",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 242368,
       "coord": [-80.4927815, 43.451291],
@@ -38026,7 +38026,7 @@
     "place": {
       "name": "Klagenfurt",
       "state": "Kärnten",
-      "country": "AT",
+      "country": "Austria",
       "type": "city",
       "pop": 101403,
       "coord": [14.3075976, 46.623943],
@@ -38045,7 +38045,7 @@
     "place": {
       "name": "Klamath Falls",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21335,
       "coord": [-121.7816704, 42.224867],
@@ -38064,7 +38064,7 @@
     "place": {
       "name": "Knob Noster",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2782,
       "coord": [-93.5585458, 38.7666798],
@@ -38083,7 +38083,7 @@
     "place": {
       "name": "Knoxville",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 190740,
       "coord": [-83.9210261, 35.9603948],
@@ -38124,7 +38124,7 @@
     "place": {
       "name": "Koblenz",
       "state": "RP",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 115268,
       "coord": [7.5943951, 50.3533278],
@@ -38159,7 +38159,7 @@
     "place": {
       "name": "Kochville Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4911,
       "coord": [-83.9838728833003, 43.5034459],
@@ -38178,7 +38178,7 @@
     "place": {
       "name": "Kokomo",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 59604,
       "coord": [-86.1336351, 40.4864444],
@@ -38197,7 +38197,7 @@
     "place": {
       "name": "Konstanz",
       "state": "BW",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 85859,
       "coord": [9.1750718, 47.659216],
@@ -38216,7 +38216,7 @@
     "place": {
       "name": "Kouts",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2028,
       "coord": [-87.0258594, 41.3167058],
@@ -38243,7 +38243,7 @@
     "place": {
       "name": "Kronenwetter",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8353,
       "coord": [-89.5903989, 44.8221909],
@@ -38267,7 +38267,7 @@
     "place": {
       "name": "Kuna",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24011,
       "coord": [-116.420122, 43.4918307],
@@ -38290,7 +38290,7 @@
     "place": {
       "name": "Kutztown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4162,
       "coord": [-75.7774177, 40.5173165],
@@ -38309,7 +38309,7 @@
     "place": {
       "name": "L'Anse",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1874,
       "coord": [-88.452909, 46.756599],
@@ -38328,7 +38328,7 @@
     "place": {
       "name": "La Crescent",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5276,
       "coord": [-91.3040274, 43.8280216],
@@ -38347,7 +38347,7 @@
     "place": {
       "name": "La Crosse",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 52680,
       "coord": [-91.2395429, 43.8014053],
@@ -38372,7 +38372,7 @@
     "place": {
       "name": "La Cygne",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1050,
       "coord": [-94.7613476, 38.3500206],
@@ -38391,7 +38391,7 @@
     "place": {
       "name": "La Farge",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 720,
       "coord": [-90.6394929, 43.5751362],
@@ -38410,7 +38410,7 @@
     "place": {
       "name": "La Grange Park",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13475,
       "coord": [-87.8677324, 41.8333646],
@@ -38437,7 +38437,7 @@
     "place": {
       "name": "La Grange",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16321,
       "coord": [-87.8748644, 41.8054577],
@@ -38456,7 +38456,7 @@
     "place": {
       "name": "La Plata",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10159,
       "coord": [-76.9766569, 38.5260311],
@@ -38475,7 +38475,7 @@
     "place": {
       "name": "La Plata",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1257,
       "coord": [-92.4915779, 40.0233687],
@@ -38494,7 +38494,7 @@
     "place": {
       "name": "La Porte City",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2284,
       "coord": [-92.1921275, 42.3149911],
@@ -38513,7 +38513,7 @@
     "place": {
       "name": "La Porte",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22471,
       "coord": [-86.7225227, 41.6105983],
@@ -38548,7 +38548,7 @@
     "place": {
       "name": "La Rochelle",
       "state": "Charente-Maritime",
-      "country": "FR",
+      "country": "France",
       "type": "city",
       "pop": 77210,
       "coord": [-1.1520434, 46.1591126],
@@ -38567,7 +38567,7 @@
     "place": {
       "name": "LaSalle County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 109658,
       "coord": [-88.9011861, 41.3474892],
@@ -38586,7 +38586,7 @@
     "place": {
       "name": "LaSalle",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9499,
       "coord": [-89.0917497, 41.3333679],
@@ -38605,7 +38605,7 @@
     "place": {
       "name": "Laceyville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 363,
       "coord": [-76.1613189, 41.6459089],
@@ -38624,7 +38624,7 @@
     "place": {
       "name": "Ladysmith",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3180,
       "coord": [-91.1040358, 45.4630231],
@@ -38643,7 +38643,7 @@
     "place": {
       "name": "Lafayette",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30411,
       "coord": [-105.0897058, 39.9935959],
@@ -38662,7 +38662,7 @@
     "place": {
       "name": "Lafayette",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 70783,
       "coord": [-86.8752869, 40.4167022],
@@ -38689,7 +38689,7 @@
     "place": {
       "name": "Lafayette",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 121374,
       "coord": [-92.0178202, 30.2262187],
@@ -38716,7 +38716,7 @@
     "place": {
       "name": "Laingsburg",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1424,
       "coord": [-84.3496697, 42.8915618],
@@ -38735,7 +38735,7 @@
     "place": {
       "name": "Lake Barrington",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5100,
       "coord": [-88.1671534508794, 42.2126265],
@@ -38754,7 +38754,7 @@
     "place": {
       "name": "Lake Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3316,
       "coord": [-86.5284992098115, 41.94220675],
@@ -38773,7 +38773,7 @@
     "place": {
       "name": "Lake City",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 829,
       "coord": [-85.215046, 44.335287],
@@ -38808,7 +38808,7 @@
     "place": {
       "name": "Lake City",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5252,
       "coord": [-92.2678663, 44.4478474],
@@ -38827,7 +38827,7 @@
     "place": {
       "name": "Lake City",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2936,
       "coord": [-80.3460736, 42.0187713],
@@ -38846,7 +38846,7 @@
     "place": {
       "name": "Lake Elmo",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11335,
       "coord": [-92.8801862, 45.0021685],
@@ -38865,7 +38865,7 @@
     "place": {
       "name": "Lake Forest",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19367,
       "coord": [-87.8407055, 42.2586461],
@@ -38884,7 +38884,7 @@
     "place": {
       "name": "Lake Geneva",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8277,
       "coord": [-88.4334301, 42.5916836],
@@ -38903,7 +38903,7 @@
     "place": {
       "name": "Lake Havasu City",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 57144,
       "coord": [-114.3379972, 34.4775296],
@@ -38930,7 +38930,7 @@
     "place": {
       "name": "Lake Lillian",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 246,
       "coord": [-94.8798814, 44.9435162],
@@ -38949,7 +38949,7 @@
     "place": {
       "name": "Lake Mills",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2143,
       "coord": [-93.5336177, 43.4193665],
@@ -38968,7 +38968,7 @@
     "place": {
       "name": "Lake Mills",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6211,
       "coord": [-88.9125723, 43.0798032],
@@ -39015,7 +39015,7 @@
     "place": {
       "name": "Lake Norden",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 554,
       "coord": [-97.209238, 44.580522],
@@ -39034,7 +39034,7 @@
     "place": {
       "name": "Lake Orion",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2876,
       "coord": [-83.2396612, 42.7844752],
@@ -39067,7 +39067,7 @@
     "place": {
       "name": "Lake Oswego",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40731,
       "coord": [-122.670649, 45.4206749],
@@ -39100,7 +39100,7 @@
     "place": {
       "name": "Lake Ozark",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2077,
       "coord": [-92.6226454, 38.1798796],
@@ -39119,7 +39119,7 @@
     "place": {
       "name": "Lake Park",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1167,
       "coord": [-95.3207429, 43.455556],
@@ -39138,7 +39138,7 @@
     "place": {
       "name": "Lake Park",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3269,
       "coord": [-80.6355536, 35.0859691],
@@ -39157,7 +39157,7 @@
     "place": {
       "name": "Lake Placid",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2205,
       "coord": [-73.9828318, 44.2831194],
@@ -39176,7 +39176,7 @@
     "place": {
       "name": "Lake Preston",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 589,
       "coord": [-97.377294, 44.36358],
@@ -39195,7 +39195,7 @@
     "place": {
       "name": "Lake St. Louis",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16707,
       "coord": [-90.7935034, 38.7850251],
@@ -39220,7 +39220,7 @@
     "place": {
       "name": "Lake View",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1113,
       "coord": [-95.0510911, 42.3069227],
@@ -39239,7 +39239,7 @@
     "place": {
       "name": "Lake Zurich",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19759,
       "coord": [-88.0934108, 42.1969689],
@@ -39258,7 +39258,7 @@
     "place": {
       "name": "Lake of Bays",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 3759,
       "coord": [-79.005432, 45.327048],
@@ -39277,7 +39277,7 @@
     "place": {
       "name": "Lakeland",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 112641,
       "coord": [-81.9498042, 28.0394654],
@@ -39319,7 +39319,7 @@
     "place": {
       "name": "Lakeland",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13904,
       "coord": [-89.7403606, 35.2306435],
@@ -39346,7 +39346,7 @@
     "place": {
       "name": "Lakeshore",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 40410,
       "coord": [-82.8189267, 42.3038299],
@@ -39365,7 +39365,7 @@
     "place": {
       "name": "Lakesite",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1856,
       "coord": [-85.126899, 35.2086819],
@@ -39384,7 +39384,7 @@
     "place": {
       "name": "Lakeville",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 69490,
       "coord": [-93.2432791, 44.650051],
@@ -39403,7 +39403,7 @@
     "place": {
       "name": "Lakewood Club",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1340,
       "coord": [-86.260342, 43.371124],
@@ -39422,7 +39422,7 @@
     "place": {
       "name": "Lakewood Township",
       "state": "NJ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 135158,
       "coord": [-74.2176435, 40.0978929],
@@ -39441,7 +39441,7 @@
     "place": {
       "name": "Lakewood",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 155984,
       "coord": [-105.0846694, 39.7085736],
@@ -39468,7 +39468,7 @@
     "place": {
       "name": "Lakewood",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2993,
       "coord": [-79.333104, 42.104224],
@@ -39487,7 +39487,7 @@
     "place": {
       "name": "Lakewood",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 50942,
       "coord": [-81.7981908, 41.4819932],
@@ -39506,7 +39506,7 @@
     "place": {
       "name": "Lakin",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2205,
       "coord": [-101.254892, 37.9405751],
@@ -39525,7 +39525,7 @@
     "place": {
       "name": "Lambton Shores",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 11876,
       "coord": [-81.90202425000001, 43.19264175],
@@ -39544,7 +39544,7 @@
     "place": {
       "name": "Lamoni",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1969,
       "coord": [-93.9342515, 40.6228083],
@@ -39563,7 +39563,7 @@
     "place": {
       "name": "Lanark",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1519,
       "coord": [-89.8329726, 42.1020953],
@@ -39582,7 +39582,7 @@
     "place": {
       "name": "Lancaster",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 173516,
       "coord": [-118.1366153, 34.6981064],
@@ -39605,7 +39605,7 @@
     "place": {
       "name": "Lancaster",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40552,
       "coord": [-82.5993294, 39.7136754],
@@ -39632,7 +39632,7 @@
     "place": {
       "name": "Lancaster",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 59265,
       "coord": [-76.3056686, 40.03813],
@@ -39651,7 +39651,7 @@
     "place": {
       "name": "Lancaster",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8460,
       "coord": [-80.770012, 34.7189],
@@ -39670,7 +39670,7 @@
     "place": {
       "name": "Landis",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3109,
       "coord": [-80.6108998, 35.5456947],
@@ -39710,7 +39710,7 @@
     "place": {
       "name": "Landshut",
       "state": "BY",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 75457,
       "coord": [12.1516551, 48.536217],
@@ -39729,7 +39729,7 @@
     "place": {
       "name": "Langhorne",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1643,
       "coord": [-74.9226665, 40.1745538],
@@ -39748,7 +39748,7 @@
     "place": {
       "name": "Lansdale",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18773,
       "coord": [-75.2837862, 40.2414952],
@@ -39775,7 +39775,7 @@
     "place": {
       "name": "Lansdowne",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11107,
       "coord": [-75.2718507, 39.9381682],
@@ -39794,7 +39794,7 @@
     "place": {
       "name": "Lansing ",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 117159,
       "coord": [-84.5553805, 42.7337712],
@@ -39813,7 +39813,7 @@
     "place": {
       "name": "Lansing",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11239,
       "coord": [-94.900246, 39.248739],
@@ -39840,7 +39840,7 @@
     "place": {
       "name": "Lapeer",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9023,
       "coord": [-83.312549, 43.053788],
@@ -39859,7 +39859,7 @@
     "place": {
       "name": "Lapel",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2325,
       "coord": [-85.8479102, 40.0687245],
@@ -39878,7 +39878,7 @@
     "place": {
       "name": "Laramie",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31407,
       "coord": [-105.591101, 41.311367],
@@ -39913,7 +39913,7 @@
     "place": {
       "name": "Larder Lake",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 745,
       "coord": [-79.712342, 48.099217],
@@ -39932,7 +39932,7 @@
     "place": {
       "name": "Laredo",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 255205,
       "coord": [-99.5075644, 27.5030915],
@@ -39951,7 +39951,7 @@
     "place": {
       "name": "Larimer County",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 359066,
       "coord": [-105.4726907, 40.6810174],
@@ -39970,7 +39970,7 @@
     "place": {
       "name": "Larned",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3769,
       "coord": [-99.098713, 38.1805693],
@@ -39989,7 +39989,7 @@
     "place": {
       "name": "Las Cruces",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 103432,
       "coord": [-106.7798078, 32.3140354],
@@ -40008,7 +40008,7 @@
     "place": {
       "name": "Las Vegas",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13166,
       "coord": [-105.223896, 35.5939325],
@@ -40027,7 +40027,7 @@
     "place": {
       "name": "Las Vegas",
       "state": "NV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 641903,
       "coord": [-115.148516, 36.1672559],
@@ -40062,7 +40062,7 @@
     "place": {
       "name": "Latrobe",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8060,
       "coord": [-79.3840301, 40.317287],
@@ -40081,7 +40081,7 @@
     "place": {
       "name": "Laurel",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30060,
       "coord": [-76.8485094, 39.0984317],
@@ -40100,7 +40100,7 @@
     "place": {
       "name": "Laurel",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17161,
       "coord": [-89.1306124, 31.6940509],
@@ -40119,7 +40119,7 @@
     "place": {
       "name": "Laurel",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7222,
       "coord": [-108.771532, 45.6691159],
@@ -40138,7 +40138,7 @@
     "place": {
       "name": "Laurie",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 939,
       "coord": [-92.8335237, 38.1991971],
@@ -40157,7 +40157,7 @@
     "place": {
       "name": "Laval",
       "state": "QC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 437000,
       "coord": [-73.73441731, 45.60558895],
@@ -40184,7 +40184,7 @@
     "place": {
       "name": "Lawrence County",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 25768,
       "coord": [-103.8248538, 44.3501591],
@@ -40203,7 +40203,7 @@
     "place": {
       "name": "Lawrence",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 95256,
       "coord": [-95.2359496, 38.9719384],
@@ -40236,7 +40236,7 @@
     "place": {
       "name": "Lawrenceville",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30629,
       "coord": [-83.9890066, 33.9566391],
@@ -40255,7 +40255,7 @@
     "place": {
       "name": "Lawson",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2541,
       "coord": [-94.2041096, 39.4383387],
@@ -40274,7 +40274,7 @@
     "place": {
       "name": "Lawton",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1850,
       "coord": [-85.8469539, 42.1672629],
@@ -40293,7 +40293,7 @@
     "place": {
       "name": "Lawton",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 90381,
       "coord": [-98.3903305, 34.6086854],
@@ -40320,7 +40320,7 @@
     "place": {
       "name": "Layton",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 81773,
       "coord": [-111.9741925, 41.0751048],
@@ -40347,7 +40347,7 @@
     "place": {
       "name": "Le Claire",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4710,
       "coord": [-90.3434618, 41.5986442],
@@ -40366,7 +40366,7 @@
     "place": {
       "name": "Le Mars",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10571,
       "coord": [-96.1662993, 42.792151],
@@ -40385,7 +40385,7 @@
     "place": {
       "name": "Leadville",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2633,
       "coord": [-106.2925238, 39.2508229],
@@ -40412,7 +40412,7 @@
     "place": {
       "name": "Leamington",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 29680,
       "coord": [-82.5996998, 42.0531166],
@@ -40431,7 +40431,7 @@
     "place": {
       "name": "Leavenworth",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 37351,
       "coord": [-94.922759, 39.3113257],
@@ -40450,7 +40450,7 @@
     "place": {
       "name": "Lebanon",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16662,
       "coord": [-86.4691677, 40.0483744],
@@ -40469,7 +40469,7 @@
     "place": {
       "name": "Lebanon",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20841,
       "coord": [-84.2029922, 39.4353373],
@@ -40496,7 +40496,7 @@
     "place": {
       "name": "Lebanon",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26814,
       "coord": [-76.426219, 40.339178],
@@ -40523,7 +40523,7 @@
     "place": {
       "name": "Leduc",
       "state": "AB",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 34094,
       "coord": [-113.5511681, 53.2607825],
@@ -40542,7 +40542,7 @@
     "place": {
       "name": "Lee's Summit",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 101108,
       "coord": [-94.3821295, 38.9107156],
@@ -40569,7 +40569,7 @@
     "place": {
       "name": "Lee",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 313,
       "coord": [-88.9411148, 41.7951282],
@@ -40588,7 +40588,7 @@
     "place": {
       "name": "Leesport",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1954,
       "coord": [-75.9663222, 40.4470377],
@@ -40607,7 +40607,7 @@
     "place": {
       "name": "Lehighton",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5248,
       "coord": [-75.7135568, 40.8339907],
@@ -40634,7 +40634,7 @@
     "place": {
       "name": "Leland Grove",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1454,
       "coord": [-89.6822478749224, 39.7790889],
@@ -40661,7 +40661,7 @@
     "place": {
       "name": "Leland",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 951,
       "coord": [-88.7995237, 41.6125307],
@@ -40688,7 +40688,7 @@
     "place": {
       "name": "Lemont",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17629,
       "coord": [-88.0016263, 41.6737149],
@@ -40715,7 +40715,7 @@
     "place": {
       "name": "Lemoyne",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4659,
       "coord": [-76.894272, 40.2412143],
@@ -40740,7 +40740,7 @@
     "place": {
       "name": "Lenexa",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 57434,
       "coord": [-94.7845837, 38.9697458],
@@ -40759,7 +40759,7 @@
     "place": {
       "name": "Lennon",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 509,
       "coord": [-83.9282955, 42.985585],
@@ -40778,7 +40778,7 @@
     "place": {
       "name": "Lennox",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2423,
       "coord": [-96.8918394, 43.3541831],
@@ -40797,7 +40797,7 @@
     "place": {
       "name": "Leon",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1806,
       "coord": [-93.7465075, 40.740465],
@@ -40816,7 +40816,7 @@
     "place": {
       "name": "Leonard",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 377,
       "coord": [-83.1427148, 42.8653073],
@@ -40835,7 +40835,7 @@
     "place": {
       "name": "Leonardtown",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4563,
       "coord": [-76.6357946, 38.2912431],
@@ -40854,7 +40854,7 @@
     "place": {
       "name": "Lewes",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3303,
       "coord": [-75.1379574, 38.7733961],
@@ -40873,7 +40873,7 @@
     "place": {
       "name": "Lewisburg",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1745,
       "coord": [-84.5396736, 39.8461629],
@@ -40892,7 +40892,7 @@
     "place": {
       "name": "Lewisburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5158,
       "coord": [-76.8847639, 40.9645337],
@@ -40919,7 +40919,7 @@
     "place": {
       "name": "Lewisburg",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3930,
       "coord": [-80.4456303, 37.8017879],
@@ -40938,7 +40938,7 @@
     "place": {
       "name": "Lewistown",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1982,
       "coord": [-90.1548421, 40.3930973],
@@ -40957,7 +40957,7 @@
     "place": {
       "name": "Lexington",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2090,
       "coord": [-88.7834001, 40.6414237],
@@ -40976,7 +40976,7 @@
     "place": {
       "name": "Lexington",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 341000,
       "coord": [-84.4970393, 38.0464066],
@@ -40995,7 +40995,7 @@
     "place": {
       "name": "Lexington",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 943,
       "coord": [-82.5307956, 43.2681289],
@@ -41014,7 +41014,7 @@
     "place": {
       "name": "Lexington",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4652,
       "coord": [-93.8828515, 39.1851824],
@@ -41033,7 +41033,7 @@
     "place": {
       "name": "Libby",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2775,
       "coord": [-115.5558612, 48.3883645],
@@ -41052,7 +41052,7 @@
     "place": {
       "name": "Liberal",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19825,
       "coord": [-100.920999, 37.0430812],
@@ -41071,7 +41071,7 @@
     "place": {
       "name": "Liberty",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30167,
       "coord": [-94.419079, 39.246479],
@@ -41098,7 +41098,7 @@
     "place": {
       "name": "Liberty",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 232,
       "coord": [-79.856689, 40.325261],
@@ -41125,7 +41125,7 @@
     "place": {
       "name": "Liberty",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3366,
       "coord": [-82.6936822, 34.7869865],
@@ -41144,7 +41144,7 @@
     "place": {
       "name": "Libertyville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20579,
       "coord": [-87.9531303, 42.2830786],
@@ -41171,7 +41171,7 @@
     "place": {
       "name": "Ligonier",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4568,
       "coord": [-85.5875346, 41.4638387],
@@ -41190,7 +41190,7 @@
     "place": {
       "name": "Ligonier",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1513,
       "coord": [-79.2376363, 40.2430966],
@@ -41217,7 +41217,7 @@
     "place": {
       "name": "Lilburn",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14502,
       "coord": [-84.1429719, 33.8901036],
@@ -41236,7 +41236,7 @@
     "place": {
       "name": "Limon",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2043,
       "coord": [-103.693123, 39.2648545],
@@ -41255,7 +41255,7 @@
     "place": {
       "name": "Lincoln Heights",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3144,
       "coord": [-84.4554979, 39.2389469],
@@ -41274,7 +41274,7 @@
     "place": {
       "name": "Lincoln Park",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40245,
       "coord": [-83.1785361, 42.2505943],
@@ -41301,7 +41301,7 @@
     "place": {
       "name": "Lincoln",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6845,
       "coord": [-86.1183061, 33.6131588],
@@ -41320,7 +41320,7 @@
     "place": {
       "name": "Lincoln",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2294,
       "coord": [-94.423802, 35.948981],
@@ -41339,7 +41339,7 @@
     "place": {
       "name": "Lincoln",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13058,
       "coord": [-89.3636569, 40.1481349],
@@ -41358,7 +41358,7 @@
     "place": {
       "name": "Lincoln",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 305,
       "coord": [-83.412194, 44.684735],
@@ -41391,7 +41391,7 @@
     "place": {
       "name": "Lincoln",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1144,
       "coord": [-93.3346497, 38.3908555],
@@ -41410,7 +41410,7 @@
     "place": {
       "name": "Lincoln",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 291082,
       "coord": [-96.7077751, 40.8088861],
@@ -41437,7 +41437,7 @@
     "place": {
       "name": "Lincolnwood",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13463,
       "coord": [-87.735572, 42.0055985],
@@ -41456,7 +41456,7 @@
     "place": {
       "name": "Lindau",
       "state": "BY",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 26155,
       "coord": [9.6926624, 47.550753],
@@ -41479,7 +41479,7 @@
     "place": {
       "name": "Linden",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4142,
       "coord": [-83.7821563, 42.8146748],
@@ -41498,7 +41498,7 @@
     "place": {
       "name": "Lindsay",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 22367,
       "coord": [-78.7369939, 44.3551266],
@@ -41517,7 +41517,7 @@
     "place": {
       "name": "Lindsborg",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3776,
       "coord": [-97.6744838, 38.5736176],
@@ -41536,7 +41536,7 @@
     "place": {
       "name": "Lindstrom",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4888,
       "coord": [-92.8479921, 45.3894083],
@@ -41555,7 +41555,7 @@
     "place": {
       "name": "Lisle",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24223,
       "coord": [-88.0747687, 41.801159],
@@ -41582,7 +41582,7 @@
     "place": {
       "name": "Litchfield Park",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6847,
       "coord": [-112.358124, 33.4933796],
@@ -41601,7 +41601,7 @@
     "place": {
       "name": "Litchfield",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6624,
       "coord": [-94.5280474, 45.1271847],
@@ -41620,7 +41620,7 @@
     "place": {
       "name": "Lititz",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9370,
       "coord": [-76.307162, 40.1571324],
@@ -41639,7 +41639,7 @@
     "place": {
       "name": "Little Falls",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9140,
       "coord": [-94.3625024, 45.9763545],
@@ -41658,7 +41658,7 @@
     "place": {
       "name": "Little Rock",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 201998,
       "coord": [-92.2896267, 34.7465071],
@@ -41677,7 +41677,7 @@
     "place": {
       "name": "Littlestown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4782,
       "coord": [-77.0880163, 39.7446302],
@@ -41696,7 +41696,7 @@
     "place": {
       "name": "Littleton",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 45652,
       "coord": [-105.016649, 39.613321],
@@ -41744,7 +41744,7 @@
     "place": {
       "name": "Livingston",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8040,
       "coord": [-110.56104, 45.662436],
@@ -41763,7 +41763,7 @@
     "place": {
       "name": "Livonia",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 95535,
       "coord": [-83.3527097, 42.36837],
@@ -41782,7 +41782,7 @@
     "place": {
       "name": "Lock Haven",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8108,
       "coord": [-77.4471641, 41.1369077],
@@ -41801,7 +41801,7 @@
     "place": {
       "name": "Lockport",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26094,
       "coord": [-88.057837, 41.5894753],
@@ -41820,7 +41820,7 @@
     "place": {
       "name": "Locust",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4537,
       "coord": [-80.4355713655848, 35.27267145],
@@ -41839,7 +41839,7 @@
     "place": {
       "name": "Lodi",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3189,
       "coord": [-89.5265093, 43.313878],
@@ -41858,7 +41858,7 @@
     "place": {
       "name": "Logan",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7296,
       "coord": [-82.408817, 39.540138],
@@ -41877,7 +41877,7 @@
     "place": {
       "name": "Logan",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 52778,
       "coord": [-111.834914, 41.7313063],
@@ -41904,7 +41904,7 @@
     "place": {
       "name": "Logansport",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18366,
       "coord": [-86.3567356, 40.7545006],
@@ -41939,7 +41939,7 @@
     "place": {
       "name": "Loganville",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14127,
       "coord": [-83.9007382, 33.8389977],
@@ -41958,7 +41958,7 @@
     "place": {
       "name": "Loganville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 302,
       "coord": [-90.0359588, 43.4402612],
@@ -41977,7 +41977,7 @@
     "place": {
       "name": "Lombard",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 44476,
       "coord": [-88.0201536, 41.8864687],
@@ -41996,7 +41996,7 @@
     "place": {
       "name": "Lomira",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2678,
       "coord": [-88.443713, 43.591382],
@@ -42015,7 +42015,7 @@
     "place": {
       "name": "London",
       "state": "England",
-      "country": "UK",
+      "country": "United Kingdom",
       "type": "city",
       "pop": 8799800,
       "coord": [-0.1277653, 51.5074456],
@@ -42042,7 +42042,7 @@
     "place": {
       "name": "London",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 404699,
       "coord": [-81.243372, 42.9832406],
@@ -42061,7 +42061,7 @@
     "place": {
       "name": "Lone Tree",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14253,
       "coord": [-104.9041528, 39.5364152],
@@ -42080,7 +42080,7 @@
     "place": {
       "name": "Long Beach",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 466742,
       "coord": [-118.191604, 33.7690164],
@@ -42107,7 +42107,7 @@
     "place": {
       "name": "Long Beach",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15829,
       "coord": [-89.1528176, 30.3504751],
@@ -42126,7 +42126,7 @@
     "place": {
       "name": "Long Beach",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1688,
       "coord": [-124.054331, 46.35232],
@@ -42145,7 +42145,7 @@
     "place": {
       "name": "Long Grove",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8366,
       "coord": [-87.9978518, 42.1783584],
@@ -42164,7 +42164,7 @@
     "place": {
       "name": "Long Lake Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9956,
       "coord": [-85.763955, 44.747736],
@@ -42188,7 +42188,7 @@
     "place": {
       "name": "Longmont",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 97261,
       "coord": [-105.1019287, 40.1672117],
@@ -42215,7 +42215,7 @@
     "place": {
       "name": "Longview",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 81638,
       "coord": [-94.74049, 32.5007031],
@@ -42234,7 +42234,7 @@
     "place": {
       "name": "Longville",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 153,
       "coord": [-94.2113636, 46.9863443],
@@ -42253,7 +42253,7 @@
     "place": {
       "name": "Lonoke",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4276,
       "coord": [-91.862792, 34.7414404],
@@ -42272,7 +42272,7 @@
     "place": {
       "name": "Lorain",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 65211,
       "coord": [-82.1781904, 41.4673238],
@@ -42291,7 +42291,7 @@
     "place": {
       "name": "Los Angeles",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3979576,
       "coord": [-118.242766, 34.0536909],
@@ -42316,7 +42316,7 @@
     "place": {
       "name": "Los Lunas",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17242,
       "coord": [-106.7613067, 34.8142093],
@@ -42343,7 +42343,7 @@
     "place": {
       "name": "Loudonville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2786,
       "coord": [-82.2334461, 40.6355985],
@@ -42362,7 +42362,7 @@
     "place": {
       "name": "Louisburg",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4969,
       "coord": [-94.6810214, 38.6195586],
@@ -42381,7 +42381,7 @@
     "place": {
       "name": "Louisville",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21226,
       "coord": [-105.1319296, 39.977763],
@@ -42416,7 +42416,7 @@
     "place": {
       "name": "Louisville",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 617790,
       "coord": [-85.759407, 38.2542376],
@@ -42455,7 +42455,7 @@
     "place": {
       "name": "Louisville",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6072,
       "coord": [-89.0550624, 33.1237377],
@@ -42474,7 +42474,7 @@
     "place": {
       "name": "Louisville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9521,
       "coord": [-81.2595731, 40.8375307],
@@ -42493,7 +42493,7 @@
     "place": {
       "name": "Loveland",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 76378,
       "coord": [-105.07498, 40.3977612],
@@ -42520,7 +42520,7 @@
     "place": {
       "name": "Lovington",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1069,
       "coord": [-88.6325641, 39.71559],
@@ -42539,7 +42539,7 @@
     "place": {
       "name": "Lowell Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6276,
       "coord": [-85.3710101, 42.8855418],
@@ -42558,7 +42558,7 @@
     "place": {
       "name": "Lowell",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9839,
       "coord": [-94.1307587, 36.2553543],
@@ -42582,7 +42582,7 @@
     "place": {
       "name": "Lowell",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10680,
       "coord": [-87.4205903, 41.2914244],
@@ -42601,7 +42601,7 @@
     "place": {
       "name": "Lowell",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 113994,
       "coord": [-71.3085329, 42.6414437],
@@ -42620,7 +42620,7 @@
     "place": {
       "name": "Lowell",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4142,
       "coord": [-85.3418551, 42.933601],
@@ -42639,7 +42639,7 @@
     "place": {
       "name": "Lowell",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3654,
       "coord": [-81.1028542, 35.2679163],
@@ -42680,7 +42680,7 @@
     "place": {
       "name": "Lower Burrell",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11758,
       "coord": [-79.7298187, 40.5882821],
@@ -42699,7 +42699,7 @@
     "place": {
       "name": "Lower Macungie Township",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32626,
       "coord": [-75.59507843, 40.5283605],
@@ -42718,7 +42718,7 @@
     "place": {
       "name": "Lubbock",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 257141,
       "coord": [-101.8470215, 33.5855677],
@@ -42737,7 +42737,7 @@
     "place": {
       "name": "Lucedale",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2869,
       "coord": [-88.5900235, 30.9251869],
@@ -42756,7 +42756,7 @@
     "place": {
       "name": "Luck",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1067,
       "coord": [-92.4822709, 45.5758884],
@@ -42775,7 +42775,7 @@
     "place": {
       "name": "Ludington",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7655,
       "coord": [-86.4477416, 43.9555406],
@@ -42794,7 +42794,7 @@
     "place": {
       "name": "Ludlow",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4385,
       "coord": [-84.5474435, 39.0925598],
@@ -42813,7 +42813,7 @@
     "place": {
       "name": "Luna Pier",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1382,
       "coord": [-83.442433, 41.8069907],
@@ -42832,7 +42832,7 @@
     "place": {
       "name": "Lunenburg",
       "state": "NS",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 2263,
       "coord": [-64.31677402, 44.3750592],
@@ -42851,7 +42851,7 @@
     "place": {
       "name": "Lyman",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6173,
       "coord": [-82.1273312, 34.9481741],
@@ -42870,7 +42870,7 @@
     "place": {
       "name": "Lynchburg",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 80569,
       "coord": [-79.1422464, 37.4137536],
@@ -42889,7 +42889,7 @@
     "place": {
       "name": "Lyndon",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1037,
       "coord": [-95.684429, 38.6100099],
@@ -42908,7 +42908,7 @@
     "place": {
       "name": "Lyndon",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11008,
       "coord": [-85.6016275, 38.2567376],
@@ -42947,7 +42947,7 @@
     "place": {
       "name": "Lyon County",
       "state": "NV",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 59235,
       "coord": [-119.198223, 39.135398],
@@ -42966,7 +42966,7 @@
     "place": {
       "name": "Lyons",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2209,
       "coord": [-105.270532, 40.224432],
@@ -42993,7 +42993,7 @@
     "place": {
       "name": "Mackinac Island",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 583,
       "coord": [-84.6196721, 45.8492045],
@@ -43012,7 +43012,7 @@
     "place": {
       "name": "Mackinaw City",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 846,
       "coord": [-84.727828, 45.783901],
@@ -43039,7 +43039,7 @@
     "place": {
       "name": "Macomb Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 91663,
       "coord": [-82.9179487, 42.6726042],
@@ -43066,7 +43066,7 @@
     "place": {
       "name": "Macomb",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15052,
       "coord": [-90.6713939, 40.4588934],
@@ -43085,7 +43085,7 @@
     "place": {
       "name": "Macon County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 103998,
       "coord": [-88.968482, 39.874188],
@@ -43104,7 +43104,7 @@
     "place": {
       "name": "Macon-Bibb County",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 157346,
       "coord": [-83.6324022, 32.8406946],
@@ -43123,7 +43123,7 @@
     "place": {
       "name": "Macungie",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3257,
       "coord": [-75.5551858, 40.5159304],
@@ -43142,7 +43142,7 @@
     "place": {
       "name": "Madeira",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9487,
       "coord": [-84.3635507, 39.1908926],
@@ -43161,7 +43161,7 @@
     "place": {
       "name": "Madison",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 56933,
       "coord": [-86.75131124920155, 34.693193262630174],
@@ -43194,7 +43194,7 @@
     "place": {
       "name": "Madison",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3435,
       "coord": [-81.049321, 41.771257],
@@ -43221,7 +43221,7 @@
     "place": {
       "name": "Madison",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6191,
       "coord": [-97.11395, 44.006085],
@@ -43240,7 +43240,7 @@
     "place": {
       "name": "Madison",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 259680,
       "coord": [-89.3837613, 43.074761],
@@ -43259,7 +43259,7 @@
     "place": {
       "name": "Madras",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7051,
       "coord": [-121.1294872, 44.6334544],
@@ -43278,7 +43278,7 @@
     "place": {
       "name": "Madrid",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2802,
       "coord": [-93.8232813, 41.8766526],
@@ -43297,7 +43297,7 @@
     "place": {
       "name": "Magnetawan",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1753,
       "coord": [-79.6438541, 45.6651963],
@@ -43316,7 +43316,7 @@
     "place": {
       "name": "Magnolia Springs",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 811,
       "coord": [-87.7761001, 30.3996424],
@@ -43343,7 +43343,7 @@
     "place": {
       "name": "Magnolia",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11162,
       "coord": [-93.2393341, 33.2670725],
@@ -43362,7 +43362,7 @@
     "place": {
       "name": "Maharashtra",
       "state": "MH",
-      "country": "IN",
+      "country": "India",
       "type": "state",
       "pop": 112374333,
       "coord": [74.58622221140698, 19.1194345],
@@ -43393,7 +43393,7 @@
     "place": {
       "name": "Mahtomedi",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8138,
       "coord": [-92.9516037, 45.0696886],
@@ -43412,7 +43412,7 @@
     "place": {
       "name": "Maiden",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3736,
       "coord": [-81.2139216, 35.5766048],
@@ -43431,7 +43431,7 @@
     "place": {
       "name": "Maine",
       "state": "ME",
-      "country": "US",
+      "country": "United States",
       "type": "state",
       "pop": 1372559,
       "coord": [-69.4455, 45.25381],
@@ -43464,7 +43464,7 @@
     "place": {
       "name": "Maize",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5735,
       "coord": [-97.4672674, 37.7791787],
@@ -43483,7 +43483,7 @@
     "place": {
       "name": "Malden",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3706,
       "coord": [-89.9660641, 36.5568929],
@@ -43502,7 +43502,7 @@
     "place": {
       "name": "Malvern",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1046,
       "coord": [-95.5851939, 41.0024095],
@@ -43521,7 +43521,7 @@
     "place": {
       "name": "Malvern",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3419,
       "coord": [-75.5138959, 40.036202],
@@ -43540,7 +43540,7 @@
     "place": {
       "name": "Manawa",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1441,
       "coord": [-88.919829, 44.4644255],
@@ -43559,7 +43559,7 @@
     "place": {
       "name": "Mancelona",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1708,
       "coord": [-85.060885, 44.902229],
@@ -43586,7 +43586,7 @@
     "place": {
       "name": "Manchester",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5065,
       "coord": [-91.4555379, 42.4840907],
@@ -43605,7 +43605,7 @@
     "place": {
       "name": "Manchester",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2037,
       "coord": [-84.0377231, 42.1503178],
@@ -43624,7 +43624,7 @@
     "place": {
       "name": "Manchester",
       "state": "NH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 112673,
       "coord": [-71.4547891, 42.9956397],
@@ -43643,7 +43643,7 @@
     "place": {
       "name": "Mancos",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1196,
       "coord": [-108.2925568, 37.3440947],
@@ -43662,7 +43662,7 @@
     "place": {
       "name": "Mandan",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24206,
       "coord": [-100.889704, 46.826415],
@@ -43681,7 +43681,7 @@
     "place": {
       "name": "Mandeville",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13192,
       "coord": [-90.0657477, 30.3582305],
@@ -43700,7 +43700,7 @@
     "place": {
       "name": "Manhattan",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 55290,
       "coord": [-96.5716694, 39.1836082],
@@ -43733,7 +43733,7 @@
     "place": {
       "name": "Manhattan",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2086,
       "coord": [-111.334081, 45.855369],
@@ -43752,7 +43752,7 @@
     "place": {
       "name": "Manheim Township",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43977,
       "coord": [-76.2950901541993, 40.0896562],
@@ -43771,7 +43771,7 @@
     "place": {
       "name": "Manheim",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5064,
       "coord": [-76.3952429, 40.1637359],
@@ -43790,7 +43790,7 @@
     "place": {
       "name": "Manistee",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6259,
       "coord": [-86.3216, 44.247989],
@@ -43823,7 +43823,7 @@
     "place": {
       "name": "Manistique",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2828,
       "coord": [-86.246419, 45.95779],
@@ -43842,7 +43842,7 @@
     "place": {
       "name": "Manitou Springs",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4858,
       "coord": [-104.917873, 38.8585777],
@@ -43861,7 +43861,7 @@
     "place": {
       "name": "Manitowoc",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 34626,
       "coord": [-87.6575841, 44.0886059],
@@ -43880,7 +43880,7 @@
     "place": {
       "name": "Mankato",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 44488,
       "coord": [-93.9993505, 44.1634663],
@@ -43899,7 +43899,7 @@
     "place": {
       "name": "Manley",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 167,
       "coord": [-96.1660582, 40.9196531],
@@ -43918,7 +43918,7 @@
     "place": {
       "name": "Manning",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1455,
       "coord": [-95.0650571, 41.9092293],
@@ -43937,7 +43937,7 @@
     "place": {
       "name": "Mannington",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1961,
       "coord": [-80.343418, 39.5309169],
@@ -43956,7 +43956,7 @@
     "place": {
       "name": "Mansfield",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25892,
       "coord": [-72.2131565, 41.7782147],
@@ -43975,7 +43975,7 @@
     "place": {
       "name": "Mansfield",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 47534,
       "coord": [-82.5154471, 40.75839],
@@ -43994,7 +43994,7 @@
     "place": {
       "name": "Mansfield",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2852,
       "coord": [-77.0792881, 41.805687],
@@ -44013,7 +44013,7 @@
     "place": {
       "name": "Manteno",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9210,
       "coord": [-87.8314299, 41.2506759],
@@ -44032,7 +44032,7 @@
     "place": {
       "name": "Manton",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1258,
       "coord": [-85.398944, 44.41084],
@@ -44051,7 +44051,7 @@
     "place": {
       "name": "Mantua",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1001,
       "coord": [-81.223991, 41.283944],
@@ -44070,7 +44070,7 @@
     "place": {
       "name": "Maple Park",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1433,
       "coord": [-88.5992494, 41.9075282],
@@ -44089,7 +44089,7 @@
     "place": {
       "name": "Mapleton",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1165,
       "coord": [-95.7933336, 42.1658147],
@@ -44108,7 +44108,7 @@
     "place": {
       "name": "Maplewood",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 42088,
       "coord": [-93.0456985, 45.0082216],
@@ -44135,7 +44135,7 @@
     "place": {
       "name": "Maquoketa",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6128,
       "coord": [-90.6654748, 42.0690915],
@@ -44154,7 +44154,7 @@
     "place": {
       "name": "Marana",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 51908,
       "coord": [-111.211475, 32.4483736],
@@ -44181,7 +44181,7 @@
     "place": {
       "name": "Marathon City",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1582,
       "coord": [-89.8394576, 44.9310044],
@@ -44200,7 +44200,7 @@
     "place": {
       "name": "Marathon County",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 138013,
       "coord": [-89.7748098, 44.8914036],
@@ -44219,7 +44219,7 @@
     "place": {
       "name": "Marcellus",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1074,
       "coord": [-85.8155576, 42.0258779],
@@ -44252,7 +44252,7 @@
     "place": {
       "name": "Marcus Hook",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2454,
       "coord": [-75.4196694, 39.8214874],
@@ -44271,7 +44271,7 @@
     "place": {
       "name": "Marcus",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1079,
       "coord": [-95.8079104, 42.82471],
@@ -44290,7 +44290,7 @@
     "place": {
       "name": "Marengo",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2435,
       "coord": [-92.069382, 41.8001041],
@@ -44309,7 +44309,7 @@
     "place": {
       "name": "Maricopa",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 58125,
       "coord": [-112.048046, 33.057303],
@@ -44351,7 +44351,7 @@
     "place": {
       "name": "Marietta",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2633,
       "coord": [-76.55311563959538, 40.0573456],
@@ -44370,7 +44370,7 @@
     "place": {
       "name": "Marine City",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4079,
       "coord": [-82.4941921, 42.7190045],
@@ -44397,7 +44397,7 @@
     "place": {
       "name": "Marion",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 41535,
       "coord": [-91.5987335, 42.0329753],
@@ -44416,7 +44416,7 @@
     "place": {
       "name": "Marion",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28310,
       "coord": [-85.6591442, 40.5583739],
@@ -44435,7 +44435,7 @@
     "place": {
       "name": "Marion",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35999,
       "coord": [-83.12887, 40.588691],
@@ -44454,7 +44454,7 @@
     "place": {
       "name": "Marion",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 849,
       "coord": [-97.260615, 43.423039],
@@ -44473,7 +44473,7 @@
     "place": {
       "name": "Markesan",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1362,
       "coord": [-88.9900685, 43.7073195],
@@ -44492,7 +44492,7 @@
     "place": {
       "name": "Markstay-Warren",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 2708,
       "coord": [-80.49241648711632, 46.493508750000004],
@@ -44511,7 +44511,7 @@
     "place": {
       "name": "Marlborough",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6133,
       "coord": [-72.459808, 41.631488],
@@ -44538,7 +44538,7 @@
     "place": {
       "name": "Marlette",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1855,
       "coord": [-83.08022, 43.326969],
@@ -44557,7 +44557,7 @@
     "place": {
       "name": "Marlow",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4385,
       "coord": [-97.9579447, 34.6477329],
@@ -44576,7 +44576,7 @@
     "place": {
       "name": "Marquette",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 429,
       "coord": [-91.1793055, 43.0450606],
@@ -44595,7 +44595,7 @@
     "place": {
       "name": "Marquette",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20995,
       "coord": [-87.396433, 46.5434914],
@@ -44614,7 +44614,7 @@
     "place": {
       "name": "Marshall",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3947,
       "coord": [-87.695882, 39.39053],
@@ -44633,7 +44633,7 @@
     "place": {
       "name": "Marshall",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6822,
       "coord": [-84.9642008, 42.2721367],
@@ -44652,7 +44652,7 @@
     "place": {
       "name": "Marshall",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13628,
       "coord": [-95.7886581, 44.4469635],
@@ -44671,7 +44671,7 @@
     "place": {
       "name": "Marshall",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13806,
       "coord": [-93.1968704, 39.1230777],
@@ -44690,7 +44690,7 @@
     "place": {
       "name": "Marshall",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3813,
       "coord": [-89.0667775, 43.1683286],
@@ -44709,7 +44709,7 @@
     "place": {
       "name": "Marshalltown",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27591,
       "coord": [-92.9122672, 42.048881],
@@ -44742,7 +44742,7 @@
     "place": {
       "name": "Marshville",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2522,
       "coord": [-80.3670085, 34.988486],
@@ -44782,7 +44782,7 @@
     "place": {
       "name": "Martinsburg",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18773,
       "coord": [-77.9639604, 39.4562528],
@@ -44809,7 +44809,7 @@
     "place": {
       "name": "Marysville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24667,
       "coord": [-83.3671432, 40.2364486],
@@ -44828,7 +44828,7 @@
     "place": {
       "name": "Marysville",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 70298,
       "coord": [-122.1768209, 48.0517429],
@@ -44847,7 +44847,7 @@
     "place": {
       "name": "Maryville",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10633,
       "coord": [-94.8723858, 40.3460468],
@@ -44866,7 +44866,7 @@
     "place": {
       "name": "Mascoutah",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8754,
       "coord": [-89.793154, 38.490327],
@@ -44885,7 +44885,7 @@
     "place": {
       "name": "Mason City",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26931,
       "coord": [-93.2010367, 43.1535728],
@@ -44912,7 +44912,7 @@
     "place": {
       "name": "Mason",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8283,
       "coord": [-84.443096, 42.57972],
@@ -44931,7 +44931,7 @@
     "place": {
       "name": "Mason",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1337,
       "coord": [-89.533788, 35.411132],
@@ -44950,7 +44950,7 @@
     "place": {
       "name": "Massillon",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32146,
       "coord": [-81.5231597, 40.7965119],
@@ -44969,7 +44969,7 @@
     "place": {
       "name": "Matamoras",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2362,
       "coord": [-74.7001632, 41.3687049],
@@ -44988,7 +44988,7 @@
     "place": {
       "name": "Matherville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 707,
       "coord": [-90.6079133, 41.2597571],
@@ -45007,7 +45007,7 @@
     "place": {
       "name": "Mattawa",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1881,
       "coord": [-78.703308, 46.317296],
@@ -45026,7 +45026,7 @@
     "place": {
       "name": "Matteson",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19073,
       "coord": [-87.739267, 41.509832],
@@ -45045,7 +45045,7 @@
     "place": {
       "name": "Matthews",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29435,
       "coord": [-80.7224386, 35.1159532],
@@ -45072,7 +45072,7 @@
     "place": {
       "name": "Mattoon",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16870,
       "coord": [-88.3773279, 39.4842821],
@@ -45091,7 +45091,7 @@
     "place": {
       "name": "Maumee",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13896,
       "coord": [-83.6538244, 41.5628294],
@@ -45118,7 +45118,7 @@
     "place": {
       "name": "Mauston",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4347,
       "coord": [-90.0773495, 43.7971946],
@@ -45137,7 +45137,7 @@
     "place": {
       "name": "Mayfield",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10017,
       "coord": [-88.6352595, 36.7413624],
@@ -45156,7 +45156,7 @@
     "place": {
       "name": "Maysville",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8873,
       "coord": [-83.744365, 38.6411854],
@@ -45175,7 +45175,7 @@
     "place": {
       "name": "Mayville",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 922,
       "coord": [-83.35245, 43.336968],
@@ -45194,7 +45194,7 @@
     "place": {
       "name": "Mayville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5196,
       "coord": [-88.5448278, 43.4942003],
@@ -45213,7 +45213,7 @@
     "place": {
       "name": "Maywood",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23512,
       "coord": [-87.8436412, 41.8789942],
@@ -45240,7 +45240,7 @@
     "place": {
       "name": "Mazomanie",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1787,
       "coord": [-89.7960089, 43.1753733],
@@ -45259,7 +45259,7 @@
     "place": {
       "name": "Mazon",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 979,
       "coord": [-88.4195101, 41.2414217],
@@ -45278,7 +45278,7 @@
     "place": {
       "name": "McAdenville",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 890,
       "coord": [-81.0753535, 35.2593056],
@@ -45313,7 +45313,7 @@
     "place": {
       "name": "McAllen",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 142210,
       "coord": [-98.2300605, 26.204114],
@@ -45332,7 +45332,7 @@
     "place": {
       "name": "McBain",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 637,
       "coord": [-85.213376, 44.193623],
@@ -45351,7 +45351,7 @@
     "place": {
       "name": "McCall",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2991,
       "coord": [-116.0987364, 44.911006],
@@ -45370,7 +45370,7 @@
     "place": {
       "name": "McComb",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12413,
       "coord": [-90.4531536, 31.2437872],
@@ -45389,7 +45389,7 @@
     "place": {
       "name": "McComb",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1558,
       "coord": [-83.7927147, 41.1075523],
@@ -45416,7 +45416,7 @@
     "place": {
       "name": "McCook",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7446,
       "coord": [-100.6257666, 40.2006859],
@@ -45435,7 +45435,7 @@
     "place": {
       "name": "McCool Junction",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 453,
       "coord": [-97.5935135, 40.7442155],
@@ -45454,7 +45454,7 @@
     "place": {
       "name": "McDonald",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2056,
       "coord": [-80.2347814, 40.3709025],
@@ -45473,7 +45473,7 @@
     "place": {
       "name": "McFarland",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8991,
       "coord": [-89.2897646, 43.0123487],
@@ -45492,7 +45492,7 @@
     "place": {
       "name": "McGarry",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 579,
       "coord": [-79.58429076884471, 48.14980105],
@@ -45511,7 +45511,7 @@
     "place": {
       "name": "McGregor",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 742,
       "coord": [-91.1784542, 43.0218327],
@@ -45530,7 +45530,7 @@
     "place": {
       "name": "McGregor",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5338,
       "coord": [-97.4080875, 31.4367029],
@@ -45549,7 +45549,7 @@
     "place": {
       "name": "McHenry County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 310229,
       "coord": [-88.4605713, 42.3294391],
@@ -45568,7 +45568,7 @@
     "place": {
       "name": "McHenry",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27135,
       "coord": [-88.2674875, 42.3431427],
@@ -45587,7 +45587,7 @@
     "place": {
       "name": "McKees Rocks",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5920,
       "coord": [-80.0656106, 40.4656244],
@@ -45606,7 +45606,7 @@
     "place": {
       "name": "McKinney",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 195308,
       "coord": [-96.6154471, 33.1976496],
@@ -45633,7 +45633,7 @@
     "place": {
       "name": "McPherson",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14082,
       "coord": [-97.6642087, 38.3708415],
@@ -45652,7 +45652,7 @@
     "place": {
       "name": "Meadville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13050,
       "coord": [-80.151449, 41.641445],
@@ -45671,7 +45671,7 @@
     "place": {
       "name": "Meaford",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 11485,
       "coord": [-80.5916531, 44.6069298],
@@ -45690,7 +45690,7 @@
     "place": {
       "name": "Mechanicsburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9311,
       "coord": [-77.0047276, 40.2101972],
@@ -45717,7 +45717,7 @@
     "place": {
       "name": "Mechanicsville",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1020,
       "coord": [-91.2546067, 41.9044574],
@@ -45736,7 +45736,7 @@
     "place": {
       "name": "Mediapolis",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1688,
       "coord": [-91.1640201, 41.0079667],
@@ -45755,7 +45755,7 @@
     "place": {
       "name": "Medicine Bow",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 241,
       "coord": [-106.204739, 41.895521],
@@ -45774,7 +45774,7 @@
     "place": {
       "name": "Medina",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9002,
       "coord": [-81.8637474, 41.1383878],
@@ -45807,7 +45807,7 @@
     "place": {
       "name": "Melbourne",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 84678,
       "coord": [-80.6371513, 28.106471],
@@ -45834,7 +45834,7 @@
     "place": {
       "name": "Memphis",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1084,
       "coord": [-82.7688135, 42.8964179],
@@ -45853,7 +45853,7 @@
     "place": {
       "name": "Memphis",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1731,
       "coord": [-92.1712924, 40.4578119],
@@ -45872,7 +45872,7 @@
     "place": {
       "name": "Memphis",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 633104,
       "coord": [-90.0517638, 35.1460249],
@@ -45906,7 +45906,7 @@
     "place": {
       "name": "Menahga",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1340,
       "coord": [-95.0977002, 46.7539483],
@@ -45925,7 +45925,7 @@
     "place": {
       "name": "Menands",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4554,
       "coord": [-73.7245639, 42.6920233],
@@ -45950,7 +45950,7 @@
     "place": {
       "name": "Menard County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 12705,
       "coord": [-89.7858065, 40.0166667],
@@ -45969,7 +45969,7 @@
     "place": {
       "name": "Menasha",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18268,
       "coord": [-88.4465361, 44.2022293],
@@ -45988,7 +45988,7 @@
     "place": {
       "name": "Mendota",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12595,
       "coord": [-120.381557, 36.7535486],
@@ -46007,7 +46007,7 @@
     "place": {
       "name": "Mendota",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7061,
       "coord": [-89.1175852, 41.5472547],
@@ -46026,7 +46026,7 @@
     "place": {
       "name": "Menlo",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 345,
       "coord": [-94.4048002, 41.5199394],
@@ -46045,7 +46045,7 @@
     "place": {
       "name": "Menominee",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8488,
       "coord": [-87.614491, 45.107671],
@@ -46064,7 +46064,7 @@
     "place": {
       "name": "Menomonie",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16843,
       "coord": [-91.9278716, 44.8765289],
@@ -46091,7 +46091,7 @@
     "place": {
       "name": "Mentor",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 47450,
       "coord": [-81.3399769, 41.6664781],
@@ -46110,7 +46110,7 @@
     "place": {
       "name": "Mercer",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1982,
       "coord": [-80.3014412, 41.3334542],
@@ -46129,7 +46129,7 @@
     "place": {
       "name": "Mercersburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1507,
       "coord": [-77.9037226, 39.8282214],
@@ -46148,7 +46148,7 @@
     "place": {
       "name": "Meriden",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 60850,
       "coord": [-72.8070435, 41.5381535],
@@ -46192,7 +46192,7 @@
     "place": {
       "name": "Meridian Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43916,
       "coord": [-84.414709, 42.7278577],
@@ -46219,7 +46219,7 @@
     "place": {
       "name": "Meridian",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 117635,
       "coord": [-116.392326, 43.6086295],
@@ -46242,7 +46242,7 @@
     "place": {
       "name": "Meridian",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35052,
       "coord": [-88.703656, 32.3643098],
@@ -46261,7 +46261,7 @@
     "place": {
       "name": "Merrill",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9347,
       "coord": [-89.683459, 45.180522],
@@ -46280,7 +46280,7 @@
     "place": {
       "name": "Merrillan",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 564,
       "coord": [-90.8412561, 44.4510731],
@@ -46299,7 +46299,7 @@
     "place": {
       "name": "Merrimac",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 527,
       "coord": [-89.6234552, 43.3733198],
@@ -46318,7 +46318,7 @@
     "place": {
       "name": "Merritt",
       "state": "BC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 7139,
       "coord": [-120.7884149, 50.1124876],
@@ -46337,7 +46337,7 @@
     "place": {
       "name": "Mesa",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 504258,
       "coord": [-111.831455, 33.4151005],
@@ -46364,7 +46364,7 @@
     "place": {
       "name": "Meshoppen",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 326,
       "coord": [-76.0465462, 41.6141652],
@@ -46383,7 +46383,7 @@
     "place": {
       "name": "Mesquite",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 150108,
       "coord": [-96.599472, 32.7666103],
@@ -46402,7 +46402,7 @@
     "place": {
       "name": "Metropolis",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5969,
       "coord": [-88.7319979, 37.1511655],
@@ -46421,7 +46421,7 @@
     "place": {
       "name": "Metuchen",
       "state": "NJ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14543,
       "coord": [-74.3632049, 40.5431598],
@@ -46448,7 +46448,7 @@
     "place": {
       "name": "Mexico City",
       "state": "DF",
-      "country": "MX",
+      "country": "Mexico",
       "type": "city",
       "pop": 8918653,
       "coord": [-99.1331785, 19.4326296],
@@ -46475,7 +46475,7 @@
     "place": {
       "name": "Mexico",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11469,
       "coord": [-91.8829484, 39.1697626],
@@ -46494,7 +46494,7 @@
     "place": {
       "name": "Miami",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1541,
       "coord": [-110.8709218, 33.3995392],
@@ -46513,7 +46513,7 @@
     "place": {
       "name": "Miami",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 467963,
       "coord": [-80.19362, 25.7741728],
@@ -46559,7 +46559,7 @@
     "place": {
       "name": "Michigan City",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32075,
       "coord": [-86.8950297, 41.7075394],
@@ -46586,7 +46586,7 @@
     "place": {
       "name": "Middleburg Heights",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16004,
       "coord": [-81.812912, 41.3614401],
@@ -46605,7 +46605,7 @@
     "place": {
       "name": "Middleburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1325,
       "coord": [-77.0472028, 40.7859166],
@@ -46624,7 +46624,7 @@
     "place": {
       "name": "Middlebury",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7574,
       "coord": [-73.1276107, 41.5278742],
@@ -46643,7 +46643,7 @@
     "place": {
       "name": "Middleton",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21827,
       "coord": [-89.5119565, 43.0962919],
@@ -46678,7 +46678,7 @@
     "place": {
       "name": "Middletown",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 47717,
       "coord": [-72.6509061, 41.5623178],
@@ -46697,7 +46697,7 @@
     "place": {
       "name": "Middletown",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 50987,
       "coord": [-84.3982763, 39.5150576],
@@ -46716,7 +46716,7 @@
     "place": {
       "name": "Middletown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9550,
       "coord": [-76.731259, 40.199837],
@@ -46735,7 +46735,7 @@
     "place": {
       "name": "Middletown",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17075,
       "coord": [-71.2914388, 41.5456578],
@@ -46754,7 +46754,7 @@
     "place": {
       "name": "Middleville",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4295,
       "coord": [-85.4619599, 42.7130889],
@@ -46781,7 +46781,7 @@
     "place": {
       "name": "Midland",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 42547,
       "coord": [-84.244751, 43.612621],
@@ -46822,7 +46822,7 @@
     "place": {
       "name": "Midland",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4684,
       "coord": [-80.5006219, 35.2273656],
@@ -46863,7 +46863,7 @@
     "place": {
       "name": "Midland",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 17817,
       "coord": [-79.885712, 44.750147],
@@ -46882,7 +46882,7 @@
     "place": {
       "name": "Midland",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 132524,
       "coord": [-102.076183, 31.997822],
@@ -46901,7 +46901,7 @@
     "place": {
       "name": "Midwest City",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 58409,
       "coord": [-97.3967025, 35.4495097],
@@ -46920,7 +46920,7 @@
     "place": {
       "name": "Mifflinburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3424,
       "coord": [-77.0477501, 40.917582],
@@ -46939,7 +46939,7 @@
     "place": {
       "name": "Milan",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5097,
       "coord": [-90.5720803, 41.453089],
@@ -46958,7 +46958,7 @@
     "place": {
       "name": "Milan",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6079,
       "coord": [-83.6830279, 42.0848616],
@@ -46977,7 +46977,7 @@
     "place": {
       "name": "Miles City",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8354,
       "coord": [-105.840981, 46.4085273],
@@ -47004,7 +47004,7 @@
     "place": {
       "name": "Milford Center",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 807,
       "coord": [-83.4354782, 40.1786706],
@@ -47023,7 +47023,7 @@
     "place": {
       "name": "Milford",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 50558,
       "coord": [-73.0570603, 41.2222218],
@@ -47042,7 +47042,7 @@
     "place": {
       "name": "Milford",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11190,
       "coord": [-75.4278733, 38.9130453],
@@ -47061,7 +47061,7 @@
     "place": {
       "name": "Milford",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3321,
       "coord": [-95.1508003, 43.32396],
@@ -47080,7 +47080,7 @@
     "place": {
       "name": "Milford",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6520,
       "coord": [-83.6000696, 42.5917805],
@@ -47099,7 +47099,7 @@
     "place": {
       "name": "Milford",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6582,
       "coord": [-84.2958988, 39.174625],
@@ -47118,7 +47118,7 @@
     "place": {
       "name": "Milford",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1431,
       "coord": [-113.010789, 38.3969108],
@@ -47137,7 +47137,7 @@
     "place": {
       "name": "Millbourne",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1212,
       "coord": [-75.2501821, 39.9634461],
@@ -47156,7 +47156,7 @@
     "place": {
       "name": "Millersburg",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3151,
       "coord": [-81.9179198, 40.5545071],
@@ -47175,7 +47175,7 @@
     "place": {
       "name": "Millersburg",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2919,
       "coord": [-123.061482, 44.680955],
@@ -47194,7 +47194,7 @@
     "place": {
       "name": "Millersburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2541,
       "coord": [-76.9614003, 40.5417153],
@@ -47229,7 +47229,7 @@
     "place": {
       "name": "Millersville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7629,
       "coord": [-76.3545372, 39.997998],
@@ -47248,7 +47248,7 @@
     "place": {
       "name": "Milltown",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 947,
       "coord": [-92.5085348, 45.5260681],
@@ -47267,7 +47267,7 @@
     "place": {
       "name": "Millvale",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3376,
       "coord": [-79.9783862, 40.480069],
@@ -47286,7 +47286,7 @@
     "place": {
       "name": "Milton",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3291,
       "coord": [-75.3101583, 38.7778049],
@@ -47305,7 +47305,7 @@
     "place": {
       "name": "Milton",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 132979,
       "coord": [-79.882817, 43.513671],
@@ -47346,7 +47346,7 @@
     "place": {
       "name": "Milton",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5716,
       "coord": [-88.943999, 42.7755645],
@@ -47365,7 +47365,7 @@
     "place": {
       "name": "Milwaukee",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 590157,
       "coord": [-87.922497, 43.0349931],
@@ -47384,7 +47384,7 @@
     "place": {
       "name": "Milwaukie",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20990,
       "coord": [-122.6412523, 45.4440051],
@@ -47417,7 +47417,7 @@
     "place": {
       "name": "Minden",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11928,
       "coord": [-93.2868354, 32.6154278],
@@ -47436,7 +47436,7 @@
     "place": {
       "name": "Minden",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3118,
       "coord": [-98.9476854, 40.4985164],
@@ -47455,7 +47455,7 @@
     "place": {
       "name": "Mineral Point",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2581,
       "coord": [-90.179547, 42.8601834],
@@ -47474,7 +47474,7 @@
     "place": {
       "name": "Mineral Springs",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3159,
       "coord": [-80.6686791, 34.9379274],
@@ -47493,7 +47493,7 @@
     "place": {
       "name": "Minneapolis",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1946,
       "coord": [-97.7087076, 39.1223968],
@@ -47512,7 +47512,7 @@
     "place": {
       "name": "Minneapolis",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 429606,
       "coord": [-93.2654692, 44.9772995],
@@ -47539,7 +47539,7 @@
     "place": {
       "name": "Minnetonka",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 53781,
       "coord": [-93.4638936, 44.9405086],
@@ -47558,7 +47558,7 @@
     "place": {
       "name": "Minnetrista",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8262,
       "coord": [-93.7186813, 44.923562],
@@ -47577,7 +47577,7 @@
     "place": {
       "name": "Minong",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 548,
       "coord": [-91.8248058, 46.0994196],
@@ -47596,7 +47596,7 @@
     "place": {
       "name": "Minonk",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1928,
       "coord": [-89.0345224, 40.9044778],
@@ -47615,7 +47615,7 @@
     "place": {
       "name": "Minooka",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12758,
       "coord": [-88.2617305, 41.4553084],
@@ -47634,7 +47634,7 @@
     "place": {
       "name": "Minot",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 48377,
       "coord": [-101.296273, 48.23251],
@@ -47661,7 +47661,7 @@
     "place": {
       "name": "Mint Hill",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26450,
       "coord": [-80.6570377, 35.1735388],
@@ -47680,7 +47680,7 @@
     "place": {
       "name": "Minturn",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1033,
       "coord": [-106.4308631, 39.5863749],
@@ -47699,7 +47699,7 @@
     "place": {
       "name": "Mishawaka",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 51063,
       "coord": [-86.1807031, 41.6611642],
@@ -47718,7 +47718,7 @@
     "place": {
       "name": "Missoula",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 74994,
       "coord": [-113.995267, 46.8701049],
@@ -47737,7 +47737,7 @@
     "place": {
       "name": "Moab",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5366,
       "coord": [-109.546214, 38.5738096],
@@ -47756,7 +47756,7 @@
     "place": {
       "name": "Moberly",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13783,
       "coord": [-92.4364298, 39.4201137],
@@ -47775,7 +47775,7 @@
     "place": {
       "name": "Mobile",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 187041,
       "coord": [-88.0437509, 30.6913462],
@@ -47794,7 +47794,7 @@
     "place": {
       "name": "Modena",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 544,
       "coord": [-75.8010997, 39.9617355],
@@ -47821,7 +47821,7 @@
     "place": {
       "name": "Modesto",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 218464,
       "coord": [-120.9968782, 37.6390972],
@@ -47848,7 +47848,7 @@
     "place": {
       "name": "Mokena",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19887,
       "coord": [-87.8892189, 41.5261437],
@@ -47875,7 +47875,7 @@
     "place": {
       "name": "Moline",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 42418,
       "coord": [-90.5136642, 41.5058344],
@@ -47894,7 +47894,7 @@
     "place": {
       "name": "Moncton",
       "state": "NB",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 85198,
       "coord": [-64.80011, 46.097995],
@@ -47913,7 +47913,7 @@
     "place": {
       "name": "Mondovi",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2807,
       "coord": [-91.6706955, 44.5678717],
@@ -47932,7 +47932,7 @@
     "place": {
       "name": "Monett",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9576,
       "coord": [-93.9277149, 36.9289518],
@@ -47951,7 +47951,7 @@
     "place": {
       "name": "Monona",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1471,
       "coord": [-91.3896122, 43.0527391],
@@ -47970,7 +47970,7 @@
     "place": {
       "name": "Monona",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8624,
       "coord": [-89.3340068, 43.0622189],
@@ -47989,7 +47989,7 @@
     "place": {
       "name": "Monroe",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18825,
       "coord": [-73.2073358, 41.3325962],
@@ -48008,7 +48008,7 @@
     "place": {
       "name": "Monroe",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 47702,
       "coord": [-92.1032411, 32.5102427],
@@ -48035,7 +48035,7 @@
     "place": {
       "name": "Monroe",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20462,
       "coord": [-83.397591, 41.916441],
@@ -48054,7 +48054,7 @@
     "place": {
       "name": "Monroe",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 34551,
       "coord": [-80.5495112, 34.9854275],
@@ -48073,7 +48073,7 @@
     "place": {
       "name": "Monroe",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15412,
       "coord": [-84.362371, 39.441865],
@@ -48100,7 +48100,7 @@
     "place": {
       "name": "Monroe",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 159,
       "coord": [-97.215059, 43.486371],
@@ -48119,7 +48119,7 @@
     "place": {
       "name": "Monroe",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10661,
       "coord": [-89.6395, 42.6015],
@@ -48138,7 +48138,7 @@
     "place": {
       "name": "Monrovia",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1643,
       "coord": [-86.4822187, 39.5789357],
@@ -48157,7 +48157,7 @@
     "place": {
       "name": "Montague",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2417,
       "coord": [-86.357013, 43.416677],
@@ -48184,7 +48184,7 @@
     "place": {
       "name": "Montana",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "state",
       "pop": 1084225,
       "coord": [-109.522173, 46.892258],
@@ -48203,7 +48203,7 @@
     "place": {
       "name": "Monte Vista",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4247,
       "coord": [-106.1496731, 37.5816182],
@@ -48222,7 +48222,7 @@
     "place": {
       "name": "Montello",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1418,
       "coord": [-89.3198414, 43.7913679],
@@ -48255,7 +48255,7 @@
     "place": {
       "name": "Montevallo",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7229,
       "coord": [-86.8641558, 33.1006746],
@@ -48274,7 +48274,7 @@
     "place": {
       "name": "Montevideo",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5398,
       "coord": [-95.723559, 44.942523],
@@ -48293,7 +48293,7 @@
     "place": {
       "name": "Montgomery City",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2811,
       "coord": [-91.5048844, 38.9775406],
@@ -48312,7 +48312,7 @@
     "place": {
       "name": "Montgomery County",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 1062061,
       "coord": [-77.2716502, 39.1731621],
@@ -48331,7 +48331,7 @@
     "place": {
       "name": "Montgomery",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 200603,
       "coord": [-86.3006485, 32.3669656],
@@ -48350,7 +48350,7 @@
     "place": {
       "name": "Montgomery",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20262,
       "coord": [-88.3459048, 41.730585],
@@ -48391,7 +48391,7 @@
     "place": {
       "name": "Montgomery",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3249,
       "coord": [-93.5813413, 44.4388525],
@@ -48410,7 +48410,7 @@
     "place": {
       "name": "Montgomery",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10853,
       "coord": [-84.354541, 39.227252],
@@ -48437,7 +48437,7 @@
     "place": {
       "name": "Montgomery",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1280,
       "coord": [-81.3284452, 38.1803833],
@@ -48456,7 +48456,7 @@
     "place": {
       "name": "Monticello",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14455,
       "coord": [-93.7939996, 45.3053901],
@@ -48475,7 +48475,7 @@
     "place": {
       "name": "Monticello",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1191,
       "coord": [-89.5945254, 42.7456573],
@@ -48494,7 +48494,7 @@
     "place": {
       "name": "Montoursville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4745,
       "coord": [-76.9267035, 41.2495431],
@@ -48513,7 +48513,7 @@
     "place": {
       "name": "Montpelier",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2643,
       "coord": [-111.2977044, 42.3221498],
@@ -48532,7 +48532,7 @@
     "place": {
       "name": "Montpelier",
       "state": "VT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8074,
       "coord": [-72.5751208, 44.2602164],
@@ -48565,7 +48565,7 @@
     "place": {
       "name": "Montreal",
       "state": "QC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1762949,
       "coord": [-73.5698065, 45.5031824],
@@ -48590,7 +48590,7 @@
     "place": {
       "name": "Montreal",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 799,
       "coord": [-90.2460097, 46.4280033],
@@ -48609,7 +48609,7 @@
     "place": {
       "name": "Montrose",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1743,
       "coord": [-83.892744, 43.176694],
@@ -48628,7 +48628,7 @@
     "place": {
       "name": "Monument",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10399,
       "coord": [-104.872758, 39.0916586],
@@ -48647,7 +48647,7 @@
     "place": {
       "name": "Mooresville ",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 51594,
       "coord": [-80.8100724, 35.5848596],
@@ -48674,7 +48674,7 @@
     "place": {
       "name": "Moorhead",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 44505,
       "coord": [-96.7538674, 46.8739081],
@@ -48693,7 +48693,7 @@
     "place": {
       "name": "Mora",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3665,
       "coord": [-93.2938352, 45.8769031],
@@ -48712,7 +48712,7 @@
     "place": {
       "name": "Moravia",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1224,
       "coord": [-76.4216025, 42.7125702],
@@ -48731,7 +48731,7 @@
     "place": {
       "name": "Morenci",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2270,
       "coord": [-84.2173964, 41.7195109],
@@ -48750,7 +48750,7 @@
     "place": {
       "name": "Moreno Valley",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 208634,
       "coord": [-117.2305944, 33.937517],
@@ -48769,7 +48769,7 @@
     "place": {
       "name": "Morgan City",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11472,
       "coord": [-91.20677, 29.6993748],
@@ -48796,7 +48796,7 @@
     "place": {
       "name": "Morgantown",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30347,
       "coord": [-79.9559437, 39.6296809],
@@ -48831,7 +48831,7 @@
     "place": {
       "name": "Moriarty",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1946,
       "coord": [-106.0494876, 34.9972037],
@@ -48850,7 +48850,7 @@
     "place": {
       "name": "Morning Sun",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 752,
       "coord": [-91.2555771, 41.0959721],
@@ -48869,7 +48869,7 @@
     "place": {
       "name": "Morrice",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 949,
       "coord": [-84.1783003, 42.8386425],
@@ -48888,7 +48888,7 @@
     "place": {
       "name": "Morris",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5105,
       "coord": [-95.913941, 45.586072],
@@ -48907,7 +48907,7 @@
     "place": {
       "name": "Morrison",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 396,
       "coord": [-105.1911, 39.6536],
@@ -48926,7 +48926,7 @@
     "place": {
       "name": "Morrison",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4085,
       "coord": [-89.9649496, 41.8094058],
@@ -48945,7 +48945,7 @@
     "place": {
       "name": "Morristown",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1205,
       "coord": [-85.6989709, 39.6732065],
@@ -48964,7 +48964,7 @@
     "place": {
       "name": "Morristown",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 949,
       "coord": [-93.444316, 44.2264466],
@@ -48983,7 +48983,7 @@
     "place": {
       "name": "Morrisville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9809,
       "coord": [-74.7879399, 40.2114978],
@@ -49010,7 +49010,7 @@
     "place": {
       "name": "Morton",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17117,
       "coord": [-89.459323, 40.6127349],
@@ -49029,7 +49029,7 @@
     "place": {
       "name": "Morton",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 410,
       "coord": [-94.9844392, 44.5513496],
@@ -49048,7 +49048,7 @@
     "place": {
       "name": "Morven",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 335,
       "coord": [-80.0011724, 34.8640437],
@@ -49088,7 +49088,7 @@
     "place": {
       "name": "Moscow",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2039,
       "coord": [-75.5185191, 41.3367497],
@@ -49107,7 +49107,7 @@
     "place": {
       "name": "Mosinee",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4452,
       "coord": [-89.7035959, 44.7927298],
@@ -49126,7 +49126,7 @@
     "place": {
       "name": "Moss Point",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12147,
       "coord": [-88.5344601, 30.4115881],
@@ -49145,7 +49145,7 @@
     "place": {
       "name": "Mound",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9398,
       "coord": [-93.6660719, 44.9366295],
@@ -49164,7 +49164,7 @@
     "place": {
       "name": "Moundridge",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1974,
       "coord": [-97.519207, 38.203065],
@@ -49183,7 +49183,7 @@
     "place": {
       "name": "Moundsville",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8122,
       "coord": [-80.7432124, 39.920425],
@@ -49202,7 +49202,7 @@
     "place": {
       "name": "Mount Airy",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10551,
       "coord": [-80.6071609, 36.4993297],
@@ -49221,7 +49221,7 @@
     "place": {
       "name": "Mount Carmel",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6804,
       "coord": [-87.7614174, 38.4108801],
@@ -49240,7 +49240,7 @@
     "place": {
       "name": "Mount Horeb",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7754,
       "coord": [-89.7384557, 43.0086183],
@@ -49259,7 +49259,7 @@
     "place": {
       "name": "Mount Pleasant",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9274,
       "coord": [-91.5539956, 40.966312],
@@ -49278,7 +49278,7 @@
     "place": {
       "name": "Mount Pleasant",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21688,
       "coord": [-84.7668495, 43.597646],
@@ -49297,7 +49297,7 @@
     "place": {
       "name": "Mount Pleasant",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4245,
       "coord": [-79.5421368, 40.1487475],
@@ -49316,7 +49316,7 @@
     "place": {
       "name": "Mount Pleasant",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 90801,
       "coord": [-79.8625851, 32.7940651],
@@ -49335,7 +49335,7 @@
     "place": {
       "name": "Mount Pocono",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3083,
       "coord": [-75.3646997, 41.1220987],
@@ -49354,7 +49354,7 @@
     "place": {
       "name": "Mount Prospect",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 54165,
       "coord": [-87.9372908, 42.0664167],
@@ -49373,7 +49373,7 @@
     "place": {
       "name": "Mount Pulaski",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1537,
       "coord": [-89.282314, 40.0108767],
@@ -49392,7 +49392,7 @@
     "place": {
       "name": "Mount Sterling",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2006,
       "coord": [-90.763463, 39.9872707],
@@ -49411,7 +49411,7 @@
     "place": {
       "name": "Mountain Grove",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4313,
       "coord": [-92.2634942, 37.1306078],
@@ -49430,7 +49430,7 @@
     "place": {
       "name": "Mountain Home",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14562,
       "coord": [-115.691197, 43.1329504],
@@ -49449,7 +49449,7 @@
     "place": {
       "name": "Mountain View",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2877,
       "coord": [-92.1176521, 35.8684075],
@@ -49476,7 +49476,7 @@
     "place": {
       "name": "Mountain View",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 82739,
       "coord": [-122.0832101, 37.3893889],
@@ -49511,7 +49511,7 @@
     "place": {
       "name": "Mountainair",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 884,
       "coord": [-106.2407657, 34.5203535],
@@ -49538,7 +49538,7 @@
     "place": {
       "name": "Moville",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1687,
       "coord": [-96.072453, 42.4888404],
@@ -49557,7 +49557,7 @@
     "place": {
       "name": "Mt. Carroll",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1407,
       "coord": [-89.9777041, 42.0948582],
@@ -49576,7 +49576,7 @@
     "place": {
       "name": "Mt. Clemens",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15697,
       "coord": [-82.8779754, 42.5972563],
@@ -49611,7 +49611,7 @@
     "place": {
       "name": "Mt. Healthy",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6996,
       "coord": [-84.5457778, 39.2336687],
@@ -49638,7 +49638,7 @@
     "place": {
       "name": "Mt. Holly Springs",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1995,
       "coord": [-77.1899817, 40.1184235],
@@ -49657,7 +49657,7 @@
     "place": {
       "name": "Mt. Holly",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17703,
       "coord": [-81.0161686, 35.2976298],
@@ -49676,7 +49676,7 @@
     "place": {
       "name": "Mt. Joy",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8346,
       "coord": [-76.5033406, 40.1098561],
@@ -49695,7 +49695,7 @@
     "place": {
       "name": "Mt. Morris",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2861,
       "coord": [-89.4312201, 42.0503062],
@@ -49714,7 +49714,7 @@
     "place": {
       "name": "Mt. Olive",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 895,
       "coord": [-89.0522766, 31.7443269],
@@ -49733,7 +49733,7 @@
     "place": {
       "name": "Mt. Oliver",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3394,
       "coord": [-79.9852984, 40.4123735],
@@ -49752,7 +49752,7 @@
     "place": {
       "name": "Mt. Penn",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3240,
       "coord": [-75.8907603, 40.3281484],
@@ -49771,7 +49771,7 @@
     "place": {
       "name": "Mt. Pleasant",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1671,
       "coord": [-80.4358963, 35.399308],
@@ -49798,7 +49798,7 @@
     "place": {
       "name": "Mt. Pleasant",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27732,
       "coord": [-87.851473, 42.7292465],
@@ -49825,7 +49825,7 @@
     "place": {
       "name": "Mt. Union",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2308,
       "coord": [-77.8822199, 40.3845217],
@@ -49844,7 +49844,7 @@
     "place": {
       "name": "Mt. Vernon",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1354,
       "coord": [-88.0133325, 31.0851775],
@@ -49863,7 +49863,7 @@
     "place": {
       "name": "Mt. Vernon",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4527,
       "coord": [-91.4171209, 41.9222443],
@@ -49882,7 +49882,7 @@
     "place": {
       "name": "Mt. Vernon",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14600,
       "coord": [-88.9031201, 38.3172715],
@@ -49901,7 +49901,7 @@
     "place": {
       "name": "Mt. Vernon",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6493,
       "coord": [-87.8952993, 37.9396795],
@@ -49920,7 +49920,7 @@
     "place": {
       "name": "Mt. Vernon",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4526,
       "coord": [-93.8185401, 37.1036666],
@@ -49939,7 +49939,7 @@
     "place": {
       "name": "Mt. Washington",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18090,
       "coord": [-85.5457877, 38.0500627],
@@ -49958,7 +49958,7 @@
     "place": {
       "name": "Mt. Zion",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6019,
       "coord": [-88.874724, 39.771874],
@@ -49985,7 +49985,7 @@
     "place": {
       "name": "Muir",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 646,
       "coord": [-84.9425013, 42.9958661],
@@ -50004,7 +50004,7 @@
     "place": {
       "name": "Mulliken",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 525,
       "coord": [-84.8963815, 42.762257],
@@ -50023,7 +50023,7 @@
     "place": {
       "name": "Mullins",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4026,
       "coord": [-79.2559892, 34.2060587],
@@ -50042,7 +50042,7 @@
     "place": {
       "name": "Mulvane",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6286,
       "coord": [-97.2407207, 37.4780814],
@@ -50061,7 +50061,7 @@
     "place": {
       "name": "Muncie",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 65195,
       "coord": [-85.3865271, 40.1936892],
@@ -50080,7 +50080,7 @@
     "place": {
       "name": "Mundelein",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31560,
       "coord": [-88.0039653, 42.263079],
@@ -50107,7 +50107,7 @@
     "place": {
       "name": "Munhall",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10774,
       "coord": [-79.9000499, 40.3922914],
@@ -50126,7 +50126,7 @@
     "place": {
       "name": "Munising",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1586,
       "coord": [-86.6494698, 46.4100035],
@@ -50145,7 +50145,7 @@
     "place": {
       "name": "Munster",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23894,
       "coord": [-87.5125412, 41.5644798],
@@ -50172,7 +50172,7 @@
     "place": {
       "name": "Murfreesboro",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 152769,
       "coord": [-86.3921096, 35.8460396],
@@ -50191,7 +50191,7 @@
     "place": {
       "name": "Muscatine",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23797,
       "coord": [-91.044635, 41.421939],
@@ -50210,7 +50210,7 @@
     "place": {
       "name": "Muskegon Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17596,
       "coord": [-86.1667177079714, 43.25053325],
@@ -50229,7 +50229,7 @@
     "place": {
       "name": "Muskegon Heights",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9985,
       "coord": [-86.238946, 43.201126],
@@ -50256,7 +50256,7 @@
     "place": {
       "name": "Muskegon",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 38318,
       "coord": [-86.253158, 43.235391],
@@ -50283,7 +50283,7 @@
     "place": {
       "name": "Muskogee",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36878,
       "coord": [-95.371061, 35.74945],
@@ -50302,7 +50302,7 @@
     "place": {
       "name": "Muskoka Lakes",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 7652,
       "coord": [-79.56598810161641, 45.1178146],
@@ -50321,7 +50321,7 @@
     "place": {
       "name": "Myerstown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3103,
       "coord": [-76.30675872915134, 40.3724045],
@@ -50348,7 +50348,7 @@
     "place": {
       "name": "München",
       "state": "BY",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 1512491,
       "coord": [11.5753822, 48.1371079],
@@ -50367,7 +50367,7 @@
     "place": {
       "name": "Münster",
       "state": "NW",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 320946,
       "coord": [7.6251879, 51.9625101],
@@ -50390,7 +50390,7 @@
     "place": {
       "name": "Nacogdoches",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32147,
       "coord": [-94.65596905128348, 31.603928038722238],
@@ -50417,7 +50417,7 @@
     "place": {
       "name": "Nanaimo",
       "state": "BC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 99863,
       "coord": [-123.938122, 49.163877],
@@ -50450,7 +50450,7 @@
     "place": {
       "name": "Nanty Glo",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2511,
       "coord": [-78.8361674922373, 40.468338],
@@ -50469,7 +50469,7 @@
     "place": {
       "name": "Naperville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 149540,
       "coord": [-88.1479278, 41.7728699],
@@ -50488,7 +50488,7 @@
     "place": {
       "name": "Napoleon",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8862,
       "coord": [-84.1252243, 41.3922726],
@@ -50507,7 +50507,7 @@
     "place": {
       "name": "Nappanee",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6913,
       "coord": [-86.0013699, 41.4427856],
@@ -50526,7 +50526,7 @@
     "place": {
       "name": "Narberth",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4492,
       "coord": [-75.2616109, 40.0047478],
@@ -50561,7 +50561,7 @@
     "place": {
       "name": "Nashville",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4153,
       "coord": [-93.847129, 33.9456692],
@@ -50580,7 +50580,7 @@
     "place": {
       "name": "Nashville",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 692587,
       "coord": [-86.7742984, 36.1622767],
@@ -50607,7 +50607,7 @@
     "place": {
       "name": "Natchez",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14520,
       "coord": [-91.403171, 31.5604076],
@@ -50626,7 +50626,7 @@
     "place": {
       "name": "Natchitoches",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18039,
       "coord": [-93.0860209, 31.7606732],
@@ -50645,7 +50645,7 @@
     "place": {
       "name": "Natick",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36229,
       "coord": [-71.35936848, 42.28700595],
@@ -50664,7 +50664,7 @@
     "place": {
       "name": "Nauvoo",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 950,
       "coord": [-91.3848749, 40.550042],
@@ -50683,7 +50683,7 @@
     "place": {
       "name": "Nazareth",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6053,
       "coord": [-75.3112095, 40.7423309],
@@ -50702,7 +50702,7 @@
     "place": {
       "name": "Nebraska City",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7222,
       "coord": [-95.858694, 40.676526],
@@ -50721,7 +50721,7 @@
     "place": {
       "name": "Nederland",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1471,
       "coord": [-105.510831, 39.9613759],
@@ -50740,7 +50740,7 @@
     "place": {
       "name": "Neenah",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27319,
       "coord": [-88.462609, 44.1858193],
@@ -50759,7 +50759,7 @@
     "place": {
       "name": "Negaunee",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4627,
       "coord": [-87.611803, 46.499102],
@@ -50778,7 +50778,7 @@
     "place": {
       "name": "Neillsville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2384,
       "coord": [-90.595734, 44.5601834],
@@ -50797,7 +50797,7 @@
     "place": {
       "name": "Nekoosa",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2454,
       "coord": [-89.9042937, 44.3124644],
@@ -50816,7 +50816,7 @@
     "place": {
       "name": "Nelson County",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 48065,
       "coord": [-85.4741595, 37.8078463],
@@ -50843,7 +50843,7 @@
     "place": {
       "name": "Neosho",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12590,
       "coord": [-94.3701651, 36.8665201],
@@ -50862,7 +50862,7 @@
     "place": {
       "name": "Nevada",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6925,
       "coord": [-93.4524342, 42.0227653],
@@ -50881,7 +50881,7 @@
     "place": {
       "name": "Nevada",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8212,
       "coord": [-94.3596185, 37.8381108],
@@ -50900,7 +50900,7 @@
     "place": {
       "name": "New Albany",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 37841,
       "coord": [-85.8241312, 38.2856247],
@@ -50933,7 +50933,7 @@
     "place": {
       "name": "New Athens",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1955,
       "coord": [-89.8770468, 38.3264383],
@@ -50952,7 +50952,7 @@
     "place": {
       "name": "New Auburn",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 411,
       "coord": [-94.2296994, 44.6735743],
@@ -50971,7 +50971,7 @@
     "place": {
       "name": "New Auburn",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 561,
       "coord": [-91.5582197, 45.2041282],
@@ -50990,7 +50990,7 @@
     "place": {
       "name": "New Baltimore",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12117,
       "coord": [-82.7368616, 42.6811436],
@@ -51017,7 +51017,7 @@
     "place": {
       "name": "New Berlin",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40451,
       "coord": [-88.1090391, 42.976453],
@@ -51036,7 +51036,7 @@
     "place": {
       "name": "New Bremen",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3034,
       "coord": [-84.3796729, 40.4369919],
@@ -51055,7 +51055,7 @@
     "place": {
       "name": "New Brighton",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5729,
       "coord": [-80.3100513, 40.7303534],
@@ -51074,7 +51074,7 @@
     "place": {
       "name": "New Britain",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 74135,
       "coord": [-72.7795419, 41.6612104],
@@ -51119,7 +51119,7 @@
     "place": {
       "name": "New Buffalo",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1708,
       "coord": [-86.7444526, 41.7952562],
@@ -51138,7 +51138,7 @@
     "place": {
       "name": "New Canaan",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20622,
       "coord": [-73.4948446, 41.146763],
@@ -51157,7 +51157,7 @@
     "place": {
       "name": "New Carlisle",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1891,
       "coord": [-86.5094621, 41.7003231],
@@ -51176,7 +51176,7 @@
     "place": {
       "name": "New Castle",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4923,
       "coord": [-107.534965, 39.5714753],
@@ -51203,7 +51203,7 @@
     "place": {
       "name": "New Castle",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5551,
       "coord": [-75.662956, 39.6159851],
@@ -51238,7 +51238,7 @@
     "place": {
       "name": "New Castle",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17396,
       "coord": [-85.3702477, 39.9289351],
@@ -51257,7 +51257,7 @@
     "place": {
       "name": "New Castle",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21926,
       "coord": [-80.3471856, 40.9999202],
@@ -51276,7 +51276,7 @@
     "place": {
       "name": "New Cumberland",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7507,
       "coord": [-76.8673781, 40.2284433],
@@ -51311,7 +51311,7 @@
     "place": {
       "name": "New Fairfield",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13579,
       "coord": [-73.4856789, 41.4664832],
@@ -51338,7 +51338,7 @@
     "place": {
       "name": "New Florence",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 671,
       "coord": [-79.075308, 40.3803492],
@@ -51357,7 +51357,7 @@
     "place": {
       "name": "New Franklin",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1027,
       "coord": [-92.7374075, 39.0172514],
@@ -51376,7 +51376,7 @@
     "place": {
       "name": "New Hampshire",
       "state": "NH",
-      "country": "US",
+      "country": "United States",
       "type": "state",
       "pop": 1377529,
       "coord": [-71.59341813757975, 43.659069756492634],
@@ -51395,7 +51395,7 @@
     "place": {
       "name": "New Haven",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 135081,
       "coord": [-72.9250518, 41.3082138],
@@ -51430,7 +51430,7 @@
     "place": {
       "name": "New Haven",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15583,
       "coord": [-85.0173125, 41.0733059],
@@ -51465,7 +51465,7 @@
     "place": {
       "name": "New Haven",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2414,
       "coord": [-91.2190416, 38.6083822],
@@ -51484,7 +51484,7 @@
     "place": {
       "name": "New Hope",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2889,
       "coord": [-86.3944308, 34.5370339],
@@ -51519,7 +51519,7 @@
     "place": {
       "name": "New Hope",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21986,
       "coord": [-93.3861037, 45.0347176],
@@ -51546,7 +51546,7 @@
     "place": {
       "name": "New Hope",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2612,
       "coord": [-74.9512785, 40.3642728],
@@ -51565,7 +51565,7 @@
     "place": {
       "name": "New Iberia",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28555,
       "coord": [-91.8187285, 30.0035365],
@@ -51584,7 +51584,7 @@
     "place": {
       "name": "New Kensington",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12170,
       "coord": [-79.7647705, 40.5697893],
@@ -51603,7 +51603,7 @@
     "place": {
       "name": "New London",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27367,
       "coord": [-72.0997804, 41.3556187],
@@ -51622,7 +51622,7 @@
     "place": {
       "name": "New London",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1252,
       "coord": [-94.9441773, 45.3010756],
@@ -51641,7 +51641,7 @@
     "place": {
       "name": "New London",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7348,
       "coord": [-88.7398255, 44.3927581],
@@ -51660,7 +51660,7 @@
     "place": {
       "name": "New Market",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1525,
       "coord": [-77.2726393, 39.3827893],
@@ -51687,7 +51687,7 @@
     "place": {
       "name": "New Milford",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 794,
       "coord": [-89.05669931869377, 42.1798043],
@@ -51706,7 +51706,7 @@
     "place": {
       "name": "New Morgan",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 100,
       "coord": [-75.8902108, 40.180929],
@@ -51725,7 +51725,7 @@
     "place": {
       "name": "New Orleans",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 390144,
       "coord": [-90.0701156, 29.9499323],
@@ -51752,7 +51752,7 @@
     "place": {
       "name": "New Palestine",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2744,
       "coord": [-85.8891471, 39.7219882],
@@ -51771,7 +51771,7 @@
     "place": {
       "name": "New Prague",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8162,
       "coord": [-93.5760445, 44.5433331],
@@ -51790,7 +51790,7 @@
     "place": {
       "name": "New Richland",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1229,
       "coord": [-93.4938287, 43.8938493],
@@ -51809,7 +51809,7 @@
     "place": {
       "name": "New Richmond",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2727,
       "coord": [-84.2799366, 38.9486757],
@@ -51828,7 +51828,7 @@
     "place": {
       "name": "New Richmond",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10079,
       "coord": [-92.537502, 45.1227287],
@@ -51847,7 +51847,7 @@
     "place": {
       "name": "New Roads",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4549,
       "coord": [-91.4342983, 30.6932528],
@@ -51874,7 +51874,7 @@
     "place": {
       "name": "New Shoreham",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1410,
       "coord": [-71.5573011, 41.1722089],
@@ -51893,7 +51893,7 @@
     "place": {
       "name": "New Strawn",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 414,
       "coord": [-95.7419311, 38.2625197],
@@ -51912,7 +51912,7 @@
     "place": {
       "name": "New Tecumseth",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 43948,
       "coord": [-79.77443058053504, 44.0818996],
@@ -51939,7 +51939,7 @@
     "place": {
       "name": "New Ulm",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14120,
       "coord": [-94.4614177, 44.3140261],
@@ -51966,7 +51966,7 @@
     "place": {
       "name": "New Wilmington",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2097,
       "coord": [-80.3328428, 41.1222812],
@@ -51985,7 +51985,7 @@
     "place": {
       "name": "New York City",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8336817,
       "coord": [-74.0060152, 40.7127281],
@@ -52012,7 +52012,7 @@
     "place": {
       "name": "New Zealand",
       "state": null,
-      "country": "NZ",
+      "country": "New Zealand",
       "type": "country",
       "pop": 5122600,
       "coord": [172.8344077, -41.5000831],
@@ -52031,7 +52031,7 @@
     "place": {
       "name": "Newark",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30601,
       "coord": [-75.7515682, 39.6828358],
@@ -52058,7 +52058,7 @@
     "place": {
       "name": "Newark",
       "state": "NJ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 282011,
       "coord": [-74.1723667, 40.735657],
@@ -52077,7 +52077,7 @@
     "place": {
       "name": "Newark",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 49934,
       "coord": [-82.4012643, 40.0581205],
@@ -52096,7 +52096,7 @@
     "place": {
       "name": "Newburg",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1142,
       "coord": [-88.0464812, 43.4316671],
@@ -52115,7 +52115,7 @@
     "place": {
       "name": "Newburgh Heights",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1862,
       "coord": [-81.6634618, 41.450052],
@@ -52134,7 +52134,7 @@
     "place": {
       "name": "Newhall",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 876,
       "coord": [-91.96739, 41.994547],
@@ -52153,7 +52153,7 @@
     "place": {
       "name": "Newington",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30536,
       "coord": [-72.7237063, 41.6978777],
@@ -52172,7 +52172,7 @@
     "place": {
       "name": "Newport News",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 186247,
       "coord": [-76.42977, 36.9775016],
@@ -52191,7 +52191,7 @@
     "place": {
       "name": "Newport",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 910,
       "coord": [-75.6093709, 39.7137238],
@@ -52210,7 +52210,7 @@
     "place": {
       "name": "Newport",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3797,
       "coord": [-93.0003862, 44.8734744],
@@ -52237,7 +52237,7 @@
     "place": {
       "name": "Newport",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25163,
       "coord": [-71.3137707, 41.4899827],
@@ -52256,7 +52256,7 @@
     "place": {
       "name": "Newton Falls",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4557,
       "coord": [-80.978147, 41.18839],
@@ -52275,7 +52275,7 @@
     "place": {
       "name": "Newton",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18602,
       "coord": [-97.3447244, 38.0469166],
@@ -52310,7 +52310,7 @@
     "place": {
       "name": "Newtown",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27173,
       "coord": [-73.3086445, 41.4134764],
@@ -52329,7 +52329,7 @@
     "place": {
       "name": "Newville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1376,
       "coord": [-77.399308, 40.173145],
@@ -52348,7 +52348,7 @@
     "place": {
       "name": "Niagara Falls",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 48671,
       "coord": [-79.0614686, 43.08436],
@@ -52383,7 +52383,7 @@
     "place": {
       "name": "Nibley",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7328,
       "coord": [-111.833119, 41.6745591],
@@ -52402,7 +52402,7 @@
     "place": {
       "name": "Nichols Hills",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3870,
       "coord": [-97.5489318, 35.5508857],
@@ -52421,7 +52421,7 @@
     "place": {
       "name": "Nichols",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 288,
       "coord": [-88.4634342, 44.563042],
@@ -52440,7 +52440,7 @@
     "place": {
       "name": "Niles",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11988,
       "coord": [-86.2541768, 41.8297694],
@@ -52467,7 +52467,7 @@
     "place": {
       "name": "Nipigon",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1473,
       "coord": [-88.2662307, 49.0149827],
@@ -52486,7 +52486,7 @@
     "place": {
       "name": "Noble",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 633,
       "coord": [-88.223653, 38.6975481],
@@ -52505,7 +52505,7 @@
     "place": {
       "name": "Noblesville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 69604,
       "coord": [-86.0085955, 40.0455918],
@@ -52524,7 +52524,7 @@
     "place": {
       "name": "Nogales",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19770,
       "coord": [-110.936081, 31.3402134],
@@ -52543,7 +52543,7 @@
     "place": {
       "name": "Norcross",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17209,
       "coord": [-84.2135309, 33.9412127],
@@ -52570,7 +52570,7 @@
     "place": {
       "name": "Norfolk",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24955,
       "coord": [-97.4169964, 42.0283379],
@@ -52589,7 +52589,7 @@
     "place": {
       "name": "Norfolk",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 244601,
       "coord": [-76.29054, 36.847815],
@@ -52608,7 +52608,7 @@
     "place": {
       "name": "Normal",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 52736,
       "coord": [-88.9843937, 40.5092961],
@@ -52635,7 +52635,7 @@
     "place": {
       "name": "Norman",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 122837,
       "coord": [-97.4394816, 35.2225717],
@@ -52660,7 +52660,7 @@
     "place": {
       "name": "Norristown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35748,
       "coord": [-75.3433705, 40.1148787],
@@ -52692,7 +52692,7 @@
     "place": {
       "name": "North Baltimore",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3369,
       "coord": [-83.6782668, 41.1828302],
@@ -52711,7 +52711,7 @@
     "place": {
       "name": "North Bay",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 52662,
       "coord": [-79.4607617, 46.3092115],
@@ -52738,7 +52738,7 @@
     "place": {
       "name": "North Beach",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2146,
       "coord": [-76.5331735, 38.7048801],
@@ -52757,7 +52757,7 @@
     "place": {
       "name": "North Branch",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1096,
       "coord": [-83.196612, 43.229471],
@@ -52784,7 +52784,7 @@
     "place": {
       "name": "North Canton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17842,
       "coord": [-81.4023356, 40.875891],
@@ -52803,7 +52803,7 @@
     "place": {
       "name": "North Carolina",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "state",
       "pop": 10439388,
       "coord": [-79.52708508522043, 35.67688645584902],
@@ -52822,7 +52822,7 @@
     "place": {
       "name": "North Chicago",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30759,
       "coord": [-87.8411818, 42.325578],
@@ -52841,7 +52841,7 @@
     "place": {
       "name": "North East",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4085,
       "coord": [-75.9424217, 39.5992989],
@@ -52860,7 +52860,7 @@
     "place": {
       "name": "North East",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4114,
       "coord": [-79.8358415, 42.2150373],
@@ -52879,7 +52879,7 @@
     "place": {
       "name": "North Fond du Lac",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5378,
       "coord": [-88.4834419, 43.8113769],
@@ -52898,7 +52898,7 @@
     "place": {
       "name": "North Hampton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 457,
       "coord": [-83.9401002, 39.9904136],
@@ -52917,7 +52917,7 @@
     "place": {
       "name": "North Huron",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 5052,
       "coord": [-81.42655978902513, 43.8249172],
@@ -52936,7 +52936,7 @@
     "place": {
       "name": "North Irwin",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 823,
       "coord": [-79.7115399, 40.3384866],
@@ -52955,7 +52955,7 @@
     "place": {
       "name": "North Kansas City",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4467,
       "coord": [-94.5733988, 39.1432057],
@@ -52990,7 +52990,7 @@
     "place": {
       "name": "North Kingstown",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27732,
       "coord": [-71.4693875, 41.5514283],
@@ -53009,7 +53009,7 @@
     "place": {
       "name": "North Las Vegas",
       "state": "NV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 262527,
       "coord": [-115.121584, 36.2005843],
@@ -53028,7 +53028,7 @@
     "place": {
       "name": "North Lewisburg",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1636,
       "coord": [-83.557427, 40.2231134],
@@ -53047,7 +53047,7 @@
     "place": {
       "name": "North Little Rock",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 64591,
       "coord": [-92.2670941, 34.769536],
@@ -53066,7 +53066,7 @@
     "place": {
       "name": "North Manchester",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5277,
       "coord": [-85.768597, 41.0006005],
@@ -53085,7 +53085,7 @@
     "place": {
       "name": "North Mankato",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13948,
       "coord": [-94.0338055, 44.1732916],
@@ -53104,7 +53104,7 @@
     "place": {
       "name": "North Muskegon",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4093,
       "coord": [-86.26756, 43.256125],
@@ -53123,7 +53123,7 @@
     "place": {
       "name": "North Olmsted",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32442,
       "coord": [-81.9234726, 41.4156025],
@@ -53142,7 +53142,7 @@
     "place": {
       "name": "North Pekin",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1478,
       "coord": [-89.6223229, 40.6150384],
@@ -53161,7 +53161,7 @@
     "place": {
       "name": "North Platte",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23390,
       "coord": [-100.7654232, 41.1238873],
@@ -53180,7 +53180,7 @@
     "place": {
       "name": "North Prairie",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2202,
       "coord": [-88.4053742, 42.934456],
@@ -53199,7 +53199,7 @@
     "place": {
       "name": "North Riverside",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7426,
       "coord": [-87.8152024, 41.84686],
@@ -53218,7 +53218,7 @@
     "place": {
       "name": "North St. Paul",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12364,
       "coord": [-92.9922512, 45.0122571],
@@ -53242,7 +53242,7 @@
     "place": {
       "name": "North Utica",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1323,
       "coord": [-89.010081, 41.3405897],
@@ -53261,7 +53261,7 @@
     "place": {
       "name": "North Wales",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3426,
       "coord": [-75.2774194, 40.2143282],
@@ -53280,7 +53280,7 @@
     "place": {
       "name": "Northern Territory",
       "state": "NT",
-      "country": "AU",
+      "country": "Australia",
       "type": "state",
       "pop": 228833,
       "coord": [130.86848336511576, -12.37137375],
@@ -53299,7 +53299,7 @@
     "place": {
       "name": "Northfield",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5751,
       "coord": [-87.7808967, 42.09975],
@@ -53318,7 +53318,7 @@
     "place": {
       "name": "Northfield",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20790,
       "coord": [-93.161159, 44.4582041],
@@ -53360,7 +53360,7 @@
     "place": {
       "name": "Northglenn",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 38131,
       "coord": [-104.987552, 39.9100858],
@@ -53407,7 +53407,7 @@
     "place": {
       "name": "Northport",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31125,
       "coord": [-87.5771286, 33.2292976],
@@ -53442,7 +53442,7 @@
     "place": {
       "name": "Northville Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31758,
       "coord": [-83.4922222, 42.415],
@@ -53461,7 +53461,7 @@
     "place": {
       "name": "Northville",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6119,
       "coord": [-83.4832339, 42.4310816],
@@ -53480,7 +53480,7 @@
     "place": {
       "name": "Norton",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2747,
       "coord": [-99.88887446594951, 39.829107849248025],
@@ -53506,7 +53506,7 @@
     "place": {
       "name": "Norwalk",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 91184,
       "coord": [-73.4078968, 41.1175966],
@@ -53541,7 +53541,7 @@
     "place": {
       "name": "Norwalk",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17068,
       "coord": [-82.6155745, 41.2424219],
@@ -53560,7 +53560,7 @@
     "place": {
       "name": "Norway",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2840,
       "coord": [-87.903736, 45.786902],
@@ -53579,7 +53579,7 @@
     "place": {
       "name": "Norwich",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 38768,
       "coord": [-72.0759008, 41.5243537],
@@ -53606,7 +53606,7 @@
     "place": {
       "name": "Norwich",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7051,
       "coord": [-75.5235149, 42.5311809],
@@ -53633,7 +53633,7 @@
     "place": {
       "name": "Norwood",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29195,
       "coord": [-71.199, 42.1944],
@@ -53652,7 +53652,7 @@
     "place": {
       "name": "Norwood",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19883,
       "coord": [-84.4596641, 39.1556149],
@@ -53671,7 +53671,7 @@
     "place": {
       "name": "Novi",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 66243,
       "coord": [-83.4754913, 42.48059],
@@ -53690,7 +53690,7 @@
     "place": {
       "name": "Nutter Fort",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1497,
       "coord": [-80.3197283, 39.2634213],
@@ -53709,7 +53709,7 @@
     "place": {
       "name": "Nürnberg",
       "state": "BY",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 523026,
       "coord": [11.077298, 49.453872],
@@ -53728,7 +53728,7 @@
     "place": {
       "name": "O'Fallon",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32289,
       "coord": [-89.9112124, 38.5922715],
@@ -53755,7 +53755,7 @@
     "place": {
       "name": "O'Neill",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3581,
       "coord": [-98.6477823, 42.4577934],
@@ -53774,7 +53774,7 @@
     "place": {
       "name": "Oak Creek",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 893,
       "coord": [-106.957607, 40.275049],
@@ -53793,7 +53793,7 @@
     "place": {
       "name": "Oak Creek",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36497,
       "coord": [-87.9177966, 42.898729],
@@ -53812,7 +53812,7 @@
     "place": {
       "name": "Oak Lawn",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 58362,
       "coord": [-87.7581081, 41.7108662],
@@ -53831,7 +53831,7 @@
     "place": {
       "name": "Oak Park",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 54583,
       "coord": [-87.7887615, 41.8878145],
@@ -53862,7 +53862,7 @@
     "place": {
       "name": "Oak Park",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29560,
       "coord": [-83.1821445, 42.4595317],
@@ -53881,7 +53881,7 @@
     "place": {
       "name": "Oakboro",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2128,
       "coord": [-80.3289521, 35.2257007],
@@ -53900,7 +53900,7 @@
     "place": {
       "name": "Oakdale",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1475,
       "coord": [-80.1856134, 40.3981246],
@@ -53919,7 +53919,7 @@
     "place": {
       "name": "Oakland",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 433031,
       "coord": [-122.2713563, 37.8044557],
@@ -53946,7 +53946,7 @@
     "place": {
       "name": "Oakland",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1524,
       "coord": [-95.3966425, 41.3107195],
@@ -53965,7 +53965,7 @@
     "place": {
       "name": "Oakland",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1851,
       "coord": [-79.4062658, 39.4099097],
@@ -53984,7 +53984,7 @@
     "place": {
       "name": "Oakley",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 299,
       "coord": [-84.168031, 43.139748],
@@ -54003,7 +54003,7 @@
     "place": {
       "name": "Oakmont",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6758,
       "coord": [-79.8422719, 40.5217347],
@@ -54022,7 +54022,7 @@
     "place": {
       "name": "Oakville",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 211382,
       "coord": [-79.666672, 43.447436],
@@ -54041,7 +54041,7 @@
     "place": {
       "name": "Oakwood",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1325,
       "coord": [-87.7783592, 40.1161471],
@@ -54060,7 +54060,7 @@
     "place": {
       "name": "Oberlin",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1644,
       "coord": [-100.528201, 39.818338],
@@ -54079,7 +54079,7 @@
     "place": {
       "name": "Oberlin",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8555,
       "coord": [-82.2173786, 41.2939386],
@@ -54098,7 +54098,7 @@
     "place": {
       "name": "Obetz",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5489,
       "coord": [-82.9507363, 39.8789527],
@@ -54117,7 +54117,7 @@
     "place": {
       "name": "Ocean Springs",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18429,
       "coord": [-88.8279165, 30.4112904],
@@ -54136,7 +54136,7 @@
     "place": {
       "name": "Oceanside",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 174068,
       "coord": [-117.3794834, 33.1958696],
@@ -54163,7 +54163,7 @@
     "place": {
       "name": "Ochtrup",
       "state": "NW",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 20230,
       "coord": [7.188806, 52.2102308],
@@ -54182,7 +54182,7 @@
     "place": {
       "name": "Oconomowoc",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18203,
       "coord": [-88.4992659, 43.1116731],
@@ -54209,7 +54209,7 @@
     "place": {
       "name": "Odense",
       "state": "Syddanmark",
-      "country": "DK",
+      "country": "Denmark",
       "type": "city",
       "pop": 183763,
       "coord": [10.3852104, 55.3997225],
@@ -54228,7 +54228,7 @@
     "place": {
       "name": "Oelwein",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5920,
       "coord": [-91.9145143, 42.6778743],
@@ -54253,7 +54253,7 @@
     "place": {
       "name": "Ogle County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 51788,
       "coord": [-89.3138599, 42.0397014],
@@ -54272,7 +54272,7 @@
     "place": {
       "name": "Ohio County",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 5940,
       "coord": [-84.9581728, 38.9480496],
@@ -54291,7 +54291,7 @@
     "place": {
       "name": "Oil City",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9608,
       "coord": [-79.708511, 41.434113],
@@ -54310,7 +54310,7 @@
     "place": {
       "name": "Oil Springs",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 647,
       "coord": [-82.126915, 42.7838172],
@@ -54329,7 +54329,7 @@
     "place": {
       "name": "Okemah",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3078,
       "coord": [-96.3050064, 35.4325854],
@@ -54348,7 +54348,7 @@
     "place": {
       "name": "Oklahoma City",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 681054,
       "coord": [-97.5170536, 35.4729886],
@@ -54367,7 +54367,7 @@
     "place": {
       "name": "Oklahoma",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "state",
       "pop": 3959353,
       "coord": [-97.16894365762012, 35.215088157083706],
@@ -54386,7 +54386,7 @@
     "place": {
       "name": "Okolona",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2513,
       "coord": [-88.7547357, 34.0020146],
@@ -54405,7 +54405,7 @@
     "place": {
       "name": "Olathe",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 141290,
       "coord": [-94.81887, 38.8838856],
@@ -54432,7 +54432,7 @@
     "place": {
       "name": "Old Lyme",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7628,
       "coord": [-72.3289715, 41.3159315],
@@ -54451,7 +54451,7 @@
     "place": {
       "name": "Old Saybrook",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10481,
       "coord": [-72.3761956, 41.2917652],
@@ -54478,7 +54478,7 @@
     "place": {
       "name": "Oldham",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 121,
       "coord": [-97.307846, 44.227471],
@@ -54497,7 +54497,7 @@
     "place": {
       "name": "Olivia",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2343,
       "coord": [-94.9897214, 44.77635],
@@ -54516,7 +54516,7 @@
     "place": {
       "name": "Olney",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8692,
       "coord": [-88.0846891, 38.7296538],
@@ -54535,7 +54535,7 @@
     "place": {
       "name": "Olympia Fields",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4718,
       "coord": [-87.70289569, 41.5164045],
@@ -54554,7 +54554,7 @@
     "place": {
       "name": "Olympia",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 52882,
       "coord": [-122.8950075, 47.0451022],
@@ -54581,7 +54581,7 @@
     "place": {
       "name": "Olyphant",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5395,
       "coord": [-75.602387, 41.4688301],
@@ -54600,7 +54600,7 @@
     "place": {
       "name": "Omaha",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 478192,
       "coord": [-95.9383758, 41.2587459],
@@ -54619,7 +54619,7 @@
     "place": {
       "name": "Onalaska",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18803,
       "coord": [-91.2343539, 43.8830606],
@@ -54638,7 +54638,7 @@
     "place": {
       "name": "Onancock",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1169,
       "coord": [-75.7491015, 37.7118],
@@ -54657,7 +54657,7 @@
     "place": {
       "name": "Onawa",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2906,
       "coord": [-96.0974618, 42.0268269],
@@ -54676,7 +54676,7 @@
     "place": {
       "name": "Onaway",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 890,
       "coord": [-84.223903, 45.357512],
@@ -54695,7 +54695,7 @@
     "place": {
       "name": "Oneida Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3986,
       "coord": [-84.778911, 42.7265068],
@@ -54714,7 +54714,7 @@
     "place": {
       "name": "Ontario",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 175265,
       "coord": [-117.64843, 34.065846],
@@ -54741,7 +54741,7 @@
     "place": {
       "name": "Ontonagon",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1285,
       "coord": [-89.31403, 46.871053],
@@ -54760,7 +54760,7 @@
     "place": {
       "name": "Oologah",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1193,
       "coord": [-95.7083151, 36.4470387],
@@ -54787,7 +54787,7 @@
     "place": {
       "name": "Opelika",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30995,
       "coord": [-85.3782795, 32.6454116],
@@ -54806,7 +54806,7 @@
     "place": {
       "name": "Opelousas",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15786,
       "coord": [-92.081509, 30.5335302],
@@ -54841,7 +54841,7 @@
     "place": {
       "name": "Orange City",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6267,
       "coord": [-96.0583138, 43.0072424],
@@ -54860,7 +54860,7 @@
     "place": {
       "name": "Orange",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 139911,
       "coord": [-117.853517, 33.787908],
@@ -54887,7 +54887,7 @@
     "place": {
       "name": "Orange",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14280,
       "coord": [-73.0256609, 41.2784304],
@@ -54906,7 +54906,7 @@
     "place": {
       "name": "Oregon City",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 37572,
       "coord": [-122.606758, 45.3573429],
@@ -54937,7 +54937,7 @@
     "place": {
       "name": "Oregon",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3604,
       "coord": [-89.3323279, 42.0147513],
@@ -54956,7 +54956,7 @@
     "place": {
       "name": "Oregon",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "state",
       "pop": 4028977,
       "coord": [-120.587, 43.521],
@@ -54983,7 +54983,7 @@
     "place": {
       "name": "Oregon",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11179,
       "coord": [-89.3842779, 42.9259657],
@@ -55016,7 +55016,7 @@
     "place": {
       "name": "Orillia",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 33411,
       "coord": [-79.4169256, 44.6066135],
@@ -55043,7 +55043,7 @@
     "place": {
       "name": "Orion",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1754,
       "coord": [-90.3814248, 41.353844],
@@ -55062,7 +55062,7 @@
     "place": {
       "name": "Orlando",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 307573,
       "coord": [-81.3790304, 28.5421109],
@@ -55097,7 +55097,7 @@
     "place": {
       "name": "Oro Valley",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 47070,
       "coord": [-110.955317, 32.4000525],
@@ -55116,7 +55116,7 @@
     "place": {
       "name": "Oro-Medonte",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 23017,
       "coord": [-79.54891085886374, 44.5445701],
@@ -55135,7 +55135,7 @@
     "place": {
       "name": "Oronoko Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9226,
       "coord": [-86.3919356994427, 41.94297335],
@@ -55154,7 +55154,7 @@
     "place": {
       "name": "Ortonville",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1376,
       "coord": [-83.4430002, 42.8522506],
@@ -55173,7 +55173,7 @@
     "place": {
       "name": "Orwell",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1533,
       "coord": [-80.868144, 41.535055],
@@ -55192,7 +55192,7 @@
     "place": {
       "name": "Osakis",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1771,
       "coord": [-95.152357, 45.8669022],
@@ -55211,7 +55211,7 @@
     "place": {
       "name": "Osceola",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5160,
       "coord": [-93.7665629, 41.0341224],
@@ -55230,7 +55230,7 @@
     "place": {
       "name": "Oscoda Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6788,
       "coord": [-83.33028, 44.420362],
@@ -55257,7 +55257,7 @@
     "place": {
       "name": "Oshawa",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 166000,
       "coord": [-78.8635324, 43.8975558],
@@ -55276,7 +55276,7 @@
     "place": {
       "name": "Oshkosh",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 66816,
       "coord": [-88.5408574, 44.0206919],
@@ -55309,7 +55309,7 @@
     "place": {
       "name": "Oshtemo Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23747,
       "coord": [-85.7070634185963, 42.288957],
@@ -55336,7 +55336,7 @@
     "place": {
       "name": "Oskaloosa",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11558,
       "coord": [-92.6448451, 41.2951037],
@@ -55355,7 +55355,7 @@
     "place": {
       "name": "Ostrander",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 231,
       "coord": [-92.4279497, 43.6135754],
@@ -55374,7 +55374,7 @@
     "place": {
       "name": "Oswego",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 34485,
       "coord": [-88.3525714, 41.6834778],
@@ -55416,7 +55416,7 @@
     "place": {
       "name": "Otsego",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4120,
       "coord": [-85.696852, 42.460538],
@@ -55435,7 +55435,7 @@
     "place": {
       "name": "Ottawa",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12625,
       "coord": [-95.2678474, 38.6153828],
@@ -55454,7 +55454,7 @@
     "place": {
       "name": "Ottawa",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 934243,
       "coord": [-75.6900574, 45.4211435],
@@ -55473,7 +55473,7 @@
     "place": {
       "name": "Otter Lake",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 426,
       "coord": [-83.4543963, 43.2133586],
@@ -55492,7 +55492,7 @@
     "place": {
       "name": "Ottumwa",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25529,
       "coord": [-92.4116886, 41.0195659],
@@ -55511,7 +55511,7 @@
     "place": {
       "name": "Overbrook",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1005,
       "coord": [-95.5572026, 38.7805607],
@@ -55530,7 +55530,7 @@
     "place": {
       "name": "Overland Park",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 197238,
       "coord": [-94.6851702, 38.9742502],
@@ -55549,7 +55549,7 @@
     "place": {
       "name": "Ovid",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1481,
       "coord": [-84.3714696, 43.0058396],
@@ -55568,7 +55568,7 @@
     "place": {
       "name": "Owasso",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 38299,
       "coord": [-95.8548557, 36.2659698],
@@ -55587,7 +55587,7 @@
     "place": {
       "name": "Owen Sound",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 21612,
       "coord": [-80.9430094, 44.5678105],
@@ -55614,7 +55614,7 @@
     "place": {
       "name": "Owensboro",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 60183,
       "coord": [-87.1133304, 37.7742152],
@@ -55633,7 +55633,7 @@
     "place": {
       "name": "Owingsville",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1593,
       "coord": [-83.7640847, 38.1448015],
@@ -55652,7 +55652,7 @@
     "place": {
       "name": "Owosso",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14714,
       "coord": [-84.1720541, 42.9975968],
@@ -55671,7 +55671,7 @@
     "place": {
       "name": "Oxford Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22419,
       "coord": [-83.275795, 42.8397967],
@@ -55690,7 +55690,7 @@
     "place": {
       "name": "Oxford",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12706,
       "coord": [-73.1172769, 41.4351795],
@@ -55709,7 +55709,7 @@
     "place": {
       "name": "Oxford",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1048,
       "coord": [-97.1689296, 37.2741908],
@@ -55728,7 +55728,7 @@
     "place": {
       "name": "Oxford",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25416,
       "coord": [-89.5187664, 34.3663773],
@@ -55763,7 +55763,7 @@
     "place": {
       "name": "Oxford",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1330,
       "coord": [-75.5976855, 42.4420181],
@@ -55782,7 +55782,7 @@
     "place": {
       "name": "Oxford",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23035,
       "coord": [-84.7420519, 39.5103048],
@@ -55823,7 +55823,7 @@
     "place": {
       "name": "Oxford",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5733,
       "coord": [-75.9790215, 39.7852062],
@@ -55842,7 +55842,7 @@
     "place": {
       "name": "Oxnard",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 202063,
       "coord": [-119.1803818, 34.1976308],
@@ -55861,7 +55861,7 @@
     "place": {
       "name": "Ozark",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14368,
       "coord": [-85.6405865, 31.4584764],
@@ -55880,7 +55880,7 @@
     "place": {
       "name": "Ozark",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21284,
       "coord": [-93.2053032, 37.0214248],
@@ -55899,7 +55899,7 @@
     "place": {
       "name": "Paducah",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27137,
       "coord": [-88.6000478, 37.0833893],
@@ -55918,7 +55918,7 @@
     "place": {
       "name": "Page",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7440,
       "coord": [-111.457294, 36.9148305],
@@ -55937,7 +55937,7 @@
     "place": {
       "name": "Pagosa Springs",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1571,
       "coord": [-107.010816, 37.2695661],
@@ -55956,7 +55956,7 @@
     "place": {
       "name": "Palmdale",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 169450,
       "coord": [-118.11711, 34.5793131],
@@ -55975,7 +55975,7 @@
     "place": {
       "name": "Palmer",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 439,
       "coord": [-98.2572855, 41.2222351],
@@ -55994,7 +55994,7 @@
     "place": {
       "name": "Palmerton",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5593,
       "coord": [-75.6101868, 40.8014826],
@@ -56013,7 +56013,7 @@
     "place": {
       "name": "Palmyra",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7807,
       "coord": [-76.5932369, 40.3088578],
@@ -56032,7 +56032,7 @@
     "place": {
       "name": "Palmyra",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1719,
       "coord": [-88.5862122, 42.8777882],
@@ -56051,7 +56051,7 @@
     "place": {
       "name": "Panama City",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 34667,
       "coord": [-85.6545729, 30.1600827],
@@ -56070,7 +56070,7 @@
     "place": {
       "name": "Paola",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5768,
       "coord": [-94.8786484, 38.5723318],
@@ -56097,7 +56097,7 @@
     "place": {
       "name": "Paoli",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3666,
       "coord": [-86.468321, 38.5561663],
@@ -56116,7 +56116,7 @@
     "place": {
       "name": "Paonia",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1447,
       "coord": [-107.5920018, 38.8683205],
@@ -56135,7 +56135,7 @@
     "place": {
       "name": "Papillion",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24159,
       "coord": [-96.0422378, 41.1544433],
@@ -56162,7 +56162,7 @@
     "place": {
       "name": "Parchment",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1926,
       "coord": [-85.5697296, 42.3280952],
@@ -56181,7 +56181,7 @@
     "place": {
       "name": "Paris",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8291,
       "coord": [-87.6961374, 39.611146],
@@ -56200,7 +56200,7 @@
     "place": {
       "name": "Park City",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7885,
       "coord": [-87.8842397, 42.3483554],
@@ -56227,7 +56227,7 @@
     "place": {
       "name": "Park Forest",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21687,
       "coord": [-87.6802344, 41.4825788],
@@ -56254,7 +56254,7 @@
     "place": {
       "name": "Park Ridge",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 39656,
       "coord": [-87.8406031, 42.0112329],
@@ -56273,7 +56273,7 @@
     "place": {
       "name": "Parker",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 58512,
       "coord": [-104.7612638, 39.5184514],
@@ -56308,7 +56308,7 @@
     "place": {
       "name": "Parker",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1194,
       "coord": [-97.136445, 43.397483],
@@ -56327,7 +56327,7 @@
     "place": {
       "name": "Parkersburg",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2015,
       "coord": [-92.7870402, 42.5755594],
@@ -56346,7 +56346,7 @@
     "place": {
       "name": "Parkersburg",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29749,
       "coord": [-81.5620755, 39.2667309],
@@ -56373,7 +56373,7 @@
     "place": {
       "name": "Parkesburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3866,
       "coord": [-75.9193928, 39.9587161],
@@ -56392,7 +56392,7 @@
     "place": {
       "name": "Parkville",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7177,
       "coord": [-94.6826891, 39.1896268],
@@ -56427,7 +56427,7 @@
     "place": {
       "name": "Parma Heights",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20863,
       "coord": [-81.7598257, 41.3914132],
@@ -56446,7 +56446,7 @@
     "place": {
       "name": "Parma",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 780,
       "coord": [-84.5996885, 42.2583711],
@@ -56465,7 +56465,7 @@
     "place": {
       "name": "Parowan",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2996,
       "coord": [-112.8279996, 37.8421975],
@@ -56484,7 +56484,7 @@
     "place": {
       "name": "Parry Sound",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 6879,
       "coord": [-80.033903, 45.343613],
@@ -56503,7 +56503,7 @@
     "place": {
       "name": "Parsons",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9600,
       "coord": [-95.2596295, 37.3407838],
@@ -56522,7 +56522,7 @@
     "place": {
       "name": "Pasadena",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 138699,
       "coord": [-118.144155, 34.1476507],
@@ -56563,7 +56563,7 @@
     "place": {
       "name": "Pascagoula",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22010,
       "coord": [-88.5585995, 30.3646795],
@@ -56598,7 +56598,7 @@
     "place": {
       "name": "Pasco",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 75432,
       "coord": [-119.0921006, 46.2306739],
@@ -56617,7 +56617,7 @@
     "place": {
       "name": "Pass Christian",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5686,
       "coord": [-89.247543, 30.3157527],
@@ -56636,7 +56636,7 @@
     "place": {
       "name": "Passau",
       "state": "BY",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 53907,
       "coord": [13.4609744, 48.5748229],
@@ -56655,7 +56655,7 @@
     "place": {
       "name": "Patagonia",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 804,
       "coord": [-110.753927, 31.5402016],
@@ -56674,7 +56674,7 @@
     "place": {
       "name": "Pataskala",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17886,
       "coord": [-82.6742373, 39.9955726],
@@ -56693,7 +56693,7 @@
     "place": {
       "name": "Paterson",
       "state": "NJ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 159732,
       "coord": [-74.171811, 40.9167654],
@@ -56720,7 +56720,7 @@
     "place": {
       "name": "Paw Paw",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 830,
       "coord": [-88.9811987, 41.688919],
@@ -56739,7 +56739,7 @@
     "place": {
       "name": "Paw Paw",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3362,
       "coord": [-85.8911246, 42.2178171],
@@ -56758,7 +56758,7 @@
     "place": {
       "name": "Pawnee City",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 865,
       "coord": [-96.154451, 40.108334],
@@ -56777,7 +56777,7 @@
     "place": {
       "name": "Pawnee",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2678,
       "coord": [-89.5803739, 39.5917186],
@@ -56796,7 +56796,7 @@
     "place": {
       "name": "Pawtucket",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 75604,
       "coord": [-71.3821203, 41.8789531],
@@ -56831,7 +56831,7 @@
     "place": {
       "name": "Paxtang",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1640,
       "coord": [-76.8319167, 40.2589785],
@@ -56850,7 +56850,7 @@
     "place": {
       "name": "Paxton",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4459,
       "coord": [-88.0953201, 40.4603125],
@@ -56885,7 +56885,7 @@
     "place": {
       "name": "Peace River",
       "state": "AB",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 6619,
       "coord": [-117.2910839, 56.2337111],
@@ -56904,7 +56904,7 @@
     "place": {
       "name": "Peachtree Corners",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 42243,
       "coord": [-84.2215869, 33.9701009],
@@ -56923,7 +56923,7 @@
     "place": {
       "name": "Pearl City",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 790,
       "coord": [-89.8259532, 42.265297],
@@ -56947,7 +56947,7 @@
     "place": {
       "name": "Pearland",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 125828,
       "coord": [-95.2864299, 29.5639758],
@@ -56966,7 +56966,7 @@
     "place": {
       "name": "Peculiar",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5621,
       "coord": [-94.4611204, 38.7145481],
@@ -56985,7 +56985,7 @@
     "place": {
       "name": "Pekin",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31731,
       "coord": [-89.6501621, 40.5687911],
@@ -57004,7 +57004,7 @@
     "place": {
       "name": "Pelham",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24318,
       "coord": [-86.8099884, 33.285669],
@@ -57031,7 +57031,7 @@
     "place": {
       "name": "Pella",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10464,
       "coord": [-92.9174074, 41.4073138],
@@ -57050,7 +57050,7 @@
     "place": {
       "name": "Pellston",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 774,
       "coord": [-84.783936, 45.552789],
@@ -57069,7 +57069,7 @@
     "place": {
       "name": "Pen Argyl",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3510,
       "coord": [-75.2549025, 40.8687064],
@@ -57088,7 +57088,7 @@
     "place": {
       "name": "Pender",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1115,
       "coord": [-96.7072294, 42.114025],
@@ -57107,7 +57107,7 @@
     "place": {
       "name": "Penetanguishene",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 8962,
       "coord": [-79.9339487, 44.7688035],
@@ -57134,7 +57134,7 @@
     "place": {
       "name": "Penndel",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2515,
       "coord": [-74.9165553, 40.1520541],
@@ -57153,7 +57153,7 @@
     "place": {
       "name": "Pensacola",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 54312,
       "coord": [-87.2169149, 30.421309],
@@ -57180,7 +57180,7 @@
     "place": {
       "name": "Penticton",
       "state": "BC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 33761,
       "coord": [-119.5932499, 49.5003268],
@@ -57199,7 +57199,7 @@
     "place": {
       "name": "Pentwater",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 890,
       "coord": [-86.4331053, 43.7817341],
@@ -57226,7 +57226,7 @@
     "place": {
       "name": "Peoria County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 181830,
       "coord": [-89.7713762, 40.8021278],
@@ -57245,7 +57245,7 @@
     "place": {
       "name": "Peoria",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 190985,
       "coord": [-112.237294, 33.5806115],
@@ -57264,7 +57264,7 @@
     "place": {
       "name": "Peoria",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 110417,
       "coord": [-89.5891008, 40.6938609],
@@ -57291,7 +57291,7 @@
     "place": {
       "name": "Peralta",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3342,
       "coord": [-106.6908587, 34.837038],
@@ -57310,7 +57310,7 @@
     "place": {
       "name": "Pere Marquette Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2416,
       "coord": [-86.4139221993674, 43.93805855],
@@ -57329,7 +57329,7 @@
     "place": {
       "name": "Perham",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3512,
       "coord": [-95.5725415, 46.5944042],
@@ -57348,7 +57348,7 @@
     "place": {
       "name": "Perkins",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3205,
       "coord": [-97.0337692, 35.9740886],
@@ -57367,7 +57367,7 @@
     "place": {
       "name": "Perry",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7836,
       "coord": [-94.1069211, 41.8386737],
@@ -57386,7 +57386,7 @@
     "place": {
       "name": "Perry",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1602,
       "coord": [-81.138977, 41.758953],
@@ -57405,7 +57405,7 @@
     "place": {
       "name": "Perrysburg",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25041,
       "coord": [-83.6279321, 41.5571178],
@@ -57424,7 +57424,7 @@
     "place": {
       "name": "Perryville",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8555,
       "coord": [-89.8645455, 37.7275127],
@@ -57443,7 +57443,7 @@
     "place": {
       "name": "Perth",
       "state": "WA",
-      "country": "AU",
+      "country": "Australia",
       "type": "city",
       "pop": 28463,
       "coord": [115.8605855, -31.9558933],
@@ -57476,7 +57476,7 @@
     "place": {
       "name": "Petal",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11010,
       "coord": [-89.2600605, 31.3465627],
@@ -57495,7 +57495,7 @@
     "place": {
       "name": "Petaluma",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 60520,
       "coord": [-122.636465, 38.2325829],
@@ -57514,7 +57514,7 @@
     "place": {
       "name": "Petersburg",
       "state": "AK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3043,
       "coord": [-132.9572288, 56.8133806],
@@ -57533,7 +57533,7 @@
     "place": {
       "name": "Peterson",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 234,
       "coord": [-91.8348562, 43.7862132],
@@ -57552,7 +57552,7 @@
     "place": {
       "name": "Petoskey",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5877,
       "coord": [-84.95533, 45.373343],
@@ -57587,7 +57587,7 @@
     "place": {
       "name": "Petrolia",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 6013,
       "coord": [-82.149582, 42.882002],
@@ -57606,7 +57606,7 @@
     "place": {
       "name": "Pewaukee (City)",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15914,
       "coord": [-88.2139452, 43.0846017],
@@ -57625,7 +57625,7 @@
     "place": {
       "name": "Phenix City",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 38817,
       "coord": [-85.0007653, 32.4709761],
@@ -57644,7 +57644,7 @@
     "place": {
       "name": "Philadelphia",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1584064,
       "coord": [-75.1635262, 39.9527237],
@@ -57663,7 +57663,7 @@
     "place": {
       "name": "Philippi",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2929,
       "coord": [-80.03949, 39.1523474],
@@ -57682,7 +57682,7 @@
     "place": {
       "name": "Phillipsburg",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2337,
       "coord": [-99.323985, 39.756121],
@@ -57701,7 +57701,7 @@
     "place": {
       "name": "Philo",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1392,
       "coord": [-88.1580999, 40.0069761],
@@ -57720,7 +57720,7 @@
     "place": {
       "name": "Phoenix",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1680992,
       "coord": [-112.0741417, 33.4484367],
@@ -57739,7 +57739,7 @@
     "place": {
       "name": "Phoenixville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16968,
       "coord": [-75.5149128, 40.1303822],
@@ -57758,7 +57758,7 @@
     "place": {
       "name": "Picayune",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11885,
       "coord": [-89.6795084, 30.5254692],
@@ -57777,7 +57777,7 @@
     "place": {
       "name": "Pickens",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3388,
       "coord": [-82.7073573, 34.8834489],
@@ -57796,7 +57796,7 @@
     "place": {
       "name": "Pickerington",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23094,
       "coord": [-82.7535049, 39.8842304],
@@ -57815,7 +57815,7 @@
     "place": {
       "name": "Piedmont",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7402,
       "coord": [-97.7464345, 35.6419952],
@@ -57834,7 +57834,7 @@
     "place": {
       "name": "Pierre",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14091,
       "coord": [-100.351136, 44.3683644],
@@ -57853,7 +57853,7 @@
     "place": {
       "name": "Pierz",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1418,
       "coord": [-94.1047124, 45.9816318],
@@ -57872,7 +57872,7 @@
     "place": {
       "name": "Pikeville",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7754,
       "coord": [-82.5187629, 37.4792672],
@@ -57891,7 +57891,7 @@
     "place": {
       "name": "Pima County",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 1043433,
       "coord": [-111.6546163, 32.1112624],
@@ -57910,7 +57910,7 @@
     "place": {
       "name": "Pinckney",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2415,
       "coord": [-83.9463359, 42.4567013],
@@ -57929,7 +57929,7 @@
     "place": {
       "name": "Pinckneyville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5066,
       "coord": [-89.3820321, 38.0803286],
@@ -57948,7 +57948,7 @@
     "place": {
       "name": "Pinconning",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1204,
       "coord": [-83.964987, 43.853633],
@@ -57967,7 +57967,7 @@
     "place": {
       "name": "Pine Bluff",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 41253,
       "coord": [-92.0140402, 34.2157064],
@@ -57986,7 +57986,7 @@
     "place": {
       "name": "Pine City",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3130,
       "coord": [-92.9685423, 45.8260672],
@@ -58005,7 +58005,7 @@
     "place": {
       "name": "Pinedale",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2272,
       "coord": [-109.8609808, 42.8671325],
@@ -58024,7 +58024,7 @@
     "place": {
       "name": "Pinetop-Lakeside",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4557,
       "coord": [-109.9584743, 34.1448702],
@@ -58043,7 +58043,7 @@
     "place": {
       "name": "Pineville",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10602,
       "coord": [-80.8871253, 35.0855409],
@@ -58070,7 +58070,7 @@
     "place": {
       "name": "Pinson",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7215,
       "coord": [-86.6833229, 33.6889908],
@@ -58103,7 +58103,7 @@
     "place": {
       "name": "Piqua",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20354,
       "coord": [-84.2424449, 40.1447732],
@@ -58130,7 +58130,7 @@
     "place": {
       "name": "Pittsboro",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3682,
       "coord": [-86.4669429, 39.8639329],
@@ -58149,7 +58149,7 @@
     "place": {
       "name": "Pittsburgh",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 300286,
       "coord": [-79.9900861, 40.4416941],
@@ -58184,7 +58184,7 @@
     "place": {
       "name": "Pittsfield Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 39147,
       "coord": [-83.7241068, 42.2103174],
@@ -58203,7 +58203,7 @@
     "place": {
       "name": "Pittsfield",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4206,
       "coord": [-90.805129, 39.6078254],
@@ -58222,7 +58222,7 @@
     "place": {
       "name": "Pittsfield",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43927,
       "coord": [-73.260018, 42.451302],
@@ -58241,7 +58241,7 @@
     "place": {
       "name": "Pittston",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7591,
       "coord": [-75.7893604, 41.3259134],
@@ -58260,7 +58260,7 @@
     "place": {
       "name": "Plain City",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4065,
       "coord": [-83.2669677, 40.1078821],
@@ -58279,7 +58279,7 @@
     "place": {
       "name": "Plainfield ",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35592,
       "coord": [-86.3994387, 39.7042123],
@@ -58298,7 +58298,7 @@
     "place": {
       "name": "Plainfield",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 44762,
       "coord": [-88.2054345, 41.6086711],
@@ -58333,7 +58333,7 @@
     "place": {
       "name": "Plainview",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3483,
       "coord": [-92.1717609, 44.1647423],
@@ -58352,7 +58352,7 @@
     "place": {
       "name": "Plainview",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1282,
       "coord": [-97.7934793, 42.349618],
@@ -58371,7 +58371,7 @@
     "place": {
       "name": "Plainville",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17525,
       "coord": [-72.8672429, 41.6711395],
@@ -58404,7 +58404,7 @@
     "place": {
       "name": "Plano",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11847,
       "coord": [-88.5366814, 41.662877],
@@ -58423,7 +58423,7 @@
     "place": {
       "name": "Plano",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 285494,
       "coord": [-96.6925096, 33.0136764],
@@ -58464,7 +58464,7 @@
     "place": {
       "name": "Platteville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11836,
       "coord": [-90.4784451, 42.7342942],
@@ -58483,7 +58483,7 @@
     "place": {
       "name": "Plattsmouth",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6620,
       "coord": [-95.8862157, 41.0111979],
@@ -58502,7 +58502,7 @@
     "place": {
       "name": "Pleasant Ridge",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2627,
       "coord": [-83.1421482, 42.471147],
@@ -58521,7 +58521,7 @@
     "place": {
       "name": "Pleasantville",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1676,
       "coord": [-93.2694768, 41.3867741],
@@ -58540,7 +58540,7 @@
     "place": {
       "name": "Plummer",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1015,
       "coord": [-116.888509, 47.3351803],
@@ -58559,7 +58559,7 @@
     "place": {
       "name": "Plymouth Township",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18256,
       "coord": [-75.29834666183419, 40.109412750000004],
@@ -58578,7 +58578,7 @@
     "place": {
       "name": "Plymouth",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9370,
       "coord": [-83.4675021, 42.3712],
@@ -58597,7 +58597,7 @@
     "place": {
       "name": "Plymouth",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8932,
       "coord": [-87.977038, 43.7486054],
@@ -58616,7 +58616,7 @@
     "place": {
       "name": "Plympton-Wyoming",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 8308,
       "coord": [-82.1529152, 43.0699736],
@@ -58635,7 +58635,7 @@
     "place": {
       "name": "Pocahontas",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7371,
       "coord": [-90.9711021, 36.2612154],
@@ -58654,7 +58654,7 @@
     "place": {
       "name": "Pocatello",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 55525,
       "coord": [-112.450627, 42.8620287],
@@ -58673,7 +58673,7 @@
     "place": {
       "name": "Pocomoke City",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4295,
       "coord": [-75.5679832, 38.075684],
@@ -58692,7 +58692,7 @@
     "place": {
       "name": "Point Edward",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1930,
       "coord": [-82.4132944, 42.997903],
@@ -58719,7 +58719,7 @@
     "place": {
       "name": "Polk City",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5543,
       "coord": [-93.7137582, 41.7713201],
@@ -58738,7 +58738,7 @@
     "place": {
       "name": "Pollock",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 394,
       "coord": [-92.4070823, 31.5257321],
@@ -58757,7 +58757,7 @@
     "place": {
       "name": "Polson",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5148,
       "coord": [-114.163761, 47.6905295],
@@ -58776,7 +58776,7 @@
     "place": {
       "name": "Pomona",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 151713,
       "coord": [-117.7517496, 34.0553813],
@@ -58803,7 +58803,7 @@
     "place": {
       "name": "Ponca City",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24424,
       "coord": [-97.081898, 36.703647],
@@ -58822,7 +58822,7 @@
     "place": {
       "name": "Ponchatoula",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7822,
       "coord": [-90.4414762, 30.4388041],
@@ -58841,7 +58841,7 @@
     "place": {
       "name": "Pontiac",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11150,
       "coord": [-88.6297839, 40.8808666],
@@ -58860,7 +58860,7 @@
     "place": {
       "name": "Pontiac",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 61606,
       "coord": [-83.2910468, 42.6389216],
@@ -58893,7 +58893,7 @@
     "place": {
       "name": "Poplar Bluff",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16225,
       "coord": [-90.3957115, 36.7568327],
@@ -58912,7 +58912,7 @@
     "place": {
       "name": "Poplar Grove",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5049,
       "coord": [-88.822047, 42.3683522],
@@ -58931,7 +58931,7 @@
     "place": {
       "name": "Port Allegany",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2116,
       "coord": [-78.2797352, 41.810898],
@@ -58950,7 +58950,7 @@
     "place": {
       "name": "Port Allen",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4939,
       "coord": [-91.2100569, 30.45335],
@@ -58969,7 +58969,7 @@
     "place": {
       "name": "Port Austin",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 622,
       "coord": [-82.9936835, 44.0462652],
@@ -58988,7 +58988,7 @@
     "place": {
       "name": "Port Chester",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29163,
       "coord": [-73.6656834, 41.0017643],
@@ -59007,7 +59007,7 @@
     "place": {
       "name": "Port Clinton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6025,
       "coord": [-82.9376919, 41.5119954],
@@ -59026,7 +59026,7 @@
     "place": {
       "name": "Port Edwards",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1744,
       "coord": [-89.8654036, 44.3507979],
@@ -59045,7 +59045,7 @@
     "place": {
       "name": "Port Huron",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28983,
       "coord": [-82.4333742, 42.9760854],
@@ -59064,7 +59064,7 @@
     "place": {
       "name": "Port Sanilac",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 567,
       "coord": [-82.542424, 43.430858],
@@ -59083,7 +59083,7 @@
     "place": {
       "name": "Port St. Lucie",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 204851,
       "coord": [-80.3503283, 27.2939333],
@@ -59102,7 +59102,7 @@
     "place": {
       "name": "Port Townsend",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9710,
       "coord": [-122.769544, 48.1179702],
@@ -59143,7 +59143,7 @@
     "place": {
       "name": "Port Washington",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12353,
       "coord": [-87.875644, 43.3872247],
@@ -59162,7 +59162,7 @@
     "place": {
       "name": "Portage",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 37926,
       "coord": [-87.1761455, 41.5758708],
@@ -59189,7 +59189,7 @@
     "place": {
       "name": "Portage",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 48891,
       "coord": [-85.5800022, 42.2011538],
@@ -59208,7 +59208,7 @@
     "place": {
       "name": "Portage",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10581,
       "coord": [-89.461334, 43.539494],
@@ -59227,7 +59227,7 @@
     "place": {
       "name": "Portales",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12137,
       "coord": [-103.3373367, 34.1859636],
@@ -59246,7 +59246,7 @@
     "place": {
       "name": "Portland",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9384,
       "coord": [-72.6406905, 41.5728924],
@@ -59273,7 +59273,7 @@
     "place": {
       "name": "Portland",
       "state": "ME",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 68408,
       "coord": [-70.2548596, 43.6610277],
@@ -59300,7 +59300,7 @@
     "place": {
       "name": "Portland",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3796,
       "coord": [-84.9030517, 42.8692006],
@@ -59327,7 +59327,7 @@
     "place": {
       "name": "Portland",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 654741,
       "coord": [-122.6741949, 45.5202471],
@@ -59361,7 +59361,7 @@
     "place": {
       "name": "Portland",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 494,
       "coord": [-75.0979793, 40.9221629],
@@ -59380,7 +59380,7 @@
     "place": {
       "name": "Portsmouth",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18252,
       "coord": [-82.9965441, 38.7316375],
@@ -59399,7 +59399,7 @@
     "place": {
       "name": "Postville",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2503,
       "coord": [-91.5684784, 43.0865887],
@@ -59418,7 +59418,7 @@
     "place": {
       "name": "Poteau",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8807,
       "coord": [-94.6199966, 35.0568053],
@@ -59437,7 +59437,7 @@
     "place": {
       "name": "Pottstown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23433,
       "coord": [-75.6496424, 40.2452976],
@@ -59456,7 +59456,7 @@
     "place": {
       "name": "Pottsville",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3140,
       "coord": [-93.049061, 35.2481394],
@@ -59475,7 +59475,7 @@
     "place": {
       "name": "Pottsville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13346,
       "coord": [-76.1953701, 40.6851324],
@@ -59494,7 +59494,7 @@
     "place": {
       "name": "Poughkeepsie",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31577,
       "coord": [-73.9283672, 41.7065539],
@@ -59547,7 +59547,7 @@
     "place": {
       "name": "Poynette",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2590,
       "coord": [-89.402862, 43.3912031],
@@ -59580,7 +59580,7 @@
     "place": {
       "name": "Prairie du Chien",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5506,
       "coord": [-91.1409933, 43.05194],
@@ -59599,7 +59599,7 @@
     "place": {
       "name": "Prairie du Sac",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4420,
       "coord": [-89.7222092, 43.2920249],
@@ -59618,7 +59618,7 @@
     "place": {
       "name": "Prattville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 37781,
       "coord": [-86.4753174, 32.4600136],
@@ -59644,7 +59644,7 @@
     "place": {
       "name": "Prescott",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 45827,
       "coord": [-112.468812, 34.539984],
@@ -59671,7 +59671,7 @@
     "place": {
       "name": "Prescott",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4333,
       "coord": [-92.8022347, 44.749123],
@@ -59690,7 +59690,7 @@
     "place": {
       "name": "Prestonsburg",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3681,
       "coord": [-82.7715486, 37.6656527],
@@ -59709,7 +59709,7 @@
     "place": {
       "name": "Priceville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3513,
       "coord": [-86.8947271, 34.5250932],
@@ -59728,7 +59728,7 @@
     "place": {
       "name": "Primghar",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 896,
       "coord": [-95.627232, 43.086922],
@@ -59747,7 +59747,7 @@
     "place": {
       "name": "Prince George's County",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 967201,
       "coord": [-76.8518695, 38.803929],
@@ -59787,7 +59787,7 @@
     "place": {
       "name": "Princess Anne",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3446,
       "coord": [-75.6920008, 38.2028428],
@@ -59806,7 +59806,7 @@
     "place": {
       "name": "Princeton",
       "state": "BC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 2894,
       "coord": [-120.507973, 49.460459],
@@ -59825,7 +59825,7 @@
     "place": {
       "name": "Princeton",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7832,
       "coord": [-89.4648145, 41.368092],
@@ -59844,7 +59844,7 @@
     "place": {
       "name": "Princeton",
       "state": "NJ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30681,
       "coord": [-74.6597376, 40.3496953],
@@ -59863,7 +59863,7 @@
     "place": {
       "name": "Princeton",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5872,
       "coord": [-81.10728092, 37.383603],
@@ -59882,7 +59882,7 @@
     "place": {
       "name": "Princeville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1636,
       "coord": [-89.7576022, 40.9297591],
@@ -59901,7 +59901,7 @@
     "place": {
       "name": "Prompton",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 237,
       "coord": [-75.3251782, 41.5828646],
@@ -59920,7 +59920,7 @@
     "place": {
       "name": "Prophetstown",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1946,
       "coord": [-89.9362249, 41.6714198],
@@ -59939,7 +59939,7 @@
     "place": {
       "name": "Prospect",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4592,
       "coord": [-85.6046047909377, 38.3459615],
@@ -59978,7 +59978,7 @@
     "place": {
       "name": "Providence",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 179883,
       "coord": [-71.4128343, 41.8239891],
@@ -60013,7 +60013,7 @@
     "place": {
       "name": "Provincetown",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2994,
       "coord": [-70.1786375, 42.058436],
@@ -60032,7 +60032,7 @@
     "place": {
       "name": "Provo",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 116618,
       "coord": [-111.6585337, 40.2338438],
@@ -60051,7 +60051,7 @@
     "place": {
       "name": "Pryor Creek",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9444,
       "coord": [-95.3169136, 36.3084275],
@@ -60070,7 +60070,7 @@
     "place": {
       "name": "Pulaski",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3885,
       "coord": [-88.2426026, 44.6722158],
@@ -60089,7 +60089,7 @@
     "place": {
       "name": "Punta Gorda",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20369,
       "coord": [-82.0453664, 26.9297836],
@@ -60108,7 +60108,7 @@
     "place": {
       "name": "Punxsutawney",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5769,
       "coord": [-78.971078, 40.9436303],
@@ -60127,7 +60127,7 @@
     "place": {
       "name": "Quakertown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9359,
       "coord": [-75.3415667, 40.4417682],
@@ -60146,7 +60146,7 @@
     "place": {
       "name": "Queen Creek",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 59519,
       "coord": [-111.634158, 33.2483858],
@@ -60165,7 +60165,7 @@
     "place": {
       "name": "Quincy",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7970,
       "coord": [-84.5763649, 30.5887141],
@@ -60184,7 +60184,7 @@
     "place": {
       "name": "Quincy",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 39463,
       "coord": [-91.4098727, 39.9356016],
@@ -60203,7 +60203,7 @@
     "place": {
       "name": "Quincy",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 101636,
       "coord": [-71.0037374, 42.2509914],
@@ -60222,7 +60222,7 @@
     "place": {
       "name": "Quincy",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1554,
       "coord": [-84.8838525, 41.9442145],
@@ -60249,7 +60249,7 @@
     "place": {
       "name": "Quitman County",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 6176,
       "coord": [-90.2946542, 34.1920186],
@@ -60268,7 +60268,7 @@
     "place": {
       "name": "Racine",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 77816,
       "coord": [-87.7825242, 42.7260523],
@@ -60287,7 +60287,7 @@
     "place": {
       "name": "Raleigh",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 467665,
       "coord": [-78.6390989, 35.7803977],
@@ -60319,7 +60319,7 @@
     "place": {
       "name": "Ralston",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6494,
       "coord": [-96.0323796, 41.2016674],
@@ -60338,7 +60338,7 @@
     "place": {
       "name": "Rancho Cucamonga",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 174453,
       "coord": [-117.575173, 34.1033192],
@@ -60357,7 +60357,7 @@
     "place": {
       "name": "Randolph",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1796,
       "coord": [-89.0067778, 43.5391527],
@@ -60376,7 +60376,7 @@
     "place": {
       "name": "Random Lake",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1561,
       "coord": [-87.9617585, 43.55222],
@@ -60395,7 +60395,7 @@
     "place": {
       "name": "Rankin",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1896,
       "coord": [-79.8792161, 40.412569],
@@ -60414,7 +60414,7 @@
     "place": {
       "name": "Ranlo",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4511,
       "coord": [-81.130355, 35.2862489],
@@ -60454,7 +60454,7 @@
     "place": {
       "name": "Rantoul",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12371,
       "coord": [-88.1558785, 40.3083672],
@@ -60473,7 +60473,7 @@
     "place": {
       "name": "Rapid City",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 74703,
       "coord": [-103.2280239, 44.0806041],
@@ -60492,7 +60492,7 @@
     "place": {
       "name": "Raton",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6041,
       "coord": [-104.4354816, 36.8979234],
@@ -60511,7 +60511,7 @@
     "place": {
       "name": "Rawlins",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8221,
       "coord": [-107.239176, 41.7907878],
@@ -60530,7 +60530,7 @@
     "place": {
       "name": "Ray",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 740,
       "coord": [-103.165185, 48.344466],
@@ -60549,7 +60549,7 @@
     "place": {
       "name": "Raytown",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30012,
       "coord": [-94.4622103, 39.0089226],
@@ -60568,7 +60568,7 @@
     "place": {
       "name": "Reading",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1095,
       "coord": [-84.7480134, 41.8394928],
@@ -60587,7 +60587,7 @@
     "place": {
       "name": "Reading",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10600,
       "coord": [-84.4421641, 39.2236694],
@@ -60606,7 +60606,7 @@
     "place": {
       "name": "Reading",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 95112,
       "coord": [-75.9279495, 40.335345],
@@ -60625,7 +60625,7 @@
     "place": {
       "name": "Red Cloud",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 962,
       "coord": [-98.519505, 40.088903],
@@ -60644,7 +60644,7 @@
     "place": {
       "name": "Red Cross",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 762,
       "coord": [-80.3556188, 35.2673659],
@@ -60663,7 +60663,7 @@
     "place": {
       "name": "Red Lake Falls",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1339,
       "coord": [-96.2731977, 47.8822511],
@@ -60682,7 +60682,7 @@
     "place": {
       "name": "Red Lion",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6506,
       "coord": [-76.6058001, 39.9009334],
@@ -60701,7 +60701,7 @@
     "place": {
       "name": "Red Lodge",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2257,
       "coord": [-109.2470622, 45.1859038],
@@ -60720,7 +60720,7 @@
     "place": {
       "name": "Red Oak",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5362,
       "coord": [-95.228247, 41.0095189],
@@ -60739,7 +60739,7 @@
     "place": {
       "name": "Red Wing",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16763,
       "coord": [-92.5338013, 44.5624676],
@@ -60758,7 +60758,7 @@
     "place": {
       "name": "Redding",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 91580,
       "coord": [-122.391675, 40.5863563],
@@ -60777,7 +60777,7 @@
     "place": {
       "name": "Redding",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8765,
       "coord": [-73.3834532, 41.3025956],
@@ -60796,7 +60796,7 @@
     "place": {
       "name": "Redfield",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 731,
       "coord": [-94.19607, 41.5894322],
@@ -60815,7 +60815,7 @@
     "place": {
       "name": "Redford Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 49504,
       "coord": [-83.2953927, 42.3945469],
@@ -60834,7 +60834,7 @@
     "place": {
       "name": "Redwood Falls",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5102,
       "coord": [-95.1164478, 44.5393721],
@@ -60853,7 +60853,7 @@
     "place": {
       "name": "Reedsburg",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9984,
       "coord": [-90.0026259, 43.5324809],
@@ -60872,7 +60872,7 @@
     "place": {
       "name": "Reeseville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 763,
       "coord": [-88.8448278, 43.3049943],
@@ -60891,7 +60891,7 @@
     "place": {
       "name": "Regensburg",
       "state": "BY",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 157443,
       "coord": [12.0974869, 49.0195333],
@@ -60916,7 +60916,7 @@
     "place": {
       "name": "Regina",
       "state": "SK",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 228928,
       "coord": [-104.61731, 50.44876],
@@ -60935,7 +60935,7 @@
     "place": {
       "name": "Rehoboth Beach",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1108,
       "coord": [-75.0835107, 38.7164771],
@@ -60954,7 +60954,7 @@
     "place": {
       "name": "Reinbeck",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1662,
       "coord": [-92.5993534, 42.3242883],
@@ -60973,7 +60973,7 @@
     "place": {
       "name": "Reno",
       "state": "NV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 264165,
       "coord": [-119.8126581, 39.5261206],
@@ -61000,7 +61000,7 @@
     "place": {
       "name": "Renville",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1301,
       "coord": [-95.2116731, 44.7891264],
@@ -61019,7 +61019,7 @@
     "place": {
       "name": "Reykjavík",
       "state": "Höfuðborgarsvæðið",
-      "country": "IS",
+      "country": "Iceland",
       "type": "city",
       "pop": 139875,
       "coord": [-21.9422367, 64.145981],
@@ -61046,7 +61046,7 @@
     "place": {
       "name": "Reynoldsburg",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 41076,
       "coord": [-82.8121191, 39.9547861],
@@ -61073,7 +61073,7 @@
     "place": {
       "name": "Rhinebeck",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2697,
       "coord": [-73.912763, 41.9267604],
@@ -61100,7 +61100,7 @@
     "place": {
       "name": "Rhinelander",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8285,
       "coord": [-89.412075, 45.636623],
@@ -61119,7 +61119,7 @@
     "place": {
       "name": "Rib Mountain",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7313,
       "coord": [-89.6558452, 44.9112334],
@@ -61138,7 +61138,7 @@
     "place": {
       "name": "Rice Lake",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9040,
       "coord": [-91.7331646, 45.5027976],
@@ -61157,7 +61157,7 @@
     "place": {
       "name": "Richfield",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36994,
       "coord": [-93.2877877, 44.8766431],
@@ -61184,7 +61184,7 @@
     "place": {
       "name": "Richland Center",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5114,
       "coord": [-90.3854036, 43.3355111],
@@ -61203,7 +61203,7 @@
     "place": {
       "name": "Richland City",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 403,
       "coord": [-87.1677784, 37.9453257],
@@ -61222,7 +61222,7 @@
     "place": {
       "name": "Richland County",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 17304,
       "coord": [-90.4557081, 43.3662526],
@@ -61241,7 +61241,7 @@
     "place": {
       "name": "Richland",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 946,
       "coord": [-85.4550054, 42.3761504],
@@ -61260,7 +61260,7 @@
     "place": {
       "name": "Richland",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1490,
       "coord": [-76.2582849, 40.3592589],
@@ -61279,7 +61279,7 @@
     "place": {
       "name": "Richmond",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2089,
       "coord": [-88.3059251, 42.4758522],
@@ -61298,7 +61298,7 @@
     "place": {
       "name": "Richmond",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35720,
       "coord": [-84.8898521, 39.8286897],
@@ -61317,7 +61317,7 @@
     "place": {
       "name": "Richmond",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5878,
       "coord": [-82.7557554, 42.8091969],
@@ -61336,7 +61336,7 @@
     "place": {
       "name": "Richmond",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 230436,
       "coord": [-77.43428, 37.5385087],
@@ -61355,7 +61355,7 @@
     "place": {
       "name": "Richton Park",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12775,
       "coord": [-87.7033787, 41.484479],
@@ -61374,7 +61374,7 @@
     "place": {
       "name": "Ridgefield",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25033,
       "coord": [-73.4981792, 41.2814842],
@@ -61393,7 +61393,7 @@
     "place": {
       "name": "Ridgefield",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9153,
       "coord": [-122.7433775, 45.8167616],
@@ -61412,7 +61412,7 @@
     "place": {
       "name": "Ridgeland",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24340,
       "coord": [-90.1323087, 32.4284761],
@@ -61431,7 +61431,7 @@
     "place": {
       "name": "Ridgely",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1611,
       "coord": [-75.8848665, 38.9480656],
@@ -61450,7 +61450,7 @@
     "place": {
       "name": "Ridgeway",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 624,
       "coord": [-89.9925395, 42.9998454],
@@ -61469,7 +61469,7 @@
     "place": {
       "name": "Ridgway",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1183,
       "coord": [-107.761726, 38.1527685],
@@ -61488,7 +61488,7 @@
     "place": {
       "name": "Ridley Park",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7186,
       "coord": [-75.3221004, 39.8805248],
@@ -61515,7 +61515,7 @@
     "place": {
       "name": "Rifle",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10437,
       "coord": [-107.7831199, 39.5347023],
@@ -61542,7 +61542,7 @@
     "place": {
       "name": "Riley",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 938,
       "coord": [-96.830844, 39.298885],
@@ -61561,7 +61561,7 @@
     "place": {
       "name": "Rio Rancho",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 104046,
       "coord": [-106.6329806, 35.2702448],
@@ -61580,7 +61580,7 @@
     "place": {
       "name": "Rio de Janeiro",
       "state": "RJ",
-      "country": "BR",
+      "country": "Brazil",
       "type": "city",
       "pop": 6747815,
       "coord": [-43.2093727, -22.9110137],
@@ -61607,7 +61607,7 @@
     "place": {
       "name": "Ripon",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7863,
       "coord": [-88.8387158, 43.8442406],
@@ -61626,7 +61626,7 @@
     "place": {
       "name": "Rising Sun",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2248,
       "coord": [-84.853838, 38.9495047],
@@ -61645,7 +61645,7 @@
     "place": {
       "name": "Rittman",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6131,
       "coord": [-81.7811745, 40.9723644],
@@ -61664,7 +61664,7 @@
     "place": {
       "name": "River Forest",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11717,
       "coord": [-87.8139483, 41.8978091],
@@ -61683,7 +61683,7 @@
     "place": {
       "name": "River Grove",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10612,
       "coord": [-87.8358943, 41.9258642],
@@ -61718,7 +61718,7 @@
     "place": {
       "name": "River Heights",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2144,
       "coord": [-111.821417, 41.7218845],
@@ -61737,7 +61737,7 @@
     "place": {
       "name": "River Rouge",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7465,
       "coord": [-83.1352891, 42.2729262],
@@ -61764,7 +61764,7 @@
     "place": {
       "name": "Riverdale",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10663,
       "coord": [-87.6331021, 41.6333678],
@@ -61783,7 +61783,7 @@
     "place": {
       "name": "Riverside",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 314998,
       "coord": [-117.37396, 33.980351],
@@ -61810,7 +61810,7 @@
     "place": {
       "name": "Riverside",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1060,
       "coord": [-91.5812739, 41.4797157],
@@ -61829,7 +61829,7 @@
     "place": {
       "name": "Riverside",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9298,
       "coord": [-87.8153195, 41.8323474],
@@ -61856,7 +61856,7 @@
     "place": {
       "name": "Riverton",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3532,
       "coord": [-89.5395417, 39.8442164],
@@ -61875,7 +61875,7 @@
     "place": {
       "name": "Roanoke",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5311,
       "coord": [-85.3748173, 33.1522422],
@@ -61894,7 +61894,7 @@
     "place": {
       "name": "Roanoke",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 98865,
       "coord": [-79.9414313, 37.270973],
@@ -61921,7 +61921,7 @@
     "place": {
       "name": "Robbinsdale",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14646,
       "coord": [-93.3395843, 45.0313156],
@@ -61940,7 +61940,7 @@
     "place": {
       "name": "Roberts",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1919,
       "coord": [-92.5560301, 44.9838558],
@@ -61959,7 +61959,7 @@
     "place": {
       "name": "Rochelle",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9407,
       "coord": [-89.0687074, 41.9239178],
@@ -61986,7 +61986,7 @@
     "place": {
       "name": "Rochester Hills",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 76300,
       "coord": [-83.1499322, 42.6583661],
@@ -62005,7 +62005,7 @@
     "place": {
       "name": "Rochester",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13035,
       "coord": [-83.1338214, 42.680588],
@@ -62024,7 +62024,7 @@
     "place": {
       "name": "Rochester",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 121395,
       "coord": [-92.4630182, 44.0234387],
@@ -62071,7 +62071,7 @@
     "place": {
       "name": "Rochester",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 205695,
       "coord": [-77.615214, 43.157285],
@@ -62090,7 +62090,7 @@
     "place": {
       "name": "Rock Creek",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1682,
       "coord": [-92.9624327, 45.7574574],
@@ -62109,7 +62109,7 @@
     "place": {
       "name": "Rock Creek",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 667,
       "coord": [-80.860644, 41.660333],
@@ -62128,7 +62128,7 @@
     "place": {
       "name": "Rock Falls",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8606,
       "coord": [-89.6926018, 41.7816248],
@@ -62147,7 +62147,7 @@
     "place": {
       "name": "Rock Hill",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 74372,
       "coord": [-81.0250784, 34.9248667],
@@ -62174,7 +62174,7 @@
     "place": {
       "name": "Rock Island County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 144672,
       "coord": [-90.5766144, 41.4411786],
@@ -62193,7 +62193,7 @@
     "place": {
       "name": "Rock Island",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36636,
       "coord": [-90.5792031, 41.5095446],
@@ -62220,7 +62220,7 @@
     "place": {
       "name": "Rock Island",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1302,
       "coord": [-120.1439523, 47.3770731],
@@ -62239,7 +62239,7 @@
     "place": {
       "name": "Rock Rapids",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2611,
       "coord": [-96.1674831, 43.4303235],
@@ -62258,7 +62258,7 @@
     "place": {
       "name": "Rock Valley",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4059,
       "coord": [-96.294843, 43.205241],
@@ -62277,7 +62277,7 @@
     "place": {
       "name": "Rockdale",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 207,
       "coord": [-89.0315057, 42.972298],
@@ -62296,7 +62296,7 @@
     "place": {
       "name": "Rockford",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 147441,
       "coord": [-89.093966, 42.2713945],
@@ -62315,7 +62315,7 @@
     "place": {
       "name": "Rockford",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4500,
       "coord": [-93.7344099, 45.0882963],
@@ -62334,7 +62334,7 @@
     "place": {
       "name": "Rockville",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 67117,
       "coord": [-77.1516844, 39.0817985],
@@ -62353,7 +62353,7 @@
     "place": {
       "name": "Rockwell City",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2240,
       "coord": [-94.6338671, 42.3952576],
@@ -62372,7 +62372,7 @@
     "place": {
       "name": "Rockwell",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2302,
       "coord": [-80.4064485, 35.5512508],
@@ -62391,7 +62391,7 @@
     "place": {
       "name": "Rocky Hill",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20845,
       "coord": [-72.6392587, 41.6648216],
@@ -62426,7 +62426,7 @@
     "place": {
       "name": "Rocky River",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21755,
       "coord": [-81.8393034, 41.4756031],
@@ -62453,7 +62453,7 @@
     "place": {
       "name": "Rogers City",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2886,
       "coord": [-83.818185, 45.421391],
@@ -62472,7 +62472,7 @@
     "place": {
       "name": "Rogers",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 69913,
       "coord": [-94.1166283, 36.3330154],
@@ -62491,7 +62491,7 @@
     "place": {
       "name": "Rogers",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13295,
       "coord": [-93.5524563, 45.1888596],
@@ -62510,7 +62510,7 @@
     "place": {
       "name": "Rolla",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19943,
       "coord": [-91.7708076, 37.9509324],
@@ -62529,7 +62529,7 @@
     "place": {
       "name": "Rolling Meadows",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24200,
       "coord": [-88.0131275, 42.0841936],
@@ -62548,7 +62548,7 @@
     "place": {
       "name": "Rome City",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1322,
       "coord": [-85.3766454, 41.4961609],
@@ -62567,7 +62567,7 @@
     "place": {
       "name": "Romeo",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3767,
       "coord": [-83.0129874, 42.802808],
@@ -62586,7 +62586,7 @@
     "place": {
       "name": "Romeoville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 39863,
       "coord": [-88.0895061, 41.6475306],
@@ -62605,7 +62605,7 @@
     "place": {
       "name": "Romulus",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25178,
       "coord": [-83.3965995, 42.2222614],
@@ -62624,7 +62624,7 @@
     "place": {
       "name": "Roscoe",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10983,
       "coord": [-89.0092742, 42.4133505],
@@ -62643,7 +62643,7 @@
     "place": {
       "name": "Roscommon",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 981,
       "coord": [-84.592516, 44.498542],
@@ -62670,7 +62670,7 @@
     "place": {
       "name": "Rose Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6188,
       "coord": [-83.6261079696715, 42.7409565],
@@ -62689,7 +62689,7 @@
     "place": {
       "name": "Roseau",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2744,
       "coord": [-95.7613231, 48.8457996],
@@ -62708,7 +62708,7 @@
     "place": {
       "name": "Roselle",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22897,
       "coord": [-88.0799571, 41.9852583],
@@ -62727,7 +62727,7 @@
     "place": {
       "name": "Rosemount",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25650,
       "coord": [-93.12611, 44.7391873],
@@ -62746,7 +62746,7 @@
     "place": {
       "name": "Rosenheim",
       "state": "BY",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 64403,
       "coord": [12.127262, 47.8539273],
@@ -62765,7 +62765,7 @@
     "place": {
       "name": "Roseville",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 147773,
       "coord": [-121.2880059, 38.7521235],
@@ -62788,7 +62788,7 @@
     "place": {
       "name": "Roseville",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 47710,
       "coord": [-82.9371409, 42.4972583],
@@ -62807,7 +62807,7 @@
     "place": {
       "name": "Roseville",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36254,
       "coord": [-93.1566107, 45.0060767],
@@ -62834,7 +62834,7 @@
     "place": {
       "name": "Rossford",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6299,
       "coord": [-83.5643782, 41.6097726],
@@ -62853,7 +62853,7 @@
     "place": {
       "name": "Rossville",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1105,
       "coord": [-95.951656, 39.13611],
@@ -62872,7 +62872,7 @@
     "place": {
       "name": "Rostock",
       "state": "MV",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 208400,
       "coord": [12.1400211, 54.0886707],
@@ -62891,7 +62891,7 @@
     "place": {
       "name": "Roswell",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 47551,
       "coord": [-104.5229518, 33.3943282],
@@ -62910,7 +62910,7 @@
     "place": {
       "name": "Round Lake Beach",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27252,
       "coord": [-88.0900806, 42.3716881],
@@ -62929,7 +62929,7 @@
     "place": {
       "name": "Round Lake Park",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7680,
       "coord": [-88.0767465, 42.3569661],
@@ -62948,7 +62948,7 @@
     "place": {
       "name": "Round Lake",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18721,
       "coord": [-88.0934145, 42.353355],
@@ -62967,7 +62967,7 @@
     "place": {
       "name": "Roundup",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1742,
       "coord": [-108.541799, 46.445242],
@@ -62986,7 +62986,7 @@
     "place": {
       "name": "Rouses Point",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2195,
       "coord": [-73.3645221, 44.9939829],
@@ -63005,7 +63005,7 @@
     "place": {
       "name": "Roxana",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1454,
       "coord": [-90.0768875, 38.8482602],
@@ -63031,7 +63031,7 @@
     "place": {
       "name": "Royal Oak",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 58211,
       "coord": [-83.1446485, 42.4894801],
@@ -63058,7 +63058,7 @@
     "place": {
       "name": "Royalton",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1281,
       "coord": [-94.293702, 45.8299124],
@@ -63077,7 +63077,7 @@
     "place": {
       "name": "Royersford",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4940,
       "coord": [-75.5379639, 40.1842688],
@@ -63096,7 +63096,7 @@
     "place": {
       "name": "Rudolph",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 435,
       "coord": [-89.8076239, 44.4960752],
@@ -63115,7 +63115,7 @@
     "place": {
       "name": "Ruidoso Downs",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2620,
       "coord": [-105.60442, 33.3292691],
@@ -63134,7 +63134,7 @@
     "place": {
       "name": "Ruidoso",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7679,
       "coord": [-105.673099, 33.3315804],
@@ -63153,7 +63153,7 @@
     "place": {
       "name": "Rush City",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3228,
       "coord": [-92.9654903, 45.6855145],
@@ -63172,7 +63172,7 @@
     "place": {
       "name": "Rushville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6208,
       "coord": [-85.4469755, 39.608756],
@@ -63191,7 +63191,7 @@
     "place": {
       "name": "Russell Springs",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2715,
       "coord": [-85.0768487115385, 37.0439],
@@ -63210,7 +63210,7 @@
     "place": {
       "name": "Russell",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4401,
       "coord": [-98.859806, 38.895289],
@@ -63229,7 +63229,7 @@
     "place": {
       "name": "Russellville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10855,
       "coord": [-87.7332823, 34.5042652],
@@ -63248,7 +63248,7 @@
     "place": {
       "name": "Russellville",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28940,
       "coord": [-93.1337856, 35.2784173],
@@ -63275,7 +63275,7 @@
     "place": {
       "name": "Russellville",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7164,
       "coord": [-86.887219, 36.8453199],
@@ -63294,7 +63294,7 @@
     "place": {
       "name": "Ruston",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22166,
       "coord": [-92.637927, 32.5232053],
@@ -63329,7 +63329,7 @@
     "place": {
       "name": "Ruthven",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 725,
       "coord": [-94.8991531, 43.1291322],
@@ -63348,7 +63348,7 @@
     "place": {
       "name": "Sabetha",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2545,
       "coord": [-95.8002347, 39.9032342],
@@ -63367,7 +63367,7 @@
     "place": {
       "name": "Sacramento",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 513624,
       "coord": [-121.493895, 38.5810606],
@@ -63400,7 +63400,7 @@
     "place": {
       "name": "Saginaw Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 41679,
       "coord": [-84.0209848158011, 43.43695045],
@@ -63419,7 +63419,7 @@
     "place": {
       "name": "Saginaw",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 44202,
       "coord": [-83.9490365, 43.4200387],
@@ -63438,7 +63438,7 @@
     "place": {
       "name": "Sahuarita",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 34134,
       "coord": [-110.9556645, 31.9575305],
@@ -63465,7 +63465,7 @@
     "place": {
       "name": "Saint Marys",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12639,
       "coord": [-78.5611275, 41.4280432],
@@ -63484,7 +63484,7 @@
     "place": {
       "name": "Sainte-Adèle",
       "state": "QC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 14010,
       "coord": [-74.1359579, 45.951895],
@@ -63503,7 +63503,7 @@
     "place": {
       "name": "Saipan",
       "state": "MP",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 43385,
       "coord": [145.746743003024, 15.1909825],
@@ -63522,7 +63522,7 @@
     "place": {
       "name": "Salaberry-de-Valleyfield",
       "state": "QC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 42410,
       "coord": [-74.1316718, 45.2555575],
@@ -63541,7 +63541,7 @@
     "place": {
       "name": "Salem",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 44480,
       "coord": [-70.8967226, 42.5195292],
@@ -63560,7 +63560,7 @@
     "place": {
       "name": "Salem",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 174365,
       "coord": [-123.033121, 44.9391565],
@@ -63587,7 +63587,7 @@
     "place": {
       "name": "Salem",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1325,
       "coord": [-97.388953, 43.724146],
@@ -63606,7 +63606,7 @@
     "place": {
       "name": "Salida",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5666,
       "coord": [-105.990968, 38.5371195],
@@ -63625,7 +63625,7 @@
     "place": {
       "name": "Salina",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 46889,
       "coord": [-97.6114237, 38.8402805],
@@ -63652,7 +63652,7 @@
     "place": {
       "name": "Salinas",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 163542,
       "coord": [-121.655037, 36.6744117],
@@ -63679,7 +63679,7 @@
     "place": {
       "name": "Saline",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8948,
       "coord": [-83.7816075, 42.1667072],
@@ -63706,7 +63706,7 @@
     "place": {
       "name": "Salisbury",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32935,
       "coord": [-75.6009964, 38.366027],
@@ -63725,7 +63725,7 @@
     "place": {
       "name": "Salisbury",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1563,
       "coord": [-92.8015773, 39.4239175],
@@ -63744,7 +63744,7 @@
     "place": {
       "name": "Salisbury",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35540,
       "coord": [-80.4742261, 35.6709727],
@@ -63785,7 +63785,7 @@
     "place": {
       "name": "Salix",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 295,
       "coord": [-96.2877387, 42.3084403],
@@ -63804,7 +63804,7 @@
     "place": {
       "name": "Salt Lake City",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 200478,
       "coord": [-111.886797, 40.7596198],
@@ -63846,7 +63846,7 @@
     "place": {
       "name": "San Angelo",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 101004,
       "coord": [-100.4405094, 31.4649685],
@@ -63865,7 +63865,7 @@
     "place": {
       "name": "San Anselmo",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12830,
       "coord": [-122.561503, 37.9744323],
@@ -63890,7 +63890,7 @@
     "place": {
       "name": "San Antonio",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1547253,
       "coord": [-98.4951405, 29.4246002],
@@ -63909,7 +63909,7 @@
     "place": {
       "name": "San Bernardino",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 222101,
       "coord": [-117.2897652, 34.1083449],
@@ -63936,7 +63936,7 @@
     "place": {
       "name": "San Diego",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1423851,
       "coord": [-117.1627728, 32.7174202],
@@ -63955,7 +63955,7 @@
     "place": {
       "name": "San Francisco",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 881549,
       "coord": [-122.419906, 37.7790262],
@@ -63989,7 +63989,7 @@
     "place": {
       "name": "San Jose",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 971233,
       "coord": [-121.890583, 37.3361905],
@@ -64008,7 +64008,7 @@
     "place": {
       "name": "San Juan",
       "state": "PR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 342259,
       "coord": [-66.116666, 18.465299],
@@ -64027,7 +64027,7 @@
     "place": {
       "name": "San Luis Obispo",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 47063,
       "coord": [-120.662873, 35.27988],
@@ -64046,7 +64046,7 @@
     "place": {
       "name": "San Marcos",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 68580,
       "coord": [-97.9405828, 29.8826436],
@@ -64065,7 +64065,7 @@
     "place": {
       "name": "San Pedro Garza García",
       "state": "NL",
-      "country": "MX",
+      "country": "Mexico",
       "type": "city",
       "pop": 132128,
       "coord": [-100.4018251, 25.6651753],
@@ -64092,7 +64092,7 @@
     "place": {
       "name": "Sandpoint",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8931,
       "coord": [-116.5532476, 48.2765903],
@@ -64111,7 +64111,7 @@
     "place": {
       "name": "Sandusky",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2709,
       "coord": [-82.829657, 43.420299],
@@ -64138,7 +64138,7 @@
     "place": {
       "name": "Sandusky",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24564,
       "coord": [-82.7115813, 41.4561002],
@@ -64157,7 +64157,7 @@
     "place": {
       "name": "Sandwich",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7221,
       "coord": [-88.6217432, 41.6458633],
@@ -64184,7 +64184,7 @@
     "place": {
       "name": "Sandy Springs",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 108080,
       "coord": [-84.3785379, 33.9242688],
@@ -64219,7 +64219,7 @@
     "place": {
       "name": "Santa Ana",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 310227,
       "coord": [-117.8732213, 33.7494951],
@@ -64246,7 +64246,7 @@
     "place": {
       "name": "Santa Barbara",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 91364,
       "coord": [-119.7026673, 34.4221319],
@@ -64265,7 +64265,7 @@
     "place": {
       "name": "Santa Clara",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 127647,
       "coord": [-121.954716, 37.354611],
@@ -64288,7 +64288,7 @@
     "place": {
       "name": "Santa Clarita",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 228673,
       "coord": [-118.5538088, 34.4127963],
@@ -64307,7 +64307,7 @@
     "place": {
       "name": "Santa Fe",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 87505,
       "coord": [-105.938456, 35.6876096],
@@ -64326,7 +64326,7 @@
     "place": {
       "name": "Santa Monica",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 91105,
       "coord": [-118.491227, 34.0194704],
@@ -64361,7 +64361,7 @@
     "place": {
       "name": "Santa Rosa",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 176753,
       "coord": [-122.7141049, 38.4404925],
@@ -64380,7 +64380,7 @@
     "place": {
       "name": "Sapulpa",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21929,
       "coord": [-96.1049612, 36.0005035],
@@ -64415,7 +64415,7 @@
     "place": {
       "name": "Saranac Lake",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5700,
       "coord": [-74.131279, 44.329497],
@@ -64434,7 +64434,7 @@
     "place": {
       "name": "Sarasota",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 54842,
       "coord": [-82.5308545, 27.3365805],
@@ -64470,7 +64470,7 @@
     "place": {
       "name": "Saratoga Springs",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28491,
       "coord": [-73.7853915, 43.0821793],
@@ -64497,7 +64497,7 @@
     "place": {
       "name": "Saratoga",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1697,
       "coord": [-106.8053642, 41.4546384],
@@ -64516,7 +64516,7 @@
     "place": {
       "name": "Sardis",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1748,
       "coord": [-89.9159227, 34.4370511],
@@ -64535,7 +64535,7 @@
     "place": {
       "name": "Sarnia",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 72047,
       "coord": [-82.403533, 42.9743821],
@@ -64560,7 +64560,7 @@
     "place": {
       "name": "Saskatoon",
       "state": "SK",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 266141,
       "coord": [-106.660767, 52.131802],
@@ -64579,7 +64579,7 @@
     "place": {
       "name": "Sassnitz",
       "state": "MV",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 9169,
       "coord": [13.644119, 54.516728],
@@ -64598,7 +64598,7 @@
     "place": {
       "name": "Saugatuck Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3443,
       "coord": [-86.1620819781354, 42.63729695],
@@ -64617,7 +64617,7 @@
     "place": {
       "name": "Saugatuck",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 865,
       "coord": [-86.2040552, 42.6549244],
@@ -64636,7 +64636,7 @@
     "place": {
       "name": "Saugeen Shores",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 15908,
       "coord": [-81.3713261, 44.4952483],
@@ -64655,7 +64655,7 @@
     "place": {
       "name": "Sauk City",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3518,
       "coord": [-89.7226827, 43.2715944],
@@ -64674,7 +64674,7 @@
     "place": {
       "name": "Sauk Village",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9921,
       "coord": [-87.5675414, 41.4883685],
@@ -64693,7 +64693,7 @@
     "place": {
       "name": "Sault Ste. Marie",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13337,
       "coord": [-84.359269, 46.490586],
@@ -64712,7 +64712,7 @@
     "place": {
       "name": "Sault Ste. Marie",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 72051,
       "coord": [-84.320068, 46.52391],
@@ -64731,7 +64731,7 @@
     "place": {
       "name": "Savanna",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2699,
       "coord": [-90.1567944, 42.0944672],
@@ -64750,7 +64750,7 @@
     "place": {
       "name": "Savannah",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 147780,
       "coord": [-81.0921335, 32.0790074],
@@ -64777,7 +64777,7 @@
     "place": {
       "name": "Savannah",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5069,
       "coord": [-94.829946, 39.9413678],
@@ -64796,7 +64796,7 @@
     "place": {
       "name": "Schaumburg",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 78723,
       "coord": [-88.083406, 42.0333608],
@@ -64823,7 +64823,7 @@
     "place": {
       "name": "Schenectady",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 65334,
       "coord": [-73.9395687, 42.8142432],
@@ -64850,7 +64850,7 @@
     "place": {
       "name": "Schererville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29646,
       "coord": [-87.4547605, 41.4789246],
@@ -64885,7 +64885,7 @@
     "place": {
       "name": "Schiller Park",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11709,
       "coord": [-87.8708965, 41.9558637],
@@ -64904,7 +64904,7 @@
     "place": {
       "name": "Schoolcraft",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1466,
       "coord": [-85.637062, 42.115795],
@@ -64931,7 +64931,7 @@
     "place": {
       "name": "Schuyler",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6547,
       "coord": [-97.0572541, 41.4473547],
@@ -64950,7 +64950,7 @@
     "place": {
       "name": "Schuylkill Haven",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5253,
       "coord": [-76.171054, 40.6306464],
@@ -64969,7 +64969,7 @@
     "place": {
       "name": "Schwenksville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1431,
       "coord": [-75.4637876, 40.256213],
@@ -64996,7 +64996,7 @@
     "place": {
       "name": "Scio Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17552,
       "coord": [-83.8404756, 42.2976528],
@@ -65015,7 +65015,7 @@
     "place": {
       "name": "Scotland",
       "state": null,
-      "country": "UK",
+      "country": "United Kingdom",
       "type": "country",
       "pop": 5436600,
       "coord": [-4.1140518, 56.7861112],
@@ -65034,7 +65034,7 @@
     "place": {
       "name": "Scottdale",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4430,
       "coord": [-79.5869835, 40.1003507],
@@ -65053,7 +65053,7 @@
     "place": {
       "name": "Scottsbluff",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14436,
       "coord": [-103.6627088, 41.862302],
@@ -65072,7 +65072,7 @@
     "place": {
       "name": "Scottsdale",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 241361,
       "coord": [-111.926018, 33.4942189],
@@ -65091,7 +65091,7 @@
     "place": {
       "name": "Scranton",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 76997,
       "coord": [-75.6621294, 41.4086874],
@@ -65110,7 +65110,7 @@
     "place": {
       "name": "Seabrook",
       "state": "NH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8869,
       "coord": [-70.8601957, 42.8846631],
@@ -65137,7 +65137,7 @@
     "place": {
       "name": "Searcy",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22937,
       "coord": [-91.737565, 35.248688],
@@ -65156,7 +65156,7 @@
     "place": {
       "name": "Seattle",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 753675,
       "coord": [-122.3300624, 47.6038321],
@@ -65199,7 +65199,7 @@
     "place": {
       "name": "Sebewaing",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1721,
       "coord": [-83.4513398, 43.7323467],
@@ -65218,7 +65218,7 @@
     "place": {
       "name": "Sedalia",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21725,
       "coord": [-93.2295515, 38.7098314],
@@ -65242,7 +65242,7 @@
     "place": {
       "name": "Sedona",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9684,
       "coord": [-111.7614394, 34.8688613],
@@ -65266,7 +65266,7 @@
     "place": {
       "name": "Seguin",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 5280,
       "coord": [-79.85287932874844, 45.321133599999996],
@@ -65285,7 +65285,7 @@
     "place": {
       "name": "Seligman",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 813,
       "coord": [-93.9390651, 36.5208001],
@@ -65304,7 +65304,7 @@
     "place": {
       "name": "Selinsgrove",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5761,
       "coord": [-76.8607084, 40.8062437],
@@ -65323,7 +65323,7 @@
     "place": {
       "name": "Sellersville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4567,
       "coord": [-75.3050079, 40.3542858],
@@ -65342,7 +65342,7 @@
     "place": {
       "name": "Selma",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17971,
       "coord": [-87.0207473, 32.4078632],
@@ -65361,7 +65361,7 @@
     "place": {
       "name": "Senatobia",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8354,
       "coord": [-89.9646282, 34.6187807],
@@ -65380,7 +65380,7 @@
     "place": {
       "name": "Seneca",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2353,
       "coord": [-88.6090863, 41.3107161],
@@ -65415,7 +65415,7 @@
     "place": {
       "name": "Seneca",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2139,
       "coord": [-96.064168, 39.834165],
@@ -65434,7 +65434,7 @@
     "place": {
       "name": "Seoul",
       "state": "Seoul Special Metropolitan City",
-      "country": "KR",
+      "country": "Korea",
       "type": "city",
       "pop": 9586195,
       "coord": [126.78926445637777, 37.57662381985587],
@@ -65453,7 +65453,7 @@
     "place": {
       "name": "Sergeant Bluff",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5015,
       "coord": [-96.3589804, 42.4039197],
@@ -65472,7 +65472,7 @@
     "place": {
       "name": "Sesser",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1888,
       "coord": [-89.0503512, 38.0917168],
@@ -65499,7 +65499,7 @@
     "place": {
       "name": "Severance",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7683,
       "coord": [-104.850919, 40.5231623],
@@ -65518,7 +65518,7 @@
     "place": {
       "name": "Seward",
       "state": "AK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2717,
       "coord": [-149.4404281, 60.1013952],
@@ -65537,7 +65537,7 @@
     "place": {
       "name": "Seward",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7643,
       "coord": [-97.098923, 40.906953],
@@ -65556,7 +65556,7 @@
     "place": {
       "name": "Sewickley",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3907,
       "coord": [-80.1805269, 40.5403417],
@@ -65575,7 +65575,7 @@
     "place": {
       "name": "Seymour",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16748,
       "coord": [-73.0741697, 41.3943578],
@@ -65594,7 +65594,7 @@
     "place": {
       "name": "Seymour",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1841,
       "coord": [-92.7687819, 37.1464398],
@@ -65613,7 +65613,7 @@
     "place": {
       "name": "Shaker Heights",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29439,
       "coord": [-81.5370671, 41.4739419],
@@ -65640,7 +65640,7 @@
     "place": {
       "name": "Shakopee",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43698,
       "coord": [-93.5268986, 44.7980186],
@@ -65659,7 +65659,7 @@
     "place": {
       "name": "Sharon",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2680,
       "coord": [-73.4767897, 41.8792599],
@@ -65678,7 +65678,7 @@
     "place": {
       "name": "Sharon",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13147,
       "coord": [-80.4934035, 41.2331116],
@@ -65713,7 +65713,7 @@
     "place": {
       "name": "Sharon",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1586,
       "coord": [-88.7289927, 42.5025165],
@@ -65732,7 +65732,7 @@
     "place": {
       "name": "Sharonville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14117,
       "coord": [-84.4132779, 39.2681145],
@@ -65756,7 +65756,7 @@
     "place": {
       "name": "Shawano County",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 40881,
       "coord": [-88.7118868, 44.7817214],
@@ -65775,7 +65775,7 @@
     "place": {
       "name": "Shawano",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9243,
       "coord": [-88.6089917, 44.7822064],
@@ -65794,7 +65794,7 @@
     "place": {
       "name": "Shawnee",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31377,
       "coord": [-96.9253004, 35.3272928],
@@ -65821,7 +65821,7 @@
     "place": {
       "name": "Sheboygan",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 49929,
       "coord": [-87.71453, 43.7508284],
@@ -65840,7 +65840,7 @@
     "place": {
       "name": "Sheffield Lake",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8957,
       "coord": [-82.101537, 41.48754],
@@ -65859,7 +65859,7 @@
     "place": {
       "name": "Sheffield",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9403,
       "coord": [-87.6986407, 34.7650888],
@@ -65878,7 +65878,7 @@
     "place": {
       "name": "Shelby County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 20990,
       "coord": [-88.7886278, 39.3665064],
@@ -65897,7 +65897,7 @@
     "place": {
       "name": "Shelby",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 727,
       "coord": [-95.4503416, 41.5159725],
@@ -65916,7 +65916,7 @@
     "place": {
       "name": "Shelby",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1964,
       "coord": [-86.363963, 43.608619],
@@ -65935,7 +65935,7 @@
     "place": {
       "name": "Shelby",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3169,
       "coord": [-111.856872, 48.5054997],
@@ -65954,7 +65954,7 @@
     "place": {
       "name": "Shelby",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9282,
       "coord": [-82.661744, 40.88136],
@@ -65973,7 +65973,7 @@
     "place": {
       "name": "Shelbyville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4674,
       "coord": [-88.7900689, 39.4064284],
@@ -65992,7 +65992,7 @@
     "place": {
       "name": "Shelbyville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20067,
       "coord": [-85.7769238, 39.5214373],
@@ -66011,7 +66011,7 @@
     "place": {
       "name": "Sheldon",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5512,
       "coord": [-95.8525185, 43.1801338],
@@ -66030,7 +66030,7 @@
     "place": {
       "name": "Shell Rock",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1268,
       "coord": [-92.5822798, 42.7109868],
@@ -66049,7 +66049,7 @@
     "place": {
       "name": "Shelton",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40869,
       "coord": [-73.0931641, 41.3164856],
@@ -66068,7 +66068,7 @@
     "place": {
       "name": "Shenandoah",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4925,
       "coord": [-95.3723535, 40.7655468],
@@ -66087,7 +66087,7 @@
     "place": {
       "name": "Sherbrooke",
       "state": "QC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 172950,
       "coord": [-71.889038, 45.403271],
@@ -66112,7 +66112,7 @@
     "place": {
       "name": "Sheridan",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18821,
       "coord": [-106.955888, 44.797256],
@@ -66131,7 +66131,7 @@
     "place": {
       "name": "Sherman",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4673,
       "coord": [-89.6048231, 39.8936608],
@@ -66150,7 +66150,7 @@
     "place": {
       "name": "Sherman",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 100,
       "coord": [-96.4761531, 43.7591386],
@@ -66169,7 +66169,7 @@
     "place": {
       "name": "Sherman",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43645,
       "coord": [-96.60931672750198, 33.63651475768539],
@@ -66188,7 +66188,7 @@
     "place": {
       "name": "Sherwood",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3277,
       "coord": [-88.2597625, 44.1736983],
@@ -66207,7 +66207,7 @@
     "place": {
       "name": "Shiocton",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 939,
       "coord": [-88.5789902, 44.4447055],
@@ -66226,7 +66226,7 @@
     "place": {
       "name": "Shippensburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5478,
       "coord": [-77.5205485, 40.0507198],
@@ -66245,7 +66245,7 @@
     "place": {
       "name": "Shively",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15636,
       "coord": [-85.8227413, 38.2000701],
@@ -66284,7 +66284,7 @@
     "place": {
       "name": "Shoreline",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 58608,
       "coord": [-122.3437497, 47.7564667],
@@ -66303,7 +66303,7 @@
     "place": {
       "name": "Shoreview",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26921,
       "coord": [-93.1282878, 45.0722056],
@@ -66330,7 +66330,7 @@
     "place": {
       "name": "Shorewood Hills",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2169,
       "coord": [-89.4463237, 43.0780946],
@@ -66349,7 +66349,7 @@
     "place": {
       "name": "Shorewood",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18186,
       "coord": [-88.2017293, 41.5200305],
@@ -66368,7 +66368,7 @@
     "place": {
       "name": "Shorewood",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13290,
       "coord": [-87.8881302, 43.0883957],
@@ -66387,7 +66387,7 @@
     "place": {
       "name": "Show Low",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11732,
       "coord": [-110.029832, 34.2542084],
@@ -66406,7 +66406,7 @@
     "place": {
       "name": "Shreveport",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 187593,
       "coord": [-93.7477839, 32.5135356],
@@ -66441,7 +66441,7 @@
     "place": {
       "name": "Shrewsbury",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3848,
       "coord": [-76.6796518, 39.7687574],
@@ -66460,7 +66460,7 @@
     "place": {
       "name": "Sidney",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1070,
       "coord": [-95.6468803, 40.7473867],
@@ -66479,7 +66479,7 @@
     "place": {
       "name": "Sidney",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6346,
       "coord": [-104.155973, 47.716735],
@@ -66498,7 +66498,7 @@
     "place": {
       "name": "Sidney",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6410,
       "coord": [-102.9767382, 41.1448682],
@@ -66517,7 +66517,7 @@
     "place": {
       "name": "Sidney",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20421,
       "coord": [-84.1555267, 40.284241],
@@ -66536,7 +66536,7 @@
     "place": {
       "name": "Sierra Vista",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 45308,
       "coord": [-110.2997756, 31.5545973],
@@ -66555,7 +66555,7 @@
     "place": {
       "name": "Siloam Springs",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17287,
       "coord": [-94.5404962, 36.1881365],
@@ -66574,7 +66574,7 @@
     "place": {
       "name": "Silver City",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9704,
       "coord": [-108.2754371, 32.7751371],
@@ -66601,7 +66601,7 @@
     "place": {
       "name": "Silver Lake",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 866,
       "coord": [-94.1955334, 44.9032959],
@@ -66620,7 +66620,7 @@
     "place": {
       "name": "Silverthorne",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4402,
       "coord": [-106.0619636, 39.6374864],
@@ -66643,7 +66643,7 @@
     "place": {
       "name": "Simi Valley",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 126356,
       "coord": [-118.7538071, 34.2677404],
@@ -66662,7 +66662,7 @@
     "place": {
       "name": "Simsbury",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24517,
       "coord": [-72.8012211, 41.8759152],
@@ -66697,7 +66697,7 @@
     "place": {
       "name": "Singapore",
       "state": null,
-      "country": "SG",
+      "country": "Singapore",
       "type": "country",
       "pop": 6040000,
       "coord": [103.8519072, 1.2899175],
@@ -66738,7 +66738,7 @@
     "place": {
       "name": "Sinking Spring",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4286,
       "coord": [-76.0171505, 40.3246704],
@@ -66757,7 +66757,7 @@
     "place": {
       "name": "Sioux Center",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8229,
       "coord": [-96.1756497, 43.0796879],
@@ -66776,7 +66776,7 @@
     "place": {
       "name": "Sioux City",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 85797,
       "coord": [-96.4058782, 42.4966815],
@@ -66795,7 +66795,7 @@
     "place": {
       "name": "Sioux Falls",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 192517,
       "coord": [-96.7307737, 43.5488256],
@@ -66814,7 +66814,7 @@
     "place": {
       "name": "Sioux Lookout",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 5839,
       "coord": [-91.9190268, 50.1000964],
@@ -66833,7 +66833,7 @@
     "place": {
       "name": "Siren",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 823,
       "coord": [-92.3810284, 45.7857818],
@@ -66852,7 +66852,7 @@
     "place": {
       "name": "Sister Bay",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1150,
       "coord": [-87.120945, 45.187211],
@@ -66871,7 +66871,7 @@
     "place": {
       "name": "Skokie",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 67824,
       "coord": [-87.7333972, 42.0333694],
@@ -66903,7 +66903,7 @@
     "place": {
       "name": "Slayton",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2013,
       "coord": [-95.755846, 43.987742],
@@ -66922,7 +66922,7 @@
     "place": {
       "name": "Slidell",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28781,
       "coord": [-89.7811745, 30.2751945],
@@ -66941,7 +66941,7 @@
     "place": {
       "name": "Sligo",
       "state": "County Sligo",
-      "country": "IE",
+      "country": "Ireland",
       "type": "city",
       "pop": 20608,
       "coord": [-8.4751357, 54.2720696],
@@ -66960,7 +66960,7 @@
     "place": {
       "name": "Slippery Rock",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3081,
       "coord": [-80.0564468, 41.0639506],
@@ -66979,7 +66979,7 @@
     "place": {
       "name": "Sloan",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1042,
       "coord": [-96.2279425, 42.2330049],
@@ -66998,7 +66998,7 @@
     "place": {
       "name": "Slocomb",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2082,
       "coord": [-85.5936401, 31.1070277],
@@ -67017,7 +67017,7 @@
     "place": {
       "name": "Smith Center",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1571,
       "coord": [-98.785075, 39.779179],
@@ -67036,7 +67036,7 @@
     "place": {
       "name": "Smithfield",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22118,
       "coord": [-71.549507, 41.9220433],
@@ -67055,7 +67055,7 @@
     "place": {
       "name": "Smithfield",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13571,
       "coord": [-111.832804, 41.838429],
@@ -67074,7 +67074,7 @@
     "place": {
       "name": "Smithsburg",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2977,
       "coord": [-77.5727681, 39.6548186],
@@ -67093,7 +67093,7 @@
     "place": {
       "name": "Smithton",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4006,
       "coord": [-89.9920501, 38.4086616],
@@ -67112,7 +67112,7 @@
     "place": {
       "name": "Smithville",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10406,
       "coord": [-94.5815937, 39.3868396],
@@ -67131,7 +67131,7 @@
     "place": {
       "name": "Smooth Rock Falls",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1200,
       "coord": [-81.6311885, 49.2768],
@@ -67150,7 +67150,7 @@
     "place": {
       "name": "Smyrna",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12883,
       "coord": [-75.6046494, 39.2998339],
@@ -67169,7 +67169,7 @@
     "place": {
       "name": "Snellville",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20573,
       "coord": [-84.0199108, 33.857328],
@@ -67188,7 +67188,7 @@
     "place": {
       "name": "Snow Hill",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2156,
       "coord": [-75.3926959, 38.1770634],
@@ -67207,7 +67207,7 @@
     "place": {
       "name": "Snowmass Village",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3096,
       "coord": [-106.9378207, 39.2130418],
@@ -67234,7 +67234,7 @@
     "place": {
       "name": "Somerset",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6046,
       "coord": [-79.078583, 40.008416],
@@ -67261,7 +67261,7 @@
     "place": {
       "name": "Somerset",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3019,
       "coord": [-92.6735365, 45.1244108],
@@ -67280,7 +67280,7 @@
     "place": {
       "name": "Somersworth",
       "state": "NH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11855,
       "coord": [-70.8645872, 43.2625585],
@@ -67299,7 +67299,7 @@
     "place": {
       "name": "Somerton",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14197,
       "coord": [-114.709677, 32.5964404],
@@ -67326,7 +67326,7 @@
     "place": {
       "name": "Somerville",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 80906,
       "coord": [-71.0994968, 42.3875968],
@@ -67359,7 +67359,7 @@
     "place": {
       "name": "Somonauk",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1786,
       "coord": [-88.6811883, 41.6336413],
@@ -67378,7 +67378,7 @@
     "place": {
       "name": "Souderton",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7191,
       "coord": [-75.3251759, 40.3117707],
@@ -67405,7 +67405,7 @@
     "place": {
       "name": "South Australia",
       "state": "SA",
-      "country": "AU",
+      "country": "Australia",
       "type": "state",
       "pop": 1806599,
       "coord": [138.60396883837132, -34.920630700000004],
@@ -67440,7 +67440,7 @@
     "place": {
       "name": "South Bend",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 102026,
       "coord": [-86.2500066, 41.6833813],
@@ -67459,7 +67459,7 @@
     "place": {
       "name": "South Bruce Peninsula",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 9137,
       "coord": [-81.268759, 44.6310905],
@@ -67478,7 +67478,7 @@
     "place": {
       "name": "South Bruce",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 5880,
       "coord": [-81.19888638182067, 44.0319668],
@@ -67497,7 +67497,7 @@
     "place": {
       "name": "South Burlington",
       "state": "VT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19509,
       "coord": [-73.1709604, 44.4669941],
@@ -67516,7 +67516,7 @@
     "place": {
       "name": "South Charleston",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13639,
       "coord": [-81.69957, 38.368429],
@@ -67535,7 +67535,7 @@
     "place": {
       "name": "South Chicago Heights",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4026,
       "coord": [-87.6378211, 41.4808681],
@@ -67554,7 +67554,7 @@
     "place": {
       "name": "South Coatesville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1604,
       "coord": [-75.8199462, 39.9742729],
@@ -67573,7 +67573,7 @@
     "place": {
       "name": "South Elgin",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23865,
       "coord": [-88.2922996, 41.9941938],
@@ -67615,7 +67615,7 @@
     "place": {
       "name": "South Euclid",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21883,
       "coord": [-81.5184553, 41.5231076],
@@ -67634,7 +67634,7 @@
     "place": {
       "name": "South Haven",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3964,
       "coord": [-86.2736407, 42.4030865],
@@ -67653,7 +67653,7 @@
     "place": {
       "name": "South Huron",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 10063,
       "coord": [-81.52918451168405, 43.33238105],
@@ -67672,7 +67672,7 @@
     "place": {
       "name": "South Kingstown",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31931,
       "coord": [-71.5394738, 41.454944],
@@ -67691,7 +67691,7 @@
     "place": {
       "name": "South Lyon",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11746,
       "coord": [-83.659179, 42.451377],
@@ -67710,7 +67710,7 @@
     "place": {
       "name": "South Milwaukee",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20795,
       "coord": [-87.8606367, 42.9105722],
@@ -67729,7 +67729,7 @@
     "place": {
       "name": "South Pekin",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 996,
       "coord": [-89.6517711, 40.4944838],
@@ -67748,7 +67748,7 @@
     "place": {
       "name": "South Perth",
       "state": "WA",
-      "country": "AU",
+      "country": "Australia",
       "type": "city",
       "pop": 43405,
       "coord": [115.8639433, -31.9809661],
@@ -67767,7 +67767,7 @@
     "place": {
       "name": "South River",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1101,
       "coord": [-79.380341, 45.841238],
@@ -67786,7 +67786,7 @@
     "place": {
       "name": "South Rockwood",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1587,
       "coord": [-83.2610406, 42.0639323],
@@ -67813,7 +67813,7 @@
     "place": {
       "name": "South St. Paul",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20194,
       "coord": [-93.0368359, 44.8938832],
@@ -67832,7 +67832,7 @@
     "place": {
       "name": "South Whitley",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1818,
       "coord": [-85.6280381, 41.0847677],
@@ -67851,7 +67851,7 @@
     "place": {
       "name": "South Windsor",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26918,
       "coord": [-72.5717551, 41.8489872],
@@ -67870,7 +67870,7 @@
     "place": {
       "name": "Southern View",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1596,
       "coord": [-89.6536926, 39.7573207],
@@ -67889,7 +67889,7 @@
     "place": {
       "name": "Southfield",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 76618,
       "coord": [-83.2218731, 42.4733689],
@@ -67908,7 +67908,7 @@
     "place": {
       "name": "Southington",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43501,
       "coord": [-72.8782941, 41.6005435],
@@ -67927,7 +67927,7 @@
     "place": {
       "name": "Southside",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9426,
       "coord": [-86.0224718, 33.9245425],
@@ -67946,7 +67946,7 @@
     "place": {
       "name": "Southwest Greensburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2219,
       "coord": [-79.5469844, 40.2911805],
@@ -67965,7 +67965,7 @@
     "place": {
       "name": "Southwest Middlesex",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 5893,
       "coord": [-81.70352321815045, 42.74257325],
@@ -67984,7 +67984,7 @@
     "place": {
       "name": "Sparks",
       "state": "NV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 108445,
       "coord": [-119.7487235, 39.5404679],
@@ -68011,7 +68011,7 @@
     "place": {
       "name": "Sparta",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4095,
       "coord": [-89.7017658, 38.1231053],
@@ -68030,7 +68030,7 @@
     "place": {
       "name": "Sparta",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4244,
       "coord": [-85.710039, 43.160858],
@@ -68049,7 +68049,7 @@
     "place": {
       "name": "Sparta",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10175,
       "coord": [-90.8129118, 43.9441328],
@@ -68068,7 +68068,7 @@
     "place": {
       "name": "Spartanburg",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 38732,
       "coord": [-81.9320157, 34.9498007],
@@ -68087,7 +68087,7 @@
     "place": {
       "name": "Spearfish",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12193,
       "coord": [-103.85937, 44.490817],
@@ -68106,7 +68106,7 @@
     "place": {
       "name": "Spencer",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11325,
       "coord": [-95.1477536, 43.1415519],
@@ -68125,7 +68125,7 @@
     "place": {
       "name": "Spencer",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2062,
       "coord": [-81.3509777, 38.8021446],
@@ -68144,7 +68144,7 @@
     "place": {
       "name": "Spencerville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2198,
       "coord": [-84.353564, 40.708938],
@@ -68163,7 +68163,7 @@
     "place": {
       "name": "Spicer",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1112,
       "coord": [-94.9400088, 45.2330198],
@@ -68182,7 +68182,7 @@
     "place": {
       "name": "Spirit Lake",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5439,
       "coord": [-95.1024729, 43.4224868],
@@ -68201,7 +68201,7 @@
     "place": {
       "name": "Spokane",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 228989,
       "coord": [-117.42351, 47.6571934],
@@ -68220,7 +68220,7 @@
     "place": {
       "name": "Spring City",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3494,
       "coord": [-75.5476803, 40.176767],
@@ -68239,7 +68239,7 @@
     "place": {
       "name": "Spring Green",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1544,
       "coord": [-90.0680478, 43.1769367],
@@ -68258,7 +68258,7 @@
     "place": {
       "name": "Spring Lake",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2497,
       "coord": [-86.196997, 43.076963],
@@ -68277,7 +68277,7 @@
     "place": {
       "name": "Spring Park",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1734,
       "coord": [-93.632293, 44.9353256],
@@ -68296,7 +68296,7 @@
     "place": {
       "name": "Spring Valley",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1401,
       "coord": [-92.2387957, 44.8452432],
@@ -68315,7 +68315,7 @@
     "place": {
       "name": "Springboro",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19062,
       "coord": [-84.2332718, 39.5522815],
@@ -68342,7 +68342,7 @@
     "place": {
       "name": "Springdale",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 84161,
       "coord": [-94.1288142, 36.1867442],
@@ -68369,7 +68369,7 @@
     "place": {
       "name": "Springdale",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11007,
       "coord": [-84.4852213, 39.287002],
@@ -68388,7 +68388,7 @@
     "place": {
       "name": "Springfield",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 114394,
       "coord": [-89.6439575, 39.7990175],
@@ -68407,7 +68407,7 @@
     "place": {
       "name": "Springfield",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2846,
       "coord": [-85.2221819, 37.6853413],
@@ -68426,7 +68426,7 @@
     "place": {
       "name": "Springfield",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 155929,
       "coord": [-72.5886727, 42.1018764],
@@ -68445,7 +68445,7 @@
     "place": {
       "name": "Springfield",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2027,
       "coord": [-94.9758156, 44.2385706],
@@ -68464,7 +68464,7 @@
     "place": {
       "name": "Springfield",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 169176,
       "coord": [-93.2946576, 37.1968298],
@@ -68483,7 +68483,7 @@
     "place": {
       "name": "Springfield",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 58662,
       "coord": [-83.810138, 39.9234046],
@@ -68510,7 +68510,7 @@
     "place": {
       "name": "Springfield",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 61851,
       "coord": [-123.0220289, 44.0462362],
@@ -68537,7 +68537,7 @@
     "place": {
       "name": "Springport",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 776,
       "coord": [-84.6985883, 42.378372],
@@ -68556,7 +68556,7 @@
     "place": {
       "name": "Springville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4786,
       "coord": [-86.4716512, 33.7750997],
@@ -68575,7 +68575,7 @@
     "place": {
       "name": "St. Albans",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10861,
       "coord": [-81.836241, 38.3856488],
@@ -68594,7 +68594,7 @@
     "place": {
       "name": "St. Ansgar",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1160,
       "coord": [-92.9189658, 43.3785373],
@@ -68613,7 +68613,7 @@
     "place": {
       "name": "St. Bernard",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4070,
       "coord": [-84.4985573, 39.167001],
@@ -68632,7 +68632,7 @@
     "place": {
       "name": "St. Bonifacius",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2307,
       "coord": [-93.7474636, 44.9055181],
@@ -68651,7 +68651,7 @@
     "place": {
       "name": "St. Catharines",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 140370,
       "coord": [-79.2441003, 43.1579812],
@@ -68670,7 +68670,7 @@
     "place": {
       "name": "St. Charles",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 33081,
       "coord": [-88.3128183, 41.9139808],
@@ -68697,7 +68697,7 @@
     "place": {
       "name": "St. Charles",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1992,
       "coord": [-84.1405346, 43.2969699],
@@ -68724,7 +68724,7 @@
     "place": {
       "name": "St. Charles",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 70493,
       "coord": [-90.481677, 38.783855],
@@ -68743,7 +68743,7 @@
     "place": {
       "name": "St. Charles",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1357,
       "coord": [-80.417175, 46.363041],
@@ -68762,7 +68762,7 @@
     "place": {
       "name": "St. Clair Township",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 14659,
       "coord": [-82.46408292671435, 42.8427145],
@@ -68789,7 +68789,7 @@
     "place": {
       "name": "St. Clair",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5464,
       "coord": [-82.6283554, 42.9426715],
@@ -68808,7 +68808,7 @@
     "place": {
       "name": "St. Clair",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4791,
       "coord": [-90.9809735, 38.3453291],
@@ -68827,7 +68827,7 @@
     "place": {
       "name": "St. Cloud",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 68881,
       "coord": [-94.1642004, 45.5616075],
@@ -68854,7 +68854,7 @@
     "place": {
       "name": "St. Croix Falls",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2208,
       "coord": [-92.6445824, 45.4104918],
@@ -68873,7 +68873,7 @@
     "place": {
       "name": "St. Francisville",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1557,
       "coord": [-91.3763353, 30.7807244],
@@ -68892,7 +68892,7 @@
     "place": {
       "name": "St. Gabriel",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6433,
       "coord": [-91.074237400676, 30.25154],
@@ -68911,7 +68911,7 @@
     "place": {
       "name": "St. Ignace",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2306,
       "coord": [-84.7278281, 45.8686238],
@@ -68930,7 +68930,7 @@
     "place": {
       "name": "St. James",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4793,
       "coord": [-94.6269181, 43.9824577],
@@ -68949,7 +68949,7 @@
     "place": {
       "name": "St. John the Baptist Parish",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 42477,
       "coord": [-90.5276838, 30.1141748],
@@ -68968,7 +68968,7 @@
     "place": {
       "name": "St. John's",
       "state": "NL",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 113948,
       "coord": [-52.7126162, 47.5614705],
@@ -69003,7 +69003,7 @@
     "place": {
       "name": "St. John",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1228,
       "coord": [-98.7601021, 38.0021145],
@@ -69022,7 +69022,7 @@
     "place": {
       "name": "St. Johns",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7698,
       "coord": [-84.5585098, 43.000928],
@@ -69041,7 +69041,7 @@
     "place": {
       "name": "St. Joseph Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9993,
       "coord": [-86.4759514505403, 42.0760365],
@@ -69060,7 +69060,7 @@
     "place": {
       "name": "St. Joseph County",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 272912,
       "coord": [-86.2787334, 41.5941578],
@@ -69079,7 +69079,7 @@
     "place": {
       "name": "St. Joseph",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7856,
       "coord": [-86.482469, 42.108739],
@@ -69106,7 +69106,7 @@
     "place": {
       "name": "St. Joseph",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 72473,
       "coord": [-94.8466322, 39.7686055],
@@ -69125,7 +69125,7 @@
     "place": {
       "name": "St. Louis Park",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 50010,
       "coord": [-93.3569023, 44.9475726],
@@ -69152,7 +69152,7 @@
     "place": {
       "name": "St. Louis",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7010,
       "coord": [-84.608759, 43.409224],
@@ -69171,7 +69171,7 @@
     "place": {
       "name": "St. Louis",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 308174,
       "coord": [-90.1995853, 38.6264256],
@@ -69198,7 +69198,7 @@
     "place": {
       "name": "St. Maries",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2357,
       "coord": [-116.562667, 47.3143542],
@@ -69217,7 +69217,7 @@
     "place": {
       "name": "St. Matthews",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17534,
       "coord": [-85.6357423591954, 38.24988],
@@ -69256,7 +69256,7 @@
     "place": {
       "name": "St. Michael",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18235,
       "coord": [-93.6648083, 45.210202],
@@ -69275,7 +69275,7 @@
     "place": {
       "name": "St. Michaels",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1049,
       "coord": [-76.2244098, 38.7865839],
@@ -69294,7 +69294,7 @@
     "place": {
       "name": "St. Paul Park",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5544,
       "coord": [-92.9980516, 44.847917],
@@ -69313,7 +69313,7 @@
     "place": {
       "name": "St. Paul",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 304547,
       "coord": [-93.0931028, 44.9497487],
@@ -69340,7 +69340,7 @@
     "place": {
       "name": "St. Paul",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2416,
       "coord": [-98.4580649, 41.2134073],
@@ -69359,7 +69359,7 @@
     "place": {
       "name": "St. Pete Beach",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8879,
       "coord": [-82.741212, 27.7253065],
@@ -69378,7 +69378,7 @@
     "place": {
       "name": "St. Peter",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12066,
       "coord": [-93.9585295, 44.3238384],
@@ -69397,7 +69397,7 @@
     "place": {
       "name": "St. Petersburg",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 258201,
       "coord": [-82.6695085, 27.7703796],
@@ -69428,7 +69428,7 @@
     "place": {
       "name": "St. Regis Park",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1438,
       "coord": [-85.6147591834033, 38.2302255],
@@ -69467,7 +69467,7 @@
     "place": {
       "name": "St. Tammany Parish",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 264570,
       "coord": [-89.9730381, 30.4243909],
@@ -69486,7 +69486,7 @@
     "place": {
       "name": "Stafford",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11472,
       "coord": [-72.2895812, 41.9851964],
@@ -69505,7 +69505,7 @@
     "place": {
       "name": "Stallings",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16112,
       "coord": [-80.6635590216038, 35.1083615],
@@ -69545,7 +69545,7 @@
     "place": {
       "name": "Stamford",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 135470,
       "coord": [-73.5387341, 41.0534302],
@@ -69564,7 +69564,7 @@
     "place": {
       "name": "Stanfield",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1585,
       "coord": [-80.4270094, 35.2334772],
@@ -69583,7 +69583,7 @@
     "place": {
       "name": "Stanford",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 600,
       "coord": [-89.2178643, 40.4347608],
@@ -69602,7 +69602,7 @@
     "place": {
       "name": "Stanley",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3963,
       "coord": [-81.0970214, 35.3590256],
@@ -69621,7 +69621,7 @@
     "place": {
       "name": "Stanton",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1348,
       "coord": [-85.081407, 43.292532],
@@ -69648,7 +69648,7 @@
     "place": {
       "name": "Stanwood",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 637,
       "coord": [-91.1502842, 41.8927197],
@@ -69667,7 +69667,7 @@
     "place": {
       "name": "Star Prairie",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 676,
       "coord": [-92.5307537, 45.1969094],
@@ -69686,7 +69686,7 @@
     "place": {
       "name": "Star Valley Ranch",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1866,
       "coord": [-110.957740918276, 42.975225],
@@ -69705,7 +69705,7 @@
     "place": {
       "name": "Star",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11117,
       "coord": [-116.493463, 43.6921071],
@@ -69724,7 +69724,7 @@
     "place": {
       "name": "Starbuck",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1365,
       "coord": [-95.5311096, 45.6144512],
@@ -69743,7 +69743,7 @@
     "place": {
       "name": "Starkville",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24360,
       "coord": [-88.8183872, 33.4503998],
@@ -69762,7 +69762,7 @@
     "place": {
       "name": "State Center",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1391,
       "coord": [-93.1636877, 42.0167075],
@@ -69781,7 +69781,7 @@
     "place": {
       "name": "State College",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 40501,
       "coord": [-77.8616386, 40.7944504],
@@ -69808,7 +69808,7 @@
     "place": {
       "name": "Statesville",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28419,
       "coord": [-80.8872959, 35.7826363],
@@ -69827,7 +69827,7 @@
     "place": {
       "name": "Ste. Genevieve",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4999,
       "coord": [-90.1856637, 37.88958],
@@ -69846,7 +69846,7 @@
     "place": {
       "name": "Steamboat Springs",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13224,
       "coord": [-106.831735, 40.4848003],
@@ -69865,7 +69865,7 @@
     "place": {
       "name": "Steger",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9584,
       "coord": [-87.636432, 41.4700348],
@@ -69884,7 +69884,7 @@
     "place": {
       "name": "Stephenson County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 44630,
       "coord": [-89.6735637, 42.3503474],
@@ -69903,7 +69903,7 @@
     "place": {
       "name": "Sterling",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3578,
       "coord": [-71.828682, 41.707599],
@@ -69922,7 +69922,7 @@
     "place": {
       "name": "Sterling",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14750,
       "coord": [-89.6953656, 41.788253],
@@ -69957,7 +69957,7 @@
     "place": {
       "name": "Sterling",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2248,
       "coord": [-98.2070059, 38.2100112],
@@ -69976,7 +69976,7 @@
     "place": {
       "name": "Sterling",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 482,
       "coord": [-96.377514, 40.459166],
@@ -69995,7 +69995,7 @@
     "place": {
       "name": "Steubenville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18161,
       "coord": [-80.6151034, 40.3600714],
@@ -70014,7 +70014,7 @@
     "place": {
       "name": "Stevens Point",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25880,
       "coord": [-89.574111, 44.5229223],
@@ -70055,7 +70055,7 @@
     "place": {
       "name": "Stevensville",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1147,
       "coord": [-86.5194654, 42.0144871],
@@ -70074,7 +70074,7 @@
     "place": {
       "name": "Stevensville",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2002,
       "coord": [-114.094385, 46.510407],
@@ -70093,7 +70093,7 @@
     "place": {
       "name": "Stewartville",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6687,
       "coord": [-92.4883221, 43.8554243],
@@ -70112,7 +70112,7 @@
     "place": {
       "name": "Stillwater",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 48394,
       "coord": [-97.0585717, 36.1156306],
@@ -70131,7 +70131,7 @@
     "place": {
       "name": "Stirling",
       "state": "WA",
-      "country": "AU",
+      "country": "Australia",
       "type": "city",
       "pop": 226369,
       "coord": [115.823225830973, -31.8902485],
@@ -70158,7 +70158,7 @@
     "place": {
       "name": "Stockbridge",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1244,
       "coord": [-84.1805146, 42.4511466],
@@ -70177,7 +70177,7 @@
     "place": {
       "name": "Stockton",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 320804,
       "coord": [-121.2907796, 37.9577016],
@@ -70208,7 +70208,7 @@
     "place": {
       "name": "Stonington",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 884,
       "coord": [-71.9059042, 41.3359327],
@@ -70227,7 +70227,7 @@
     "place": {
       "name": "Storm Lake",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11269,
       "coord": [-95.1992726, 42.6452817],
@@ -70246,7 +70246,7 @@
     "place": {
       "name": "Story City",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3352,
       "coord": [-93.5957713, 42.1872062],
@@ -70265,7 +70265,7 @@
     "place": {
       "name": "Story County",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 98537,
       "coord": [-93.489194, 42.0161612],
@@ -70298,7 +70298,7 @@
     "place": {
       "name": "Stoughton",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13173,
       "coord": [-89.2178997, 42.9167389],
@@ -70317,7 +70317,7 @@
     "place": {
       "name": "Strafford",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2561,
       "coord": [-93.1171264, 37.2683803],
@@ -70336,7 +70336,7 @@
     "place": {
       "name": "Strasburg",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2735,
       "coord": [-81.5267864, 40.5947844],
@@ -70355,7 +70355,7 @@
     "place": {
       "name": "Stratford",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 52355,
       "coord": [-73.1331651, 41.1845415],
@@ -70382,7 +70382,7 @@
     "place": {
       "name": "Stratford",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1580,
       "coord": [-90.0792975, 44.8010763],
@@ -70401,7 +70401,7 @@
     "place": {
       "name": "Strathroy-Caradoc",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 23871,
       "coord": [-81.55485268973419, 42.9064729],
@@ -70420,7 +70420,7 @@
     "place": {
       "name": "Stratton",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 656,
       "coord": [-102.604996, 39.305198],
@@ -70439,7 +70439,7 @@
     "place": {
       "name": "Streator",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12500,
       "coord": [-88.8357361, 41.1210234],
@@ -70458,7 +70458,7 @@
     "place": {
       "name": "Stronghurst",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 833,
       "coord": [-90.9080173, 40.7452012],
@@ -70477,7 +70477,7 @@
     "place": {
       "name": "Stroudsburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5927,
       "coord": [-75.1946649, 40.9864261],
@@ -70496,7 +70496,7 @@
     "place": {
       "name": "Stuart",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16160,
       "coord": [-80.2519175, 27.197983],
@@ -70515,7 +70515,7 @@
     "place": {
       "name": "Stuart",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1782,
       "coord": [-94.3185737, 41.5033213],
@@ -70534,7 +70534,7 @@
     "place": {
       "name": "Sturgeon Bay",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9646,
       "coord": [-87.377042, 44.8341639],
@@ -70553,7 +70553,7 @@
     "place": {
       "name": "Sturgis",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11082,
       "coord": [-85.4191482, 41.799217],
@@ -70572,7 +70572,7 @@
     "place": {
       "name": "Sturgis",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7020,
       "coord": [-103.509079, 44.409707],
@@ -70591,7 +70591,7 @@
     "place": {
       "name": "Stuttgart",
       "state": "BW",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 632865,
       "coord": [9.1800132, 48.7784485],
@@ -70618,7 +70618,7 @@
     "place": {
       "name": "Subiaco",
       "state": "WA",
-      "country": "AU",
+      "country": "Australia",
       "type": "city",
       "pop": 17267,
       "coord": [115.8240314, -31.9463298],
@@ -70656,7 +70656,7 @@
     "place": {
       "name": "Sublette",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1413,
       "coord": [-100.843773, 37.4816911],
@@ -70675,7 +70675,7 @@
     "place": {
       "name": "Sudbury",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 164926,
       "coord": [-80.991211, 46.49272],
@@ -70700,7 +70700,7 @@
     "place": {
       "name": "Suffield",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15752,
       "coord": [-72.6506604, 41.9816944],
@@ -70719,7 +70719,7 @@
     "place": {
       "name": "Sugar Creek",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3271,
       "coord": [-94.40303431, 39.1399165],
@@ -70738,7 +70738,7 @@
     "place": {
       "name": "Sugar Grove",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9278,
       "coord": [-88.4439261, 41.7616204],
@@ -70757,7 +70757,7 @@
     "place": {
       "name": "Sugar Hill",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25076,
       "coord": [-84.0335197, 34.1064895],
@@ -70776,7 +70776,7 @@
     "place": {
       "name": "Sullivan",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4387,
       "coord": [-88.6078392, 39.599479],
@@ -70795,7 +70795,7 @@
     "place": {
       "name": "Sullivan",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 651,
       "coord": [-88.5881562, 43.0127852],
@@ -70814,7 +70814,7 @@
     "place": {
       "name": "Summerdale",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1468,
       "coord": [-87.6997094, 30.4876954],
@@ -70833,7 +70833,7 @@
     "place": {
       "name": "Summerset",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2972,
       "coord": [-103.3341079, 44.1787783],
@@ -70852,7 +70852,7 @@
     "place": {
       "name": "Summit",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11161,
       "coord": [-87.810334, 41.7880876],
@@ -70871,7 +70871,7 @@
     "place": {
       "name": "Sun Prairie",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35967,
       "coord": [-89.2134359, 43.1834579],
@@ -70890,7 +70890,7 @@
     "place": {
       "name": "Sunbury",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9719,
       "coord": [-76.7936252, 40.8619754],
@@ -70909,7 +70909,7 @@
     "place": {
       "name": "Sundance",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1032,
       "coord": [-104.375895, 44.4064017],
@@ -70928,7 +70928,7 @@
     "place": {
       "name": "Sundridge",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 938,
       "coord": [-79.39576851875972, 45.771078900000006],
@@ -70947,7 +70947,7 @@
     "place": {
       "name": "Sunnyvale",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 155805,
       "coord": [-122.036349, 37.3688301],
@@ -70987,7 +70987,7 @@
     "place": {
       "name": "Sunset",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5475,
       "coord": [-112.031066, 41.1363376],
@@ -71006,7 +71006,7 @@
     "place": {
       "name": "Superior Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14832,
       "coord": [-83.6041183, 42.3049933],
@@ -71025,7 +71025,7 @@
     "place": {
       "name": "Superior",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2407,
       "coord": [-111.09623, 33.293945],
@@ -71044,7 +71044,7 @@
     "place": {
       "name": "Superior",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26561,
       "coord": [-92.1040796, 46.7207737],
@@ -71063,7 +71063,7 @@
     "place": {
       "name": "Surfside Beach",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4155,
       "coord": [-78.9730887, 33.6060031],
@@ -71082,7 +71082,7 @@
     "place": {
       "name": "Suring",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 517,
       "coord": [-88.3720464, 44.9991553],
@@ -71101,7 +71101,7 @@
     "place": {
       "name": "Surprise",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 143148,
       "coord": [-112.3681428, 33.629247],
@@ -71120,7 +71120,7 @@
     "place": {
       "name": "Surrey",
       "state": "BC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 568322,
       "coord": [-122.8491439, 49.1913033],
@@ -71147,7 +71147,7 @@
     "place": {
       "name": "Susquehanna",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1365,
       "coord": [-75.6041902, 41.9439867],
@@ -71166,7 +71166,7 @@
     "place": {
       "name": "Sussex",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11487,
       "coord": [-88.2220372, 43.1339001],
@@ -71185,7 +71185,7 @@
     "place": {
       "name": "Suwanee",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20786,
       "coord": [-84.0712997, 34.0514898],
@@ -71204,7 +71204,7 @@
     "place": {
       "name": "Swanville",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 326,
       "coord": [-94.638375624536, 45.91479915],
@@ -71223,7 +71223,7 @@
     "place": {
       "name": "Swarthmore",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6543,
       "coord": [-75.3509085, 39.9023002],
@@ -71242,7 +71242,7 @@
     "place": {
       "name": "Swartz Creek",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5897,
       "coord": [-83.8305144, 42.9572508],
@@ -71261,7 +71261,7 @@
     "place": {
       "name": "Swissvale",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8624,
       "coord": [-79.8828275, 40.4236801],
@@ -71288,7 +71288,7 @@
     "place": {
       "name": "Switzerland County",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 9737,
       "coord": [-85.0373975, 38.8249258],
@@ -71307,7 +71307,7 @@
     "place": {
       "name": "Sycamore",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18577,
       "coord": [-88.6867538, 41.9889173],
@@ -71326,7 +71326,7 @@
     "place": {
       "name": "Sykesville",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4316,
       "coord": [-76.9688737, 39.365992],
@@ -71345,7 +71345,7 @@
     "place": {
       "name": "Sylacauga",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12578,
       "coord": [-86.2514099, 33.170482],
@@ -71364,7 +71364,7 @@
     "place": {
       "name": "Sylvania",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19011,
       "coord": [-83.7129935, 41.7189392],
@@ -71383,7 +71383,7 @@
     "place": {
       "name": "Syracuse",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1941,
       "coord": [-96.186398, 40.657224],
@@ -71402,7 +71402,7 @@
     "place": {
       "name": "Syracuse",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 149655,
       "coord": [-76.1474244, 43.0481221],
@@ -71421,7 +71421,7 @@
     "place": {
       "name": "São Paulo",
       "state": "SP",
-      "country": "BR",
+      "country": "Brazil",
       "type": "city",
       "pop": 12400232,
       "coord": [-46.6333824, -23.5506507],
@@ -71440,7 +71440,7 @@
     "place": {
       "name": "Tacoma",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 217827,
       "coord": [-122.4398746, 47.2495798],
@@ -71459,7 +71459,7 @@
     "place": {
       "name": "Tahlequah",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16209,
       "coord": [-94.969956, 35.91537],
@@ -71478,7 +71478,7 @@
     "place": {
       "name": "Talladega",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15861,
       "coord": [-86.10234329907128, 33.43552756767986],
@@ -71497,7 +71497,7 @@
     "place": {
       "name": "Tallahassee",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 196169,
       "coord": [-84.2809332, 30.4380832],
@@ -71516,7 +71516,7 @@
     "place": {
       "name": "Tallassee",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4763,
       "coord": [-85.8922974, 32.5348568],
@@ -71543,7 +71543,7 @@
     "place": {
       "name": "Tallmadge",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18394,
       "coord": [-81.4417989, 41.1014616],
@@ -71570,7 +71570,7 @@
     "place": {
       "name": "Tampa",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 384959,
       "coord": [-82.458444, 27.9477595],
@@ -71597,7 +71597,7 @@
     "place": {
       "name": "Tampico",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 689,
       "coord": [-89.7850393, 41.6324811],
@@ -71616,7 +71616,7 @@
     "place": {
       "name": "Taneytown",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7234,
       "coord": [-77.1756197, 39.6593585],
@@ -71635,7 +71635,7 @@
     "place": {
       "name": "Taos Ski Valley",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 100,
       "coord": [-105.4545, 36.596],
@@ -71662,7 +71662,7 @@
     "place": {
       "name": "Taos",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6474,
       "coord": [-105.573284, 36.4072377],
@@ -71681,7 +71681,7 @@
     "place": {
       "name": "Tarentum",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4352,
       "coord": [-79.7545147, 40.6021328],
@@ -71700,7 +71700,7 @@
     "place": {
       "name": "Tarrant",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6124,
       "coord": [-86.7727681, 33.5834373],
@@ -71733,7 +71733,7 @@
     "place": {
       "name": "Tasmania",
       "state": "TAS",
-      "country": "AU",
+      "country": "Australia",
       "type": "state",
       "pop": 573479,
       "coord": [146.459774, -41.989346],
@@ -71752,7 +71752,7 @@
     "place": {
       "name": "Tatamy",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1203,
       "coord": [-75.2560449, 40.7417816],
@@ -71771,7 +71771,7 @@
     "place": {
       "name": "Tawas City",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1834,
       "coord": [-83.514697, 44.269461],
@@ -71790,7 +71790,7 @@
     "place": {
       "name": "Taylor Mill",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6873,
       "coord": [-84.4963306, 38.9975616],
@@ -71809,7 +71809,7 @@
     "place": {
       "name": "Taylor",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2262,
       "coord": [-85.468267, 31.164899],
@@ -71828,7 +71828,7 @@
     "place": {
       "name": "Taylor",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3995,
       "coord": [-110.091655, 34.4647338],
@@ -71847,7 +71847,7 @@
     "place": {
       "name": "Taylor",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 63409,
       "coord": [-83.2696509, 42.240872],
@@ -71874,7 +71874,7 @@
     "place": {
       "name": "Taylor",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6302,
       "coord": [-75.709405, 41.3840712],
@@ -71893,7 +71893,7 @@
     "place": {
       "name": "Taylor",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16267,
       "coord": [-97.409484, 30.568674],
@@ -71912,7 +71912,7 @@
     "place": {
       "name": "Taylor",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 484,
       "coord": [-91.1198757, 44.3210709],
@@ -71931,7 +71931,7 @@
     "place": {
       "name": "Taylorville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10506,
       "coord": [-89.294533, 39.548935],
@@ -71950,7 +71950,7 @@
     "place": {
       "name": "Tazewell County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 131343,
       "coord": [-89.5442084, 40.5126429],
@@ -71969,7 +71969,7 @@
     "place": {
       "name": "Tecumseh",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8680,
       "coord": [-83.9449417, 42.0039331],
@@ -72002,7 +72002,7 @@
     "place": {
       "name": "Tecumseh",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1694,
       "coord": [-96.1943163, 40.3681037],
@@ -72021,7 +72021,7 @@
     "place": {
       "name": "Tekamah",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1714,
       "coord": [-96.2211284, 41.7783218],
@@ -72040,7 +72040,7 @@
     "place": {
       "name": "Tekonsha",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 653,
       "coord": [-84.9858051, 42.0933791],
@@ -72059,7 +72059,7 @@
     "place": {
       "name": "Tel Aviv",
       "state": "TA",
-      "country": "IL",
+      "country": "Israel",
       "type": "city",
       "pop": 474530,
       "coord": [34.7818064, 32.0852997],
@@ -72094,7 +72094,7 @@
     "place": {
       "name": "Temagami",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 862,
       "coord": [-79.789581, 47.062638],
@@ -72113,7 +72113,7 @@
     "place": {
       "name": "Temecula",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 114761,
       "coord": [-117.1473661, 33.4946353],
@@ -72132,7 +72132,7 @@
     "place": {
       "name": "Temiskaming Shores",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 9634,
       "coord": [-79.675598, 47.512563],
@@ -72151,7 +72151,7 @@
     "place": {
       "name": "Tempe",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 180587,
       "coord": [-111.940016, 33.4255117],
@@ -72186,7 +72186,7 @@
     "place": {
       "name": "Temple",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 82073,
       "coord": [-97.3427847, 31.098207],
@@ -72213,7 +72213,7 @@
     "place": {
       "name": "Templeton",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 352,
       "coord": [-94.9430412, 41.9185415],
@@ -72232,7 +72232,7 @@
     "place": {
       "name": "Terre Haute",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 58389,
       "coord": [-87.4139119, 39.4667025],
@@ -72251,7 +72251,7 @@
     "place": {
       "name": "Texarkana",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29387,
       "coord": [-94.0430937, 33.4254259],
@@ -72270,7 +72270,7 @@
     "place": {
       "name": "Texarkana",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36193,
       "coord": [-94.0771483052202, 33.44667445],
@@ -72289,7 +72289,7 @@
     "place": {
       "name": "The Archipelago",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 979,
       "coord": [-80.384511, 45.596382],
@@ -72308,7 +72308,7 @@
     "place": {
       "name": "The Blue Mountains",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 9390,
       "coord": [-80.388065, 44.489559],
@@ -72327,7 +72327,7 @@
     "place": {
       "name": "The Village",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9538,
       "coord": [-97.5494185, 35.5658553],
@@ -72359,7 +72359,7 @@
     "place": {
       "name": "Theresa",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1255,
       "coord": [-88.4512114, 43.5172169],
@@ -72378,7 +72378,7 @@
     "place": {
       "name": "Thermopolis",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2725,
       "coord": [-108.212043, 43.646067],
@@ -72405,7 +72405,7 @@
     "place": {
       "name": "Thessalon",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1260,
       "coord": [-83.5483478, 46.2638311],
@@ -72424,7 +72424,7 @@
     "place": {
       "name": "Thibodaux",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15948,
       "coord": [-90.822871, 29.7957633],
@@ -72443,7 +72443,7 @@
     "place": {
       "name": "Thief River Falls",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8749,
       "coord": [-96.1770667, 48.1172301],
@@ -72462,7 +72462,7 @@
     "place": {
       "name": "Thiensville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3294,
       "coord": [-87.9787001, 43.2375067],
@@ -72481,7 +72481,7 @@
     "place": {
       "name": "Thomas Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11931,
       "coord": [-84.1087820860948, 43.43772515],
@@ -72500,7 +72500,7 @@
     "place": {
       "name": "Thomasboro",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1034,
       "coord": [-88.1842134, 40.2417001],
@@ -72519,7 +72519,7 @@
     "place": {
       "name": "Thomasville",
       "state": "GA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26649,
       "coord": [-83.9787808, 30.8365815],
@@ -72554,7 +72554,7 @@
     "place": {
       "name": "Thompson",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9189,
       "coord": [-71.8625715, 41.9587089],
@@ -72581,7 +72581,7 @@
     "place": {
       "name": "Thornapple Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9331,
       "coord": [-85.4863558517014, 42.7251519],
@@ -72600,7 +72600,7 @@
     "place": {
       "name": "Thornton",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 141867,
       "coord": [-104.985181, 39.8695516],
@@ -72627,7 +72627,7 @@
     "place": {
       "name": "Thorsby",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2064,
       "coord": [-86.7158178, 32.9156796],
@@ -72660,7 +72660,7 @@
     "place": {
       "name": "Thousand Oaks",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 126966,
       "coord": [-118.8375937, 34.1705609],
@@ -72679,7 +72679,7 @@
     "place": {
       "name": "Three Oaks",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1370,
       "coord": [-86.6105778, 41.7986545],
@@ -72712,7 +72712,7 @@
     "place": {
       "name": "Three Rivers",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7973,
       "coord": [-85.6346222, 41.9442722],
@@ -72731,7 +72731,7 @@
     "place": {
       "name": "Thunder Bay",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 108843,
       "coord": [-89.245522, 48.382501],
@@ -72750,7 +72750,7 @@
     "place": {
       "name": "Tiffin",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17953,
       "coord": [-83.1779537, 41.114485],
@@ -72769,7 +72769,7 @@
     "place": {
       "name": "Tigard",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 55514,
       "coord": [-122.771933, 45.4307473],
@@ -72788,7 +72788,7 @@
     "place": {
       "name": "Tijeras",
       "state": "NM",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 465,
       "coord": [-106.3879441, 35.0796355],
@@ -72807,7 +72807,7 @@
     "place": {
       "name": "Timmins",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 41145,
       "coord": [-81.330414, 48.477473],
@@ -72826,7 +72826,7 @@
     "place": {
       "name": "Timnath",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6487,
       "coord": [-104.982086, 40.5294388],
@@ -72853,7 +72853,7 @@
     "place": {
       "name": "Tioga",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2202,
       "coord": [-102.938238, 48.397244],
@@ -72872,7 +72872,7 @@
     "place": {
       "name": "Tionesta",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 475,
       "coord": [-79.4558798, 41.49534],
@@ -72891,7 +72891,7 @@
     "place": {
       "name": "Tipp City",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10274,
       "coord": [-84.1700609, 39.961325],
@@ -72926,7 +72926,7 @@
     "place": {
       "name": "Tipton",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3149,
       "coord": [-91.1281732, 41.7697016],
@@ -72945,7 +72945,7 @@
     "place": {
       "name": "Tipton",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5275,
       "coord": [-86.041205, 40.282237],
@@ -72964,7 +72964,7 @@
     "place": {
       "name": "Tirol",
       "state": "Tirol",
-      "country": "AT",
+      "country": "Austria",
       "type": "state",
       "pop": 771304,
       "coord": [11.1867187, 47.3289241],
@@ -72983,7 +72983,7 @@
     "place": {
       "name": "Tishomingo",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3101,
       "coord": [-96.676374, 34.2348151],
@@ -73002,7 +73002,7 @@
     "place": {
       "name": "Titonka",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 511,
       "coord": [-94.0413443, 43.236906],
@@ -73021,7 +73021,7 @@
     "place": {
       "name": "Titusville",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5262,
       "coord": [-79.669652, 41.624468],
@@ -73040,7 +73040,7 @@
     "place": {
       "name": "Tiverton",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16359,
       "coord": [-71.1982208877714, 41.64634515],
@@ -73059,7 +73059,7 @@
     "place": {
       "name": "Toledo",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2369,
       "coord": [-92.5790678, 41.9958439],
@@ -73078,7 +73078,7 @@
     "place": {
       "name": "Toledo",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 270871,
       "coord": [-83.5378173, 41.6529143],
@@ -73119,7 +73119,7 @@
     "place": {
       "name": "Tolland",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14563,
       "coord": [-72.3677153, 41.8700166],
@@ -73146,7 +73146,7 @@
     "place": {
       "name": "Tolleson",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7216,
       "coord": [-112.259309, 33.4500497],
@@ -73165,7 +73165,7 @@
     "place": {
       "name": "Tolono",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3604,
       "coord": [-88.2589387, 39.9861415],
@@ -73184,7 +73184,7 @@
     "place": {
       "name": "Tomah",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9570,
       "coord": [-90.5040214, 43.978576],
@@ -73203,7 +73203,7 @@
     "place": {
       "name": "Tomahawk",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3441,
       "coord": [-89.7293317, 45.4710394],
@@ -73222,7 +73222,7 @@
     "place": {
       "name": "Tonica",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 749,
       "coord": [-89.0667489, 41.2158684],
@@ -73241,7 +73241,7 @@
     "place": {
       "name": "Topeka",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 125963,
       "coord": [-95.677556, 39.049011],
@@ -73260,7 +73260,7 @@
     "place": {
       "name": "Topton",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2041,
       "coord": [-75.7013027, 40.5034284],
@@ -73279,7 +73279,7 @@
     "place": {
       "name": "Toronto",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 2731571,
       "coord": [-79.3839347, 43.6534817],
@@ -73298,7 +73298,7 @@
     "place": {
       "name": "Torrance",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 147067,
       "coord": [-118.3413606, 33.8371392],
@@ -73317,7 +73317,7 @@
     "place": {
       "name": "Torrington",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35515,
       "coord": [-73.1212214, 41.8006523],
@@ -73344,7 +73344,7 @@
     "place": {
       "name": "Torrington",
       "state": "WY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6119,
       "coord": [-104.184394, 42.062465],
@@ -73363,7 +73363,7 @@
     "place": {
       "name": "Towanda",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2833,
       "coord": [-76.44291, 41.7673567],
@@ -73382,7 +73382,7 @@
     "place": {
       "name": "Town of Cedarburg",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6162,
       "coord": [-88.0264105837566, 43.3232784],
@@ -73401,7 +73401,7 @@
     "place": {
       "name": "Town of Empire",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2774,
       "coord": [-88.341386217473, 43.753644],
@@ -73420,7 +73420,7 @@
     "place": {
       "name": "Town of Farmington",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3645,
       "coord": [-88.100682, 43.498068],
@@ -73439,7 +73439,7 @@
     "place": {
       "name": "Town of Lac du Flambeau",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3004,
       "coord": [-89.8928015, 45.9702769],
@@ -73458,7 +73458,7 @@
     "place": {
       "name": "Town of Ledgeview",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8820,
       "coord": [-87.9775233, 44.4237815],
@@ -73491,7 +73491,7 @@
     "place": {
       "name": "Town of Lowell",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1166,
       "coord": [-88.8063619972865, 43.3103005],
@@ -73510,7 +73510,7 @@
     "place": {
       "name": "Town of Mitchell",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1900,
       "coord": [-88.1001557538852, 43.65954125],
@@ -73529,7 +73529,7 @@
     "place": {
       "name": "Town of Mosinee",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2216,
       "coord": [-89.7570632425194, 44.8149027],
@@ -73548,7 +73548,7 @@
     "place": {
       "name": "Town of Peshtigo",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4006,
       "coord": [-87.7015274945861, 45.0373632],
@@ -73567,7 +73567,7 @@
     "place": {
       "name": "Town of Richmond",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1832,
       "coord": [-88.675168725753, 44.8116149],
@@ -73586,7 +73586,7 @@
     "place": {
       "name": "Town of Scott",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1764,
       "coord": [-88.120325, 43.593596],
@@ -73605,7 +73605,7 @@
     "place": {
       "name": "Town of St. Joseph",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4178,
       "coord": [-92.7211763, 45.0581228],
@@ -73624,7 +73624,7 @@
     "place": {
       "name": "Town of Taycheedah",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4554,
       "coord": [-88.3951057, 43.8088785],
@@ -73643,7 +73643,7 @@
     "place": {
       "name": "Town of Vinland",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1769,
       "coord": [-88.5836296823291, 44.12671635],
@@ -73662,7 +73662,7 @@
     "place": {
       "name": "Town of Weston",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 657,
       "coord": [-89.517262, 44.93115],
@@ -73681,7 +73681,7 @@
     "place": {
       "name": "Travelers Rest",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5346,
       "coord": [-82.4434548, 34.9676167],
@@ -73700,7 +73700,7 @@
     "place": {
       "name": "Traverse City",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15738,
       "coord": [-85.6165301, 44.7606441],
@@ -73719,7 +73719,7 @@
     "place": {
       "name": "Trelleborg",
       "state": "Skåne",
-      "country": "SE",
+      "country": "Sweden",
       "type": "city",
       "pop": 43359,
       "coord": [13.1461522, 55.37592],
@@ -73738,7 +73738,7 @@
     "place": {
       "name": "Tremont",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2277,
       "coord": [-89.4925979, 40.5275392],
@@ -73757,7 +73757,7 @@
     "place": {
       "name": "Trempealeau",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1843,
       "coord": [-91.4414831, 44.0057611],
@@ -73776,7 +73776,7 @@
     "place": {
       "name": "Trenton",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2690,
       "coord": [-89.6817621, 38.6050833],
@@ -73795,7 +73795,7 @@
     "place": {
       "name": "Trenton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13021,
       "coord": [-84.4577222, 39.4808905],
@@ -73814,7 +73814,7 @@
     "place": {
       "name": "Trinidad",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8329,
       "coord": [-104.5005411, 37.169397],
@@ -73841,7 +73841,7 @@
     "place": {
       "name": "Troy",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 87294,
       "coord": [-83.1499304, 42.6055893],
@@ -73860,7 +73860,7 @@
     "place": {
       "name": "Troy",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26305,
       "coord": [-84.2032767, 40.0394982],
@@ -73879,7 +73879,7 @@
     "place": {
       "name": "Trumann",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7399,
       "coord": [-90.517369, 35.675279],
@@ -73898,7 +73898,7 @@
     "place": {
       "name": "Trumbull",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36827,
       "coord": [-73.2006687, 41.2428742],
@@ -73925,7 +73925,7 @@
     "place": {
       "name": "Tshwane",
       "state": "GP",
-      "country": "ZA",
+      "country": "South Africa",
       "type": "city",
       "pop": 4040315,
       "coord": [28.1879101, -25.7459277],
@@ -73952,7 +73952,7 @@
     "place": {
       "name": "Tualatin",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27942,
       "coord": [-122.7694369, 45.3809339],
@@ -73989,7 +73989,7 @@
     "place": {
       "name": "Tucson",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 542629,
       "coord": [-110.974847, 32.2228765],
@@ -74008,7 +74008,7 @@
     "place": {
       "name": "Tulsa",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 401190,
       "coord": [-95.9929113, 36.1556805],
@@ -74043,7 +74043,7 @@
     "place": {
       "name": "Tunkhannock",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1766,
       "coord": [-75.946844, 41.5385159],
@@ -74062,7 +74062,7 @@
     "place": {
       "name": "Tupelo",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 37923,
       "coord": [-88.7033859, 34.2576067],
@@ -74081,7 +74081,7 @@
     "place": {
       "name": "Turtle Lake",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1269,
       "coord": [-92.1424066, 45.3944027],
@@ -74100,7 +74100,7 @@
     "place": {
       "name": "Tusayan",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 603,
       "coord": [-112.126556, 35.9735954],
@@ -74119,7 +74119,7 @@
     "place": {
       "name": "Tuscaloosa",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 100618,
       "coord": [-87.5675258, 33.2095614],
@@ -74146,7 +74146,7 @@
     "place": {
       "name": "Tuscola",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4636,
       "coord": [-88.2831038, 39.7991986],
@@ -74173,7 +74173,7 @@
     "place": {
       "name": "Tuttle",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7413,
       "coord": [-97.8122658, 35.2908947],
@@ -74192,7 +74192,7 @@
     "place": {
       "name": "Twin Falls",
       "state": "ID",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 50197,
       "coord": [-114.4602554, 42.5704456],
@@ -74211,7 +74211,7 @@
     "place": {
       "name": "Twin Lakes",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6309,
       "coord": [-88.2479278, 42.5315239],
@@ -74230,7 +74230,7 @@
     "place": {
       "name": "Two Harbors",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3633,
       "coord": [-91.6730523, 47.0257139],
@@ -74249,7 +74249,7 @@
     "place": {
       "name": "Two Rivers",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11271,
       "coord": [-87.5692479, 44.1538845],
@@ -74268,7 +74268,7 @@
     "place": {
       "name": "Tyler",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 105995,
       "coord": [-95.300661, 32.351691],
@@ -74287,7 +74287,7 @@
     "place": {
       "name": "Tyrone",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5480,
       "coord": [-78.2383479, 40.6705508],
@@ -74314,7 +74314,7 @@
     "place": {
       "name": "US Virgin Islands",
       "state": "VI",
-      "country": "US",
+      "country": "United States",
       "type": "state",
       "pop": 87146,
       "coord": [-64.94610250230508, 18.343352334669596],
@@ -74333,7 +74333,7 @@
     "place": {
       "name": "Udall",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 661,
       "coord": [-97.1142063, 37.3875221],
@@ -74352,7 +74352,7 @@
     "place": {
       "name": "Uhrichsville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5272,
       "coord": [-81.3451733, 40.390819],
@@ -74371,7 +74371,7 @@
     "place": {
       "name": "Ulysses",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5788,
       "coord": [-101.355169, 37.5814095],
@@ -74390,7 +74390,7 @@
     "place": {
       "name": "Underwood",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 954,
       "coord": [-95.678862, 41.3872477],
@@ -74409,7 +74409,7 @@
     "place": {
       "name": "Union Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11699,
       "coord": [-84.822865735563, 43.596874],
@@ -74433,7 +74433,7 @@
     "place": {
       "name": "Union City",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2934,
       "coord": [-79.8453298, 41.8995001],
@@ -74452,7 +74452,7 @@
     "place": {
       "name": "Union City",
       "state": "TN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11170,
       "coord": [-89.0570096, 36.4242303],
@@ -74471,7 +74471,7 @@
     "place": {
       "name": "Union Springs",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1075,
       "coord": [-76.6932818, 42.8397906],
@@ -74490,7 +74490,7 @@
     "place": {
       "name": "Union",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12348,
       "coord": [-91.0082308, 38.4443875],
@@ -74509,7 +74509,7 @@
     "place": {
       "name": "University City",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35065,
       "coord": [-90.3103443, 38.6569083],
@@ -74528,7 +74528,7 @@
     "place": {
       "name": "University Park",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25278,
       "coord": [-96.7925796621688, 32.851034],
@@ -74547,7 +74547,7 @@
     "place": {
       "name": "Upper Arlington",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36800,
       "coord": [-83.0624078, 39.9945084],
@@ -74566,7 +74566,7 @@
     "place": {
       "name": "Upsala",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 487,
       "coord": [-94.5713974, 45.8107986],
@@ -74585,7 +74585,7 @@
     "place": {
       "name": "Urbana",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 36681,
       "coord": [-88.207301, 40.1117174],
@@ -74604,7 +74604,7 @@
     "place": {
       "name": "Utica",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 840,
       "coord": [-97.3447128, 40.8950274],
@@ -74623,7 +74623,7 @@
     "place": {
       "name": "Utica",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 65283,
       "coord": [-75.2326641, 43.1009031],
@@ -74658,7 +74658,7 @@
     "place": {
       "name": "Uvalde",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16001,
       "coord": [-99.7861679, 29.2096836],
@@ -74677,7 +74677,7 @@
     "place": {
       "name": "Vail",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4835,
       "coord": [-106.3801669, 39.6440207],
@@ -74704,7 +74704,7 @@
     "place": {
       "name": "Valatie",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1785,
       "coord": [-73.6731749, 42.4134168],
@@ -74723,7 +74723,7 @@
     "place": {
       "name": "Vallejo",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 126090,
       "coord": [-122.2566367, 38.1040864],
@@ -74758,7 +74758,7 @@
     "place": {
       "name": "Valley Center",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7340,
       "coord": [-97.3733759, 37.8347342],
@@ -74777,7 +74777,7 @@
     "place": {
       "name": "Valley Head",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 577,
       "coord": [-85.6149654, 34.5689732],
@@ -74796,7 +74796,7 @@
     "place": {
       "name": "Valley Springs",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 885,
       "coord": [-96.467819, 43.582473],
@@ -74815,7 +74815,7 @@
     "place": {
       "name": "Valley",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3037,
       "coord": [-96.3459776, 41.312758],
@@ -74834,7 +74834,7 @@
     "place": {
       "name": "Valparaiso",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 34151,
       "coord": [-87.0611412, 41.4730948],
@@ -74861,7 +74861,7 @@
     "place": {
       "name": "Van Buren Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30375,
       "coord": [-83.4841464, 42.2207982],
@@ -74880,7 +74880,7 @@
     "place": {
       "name": "Van Buren",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23218,
       "coord": [-94.352571, 35.436795],
@@ -74899,7 +74899,7 @@
     "place": {
       "name": "Van Meter",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1484,
       "coord": [-93.9548406, 41.5332166],
@@ -74918,7 +74918,7 @@
     "place": {
       "name": "Van Wert ",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11045,
       "coord": [-84.5755178, 40.8616225],
@@ -74937,7 +74937,7 @@
     "place": {
       "name": "Vancouver",
       "state": "BC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 662248,
       "coord": [-123.113952, 49.2608724],
@@ -74956,7 +74956,7 @@
     "place": {
       "name": "Vancouver",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 190915,
       "coord": [-122.6744557, 45.6306954],
@@ -74987,7 +74987,7 @@
     "place": {
       "name": "Vandalia",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6836,
       "coord": [-89.0936778, 38.960601],
@@ -75006,7 +75006,7 @@
     "place": {
       "name": "Vandergrift",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5075,
       "coord": [-79.5647741, 40.6028462],
@@ -75025,7 +75025,7 @@
     "place": {
       "name": "Vassar",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2727,
       "coord": [-83.583292, 43.371968],
@@ -75044,7 +75044,7 @@
     "place": {
       "name": "Veedersburg",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2098,
       "coord": [-87.2625101, 40.1130947],
@@ -75063,7 +75063,7 @@
     "place": {
       "name": "Velva",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1086,
       "coord": [-100.929317, 48.05612],
@@ -75082,7 +75082,7 @@
     "place": {
       "name": "Ventura",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 711,
       "coord": [-93.477897, 43.1266263],
@@ -75101,7 +75101,7 @@
     "place": {
       "name": "Verdigris",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5256,
       "coord": [-95.6910927, 36.2348197],
@@ -75120,7 +75120,7 @@
     "place": {
       "name": "Vermillion",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11695,
       "coord": [-96.929101, 42.7795273],
@@ -75139,7 +75139,7 @@
     "place": {
       "name": "Vernon Center",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 328,
       "coord": [-94.1691248, 43.961906],
@@ -75158,7 +75158,7 @@
     "place": {
       "name": "Vernon",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30215,
       "coord": [-72.4663331, 41.8382921],
@@ -75177,7 +75177,7 @@
     "place": {
       "name": "Verona",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2492,
       "coord": [-79.843105, 40.5064571],
@@ -75204,7 +75204,7 @@
     "place": {
       "name": "Verona",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14030,
       "coord": [-89.5335575, 42.9905492],
@@ -75237,7 +75237,7 @@
     "place": {
       "name": "Versailles",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2539,
       "coord": [-92.8410274, 38.4314141],
@@ -75256,7 +75256,7 @@
     "place": {
       "name": "Vestavia Hills",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 39102,
       "coord": [-86.7879492, 33.4487989],
@@ -75283,7 +75283,7 @@
     "place": {
       "name": "Vicksburg",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21573,
       "coord": [-90.8777342, 32.3528055],
@@ -75302,7 +75302,7 @@
     "place": {
       "name": "Victoria Park",
       "state": "WA",
-      "country": "AU",
+      "country": "Australia",
       "type": "city",
       "pop": 36889,
       "coord": [115.8954511, -31.9723554],
@@ -75329,7 +75329,7 @@
     "place": {
       "name": "Victoria",
       "state": "BC",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 91867,
       "coord": [-123.364953, 48.4283182],
@@ -75348,7 +75348,7 @@
     "place": {
       "name": "Victoria",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1129,
       "coord": [-99.147597, 38.85279],
@@ -75367,7 +75367,7 @@
     "place": {
       "name": "Victoria",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10546,
       "coord": [-93.6616266, 44.8585738],
@@ -75386,7 +75386,7 @@
     "place": {
       "name": "Victoria",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 65534,
       "coord": [-96.9766308, 28.8026443],
@@ -75405,7 +75405,7 @@
     "place": {
       "name": "Vidalia",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4027,
       "coord": [-91.4259495, 31.5654441],
@@ -75424,7 +75424,7 @@
     "place": {
       "name": "Vienna",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10676,
       "coord": [-81.5512639, 39.3208866],
@@ -75443,7 +75443,7 @@
     "place": {
       "name": "Vilas County",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 23047,
       "coord": [-89.4734462, 46.0382686],
@@ -75462,7 +75462,7 @@
     "place": {
       "name": "Villa Hills",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7310,
       "coord": [-84.5929998, 39.0633933],
@@ -75486,7 +75486,7 @@
     "place": {
       "name": "Villa Park",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21113,
       "coord": [-87.9778368, 41.8893116],
@@ -75505,7 +75505,7 @@
     "place": {
       "name": "Village of Four Seasons",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2383,
       "coord": [-92.709765, 38.1948332],
@@ -75524,7 +75524,7 @@
     "place": {
       "name": "Vinita",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5193,
       "coord": [-95.156363, 36.6408372],
@@ -75543,7 +75543,7 @@
     "place": {
       "name": "Vinton",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4938,
       "coord": [-92.0239504, 42.1679131],
@@ -75562,7 +75562,7 @@
     "place": {
       "name": "Vinton",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8104,
       "coord": [-79.8969819, 37.2809707],
@@ -75581,7 +75581,7 @@
     "place": {
       "name": "Virginia Beach",
       "state": "VA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 459470,
       "coord": [-75.9774183, 36.8529841],
@@ -75600,7 +75600,7 @@
     "place": {
       "name": "Visalia",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 141384,
       "coord": [-119.292058, 36.3302284],
@@ -75627,7 +75627,7 @@
     "place": {
       "name": "Vivian",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3073,
       "coord": [-93.986667, 32.871111],
@@ -75646,7 +75646,7 @@
     "place": {
       "name": "Volga",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2113,
       "coord": [-96.926448, 44.32358],
@@ -75665,7 +75665,7 @@
     "place": {
       "name": "Volo",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6122,
       "coord": [-88.167861, 42.3261332],
@@ -75684,7 +75684,7 @@
     "place": {
       "name": "Voorheesville",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2841,
       "coord": [-73.9287366, 42.653967],
@@ -75703,7 +75703,7 @@
     "place": {
       "name": "Vorarlberg",
       "state": "Vorarlberg",
-      "country": "AT",
+      "country": "Austria",
       "type": "state",
       "pop": 401674,
       "coord": [9.894458, 47.230877],
@@ -75722,7 +75722,7 @@
     "place": {
       "name": "Västerås",
       "state": "Västmanland",
-      "country": "SE",
+      "country": "Sweden",
       "type": "city",
       "pop": 127799,
       "coord": [16.5463679, 59.6110992],
@@ -75741,7 +75741,7 @@
     "place": {
       "name": "Wabash",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10440,
       "coord": [-85.82222, 40.795846],
@@ -75760,7 +75760,7 @@
     "place": {
       "name": "Wabasha",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2559,
       "coord": [-92.032742, 44.384023],
@@ -75779,7 +75779,7 @@
     "place": {
       "name": "Waco",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 138486,
       "coord": [-97.1474628, 31.5491899],
@@ -75798,7 +75798,7 @@
     "place": {
       "name": "Waconia",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13033,
       "coord": [-93.7869088, 44.8507957],
@@ -75817,7 +75817,7 @@
     "place": {
       "name": "Wadena",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4325,
       "coord": [-95.1361386, 46.4424614],
@@ -75836,7 +75836,7 @@
     "place": {
       "name": "Wadsworth",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3517,
       "coord": [-87.9239651, 42.4286321],
@@ -75855,7 +75855,7 @@
     "place": {
       "name": "Wagoner",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7621,
       "coord": [-95.376904, 35.959788],
@@ -75882,7 +75882,7 @@
     "place": {
       "name": "Wahoo",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4818,
       "coord": [-96.6197985, 41.2111084],
@@ -75901,7 +75901,7 @@
     "place": {
       "name": "Wahpeton",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8007,
       "coord": [-96.608863, 46.265879],
@@ -75920,7 +75920,7 @@
     "place": {
       "name": "Walker",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25132,
       "coord": [-85.7741906, 43.005597],
@@ -75939,7 +75939,7 @@
     "place": {
       "name": "Walkersville",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6156,
       "coord": [-77.3507698, 39.4817659],
@@ -75958,7 +75958,7 @@
     "place": {
       "name": "Walla Walla",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 33927,
       "coord": [-118.339345, 46.0667277],
@@ -75977,7 +75977,7 @@
     "place": {
       "name": "Wallingford",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 44396,
       "coord": [-72.8231552, 41.4570418],
@@ -75996,7 +75996,7 @@
     "place": {
       "name": "Walnut Creek",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 70812,
       "coord": [-122.0618702, 37.9020731],
@@ -76015,7 +76015,7 @@
     "place": {
       "name": "Walnut",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 704,
       "coord": [-88.900482, 34.946201],
@@ -76034,7 +76034,7 @@
     "place": {
       "name": "Walterboro",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5544,
       "coord": [-80.6672631, 32.9021377],
@@ -76053,7 +76053,7 @@
     "place": {
       "name": "Wanamingo",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1113,
       "coord": [-92.7906122, 44.3043907],
@@ -76072,7 +76072,7 @@
     "place": {
       "name": "Wanatah",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1009,
       "coord": [-86.898358, 41.4305964],
@@ -76091,7 +76091,7 @@
     "place": {
       "name": "Wapakoneta",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9957,
       "coord": [-84.1935594, 40.5678265],
@@ -76124,7 +76124,7 @@
     "place": {
       "name": "Wapella",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 513,
       "coord": [-88.9620246, 40.2203145],
@@ -76143,7 +76143,7 @@
     "place": {
       "name": "Wapello",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2084,
       "coord": [-91.185468, 41.1813612],
@@ -76162,7 +76162,7 @@
     "place": {
       "name": "Wappingers Falls",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6103,
       "coord": [-73.9112103, 41.5965635],
@@ -76181,7 +76181,7 @@
     "place": {
       "name": "Warren",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 139387,
       "coord": [-83.0062746, 42.4932575],
@@ -76200,7 +76200,7 @@
     "place": {
       "name": "Warren",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1605,
       "coord": [-96.7727048, 48.196591],
@@ -76219,7 +76219,7 @@
     "place": {
       "name": "Warren",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11147,
       "coord": [-71.2825494, 41.7303794],
@@ -76238,7 +76238,7 @@
     "place": {
       "name": "Warrensburg",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1110,
       "coord": [-89.0620278, 39.9328162],
@@ -76257,7 +76257,7 @@
     "place": {
       "name": "Warrensburg",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20313,
       "coord": [-93.7409596, 38.7624373],
@@ -76276,7 +76276,7 @@
     "place": {
       "name": "Warrensville Heights",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13789,
       "coord": [-81.514824, 41.43535],
@@ -76295,7 +76295,7 @@
     "place": {
       "name": "Warrenville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13553,
       "coord": [-88.174097, 41.8179303],
@@ -76329,7 +76329,7 @@
     "place": {
       "name": "Warrior",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3224,
       "coord": [-86.8094394, 33.8142682],
@@ -76348,7 +76348,7 @@
     "place": {
       "name": "Warsaw",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15804,
       "coord": [-85.8530544, 41.2381017],
@@ -76367,7 +76367,7 @@
     "place": {
       "name": "Warsaw",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2209,
       "coord": [-93.3774013, 38.2442186],
@@ -76394,7 +76394,7 @@
     "place": {
       "name": "Warwick Township",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 3641,
       "coord": [-81.897345, 43.002173],
@@ -76413,7 +76413,7 @@
     "place": {
       "name": "Warwick",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 82823,
       "coord": [-71.4586114, 41.6992717],
@@ -76440,7 +76440,7 @@
     "place": {
       "name": "Wasaga Beach",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 24862,
       "coord": [-80.0203156, 44.5224813],
@@ -76459,7 +76459,7 @@
     "place": {
       "name": "Waseca",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9229,
       "coord": [-93.5075767, 44.0776638],
@@ -76486,7 +76486,7 @@
     "place": {
       "name": "Washburn",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2051,
       "coord": [-90.8949055, 46.6732766],
@@ -76513,7 +76513,7 @@
     "place": {
       "name": "Washington Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28165,
       "coord": [-83.0373036, 42.7570924],
@@ -76540,7 +76540,7 @@
     "place": {
       "name": "Washington County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 13761,
       "coord": [-89.4201902, 38.3662806],
@@ -76559,7 +76559,7 @@
     "place": {
       "name": "Washington County",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 600372,
       "coord": [-123.0587907, 45.5601883],
@@ -76578,7 +76578,7 @@
     "place": {
       "name": "Washington Court House",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14401,
       "coord": [-83.4390843, 39.5364511],
@@ -76605,7 +76605,7 @@
     "place": {
       "name": "Washington",
       "state": "DC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 705749,
       "coord": [-77.0365427, 38.8950368],
@@ -76624,7 +76624,7 @@
     "place": {
       "name": "Washington",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7352,
       "coord": [-91.6923661, 41.2990848],
@@ -76643,7 +76643,7 @@
     "place": {
       "name": "Washington",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16071,
       "coord": [-89.406515, 40.703408],
@@ -76662,7 +76662,7 @@
     "place": {
       "name": "Washington",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13176,
       "coord": [-80.245011, 40.169332],
@@ -76681,7 +76681,7 @@
     "place": {
       "name": "Washington",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27993,
       "coord": [-113.5082867, 37.1305373],
@@ -76700,7 +76700,7 @@
     "place": {
       "name": "Washington",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "state",
       "pop": 7705281,
       "coord": [-120.173906, 47.297706],
@@ -76733,7 +76733,7 @@
     "place": {
       "name": "Waterbury",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 114403,
       "coord": [-73.0438362, 41.5538091],
@@ -76752,7 +76752,7 @@
     "place": {
       "name": "Waterford",
       "state": "County Waterford",
-      "country": "IE",
+      "country": "Ireland",
       "type": "city",
       "pop": 60079,
       "coord": [-7.1119081, 52.2609997],
@@ -76779,7 +76779,7 @@
     "place": {
       "name": "Waterloo",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 67314,
       "coord": [-92.3328743, 42.498275],
@@ -76806,7 +76806,7 @@
     "place": {
       "name": "Waterloo",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3483,
       "coord": [-88.9884421, 43.1838844],
@@ -76825,7 +76825,7 @@
     "place": {
       "name": "Waterman",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1433,
       "coord": [-88.7736942, 41.7716963],
@@ -76852,7 +76852,7 @@
     "place": {
       "name": "Watertown",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24685,
       "coord": [-75.9107565, 43.9747838],
@@ -76879,7 +76879,7 @@
     "place": {
       "name": "Watertown",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22655,
       "coord": [-97.115289, 44.899211],
@@ -76906,7 +76906,7 @@
     "place": {
       "name": "Watertown",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23479,
       "coord": [-88.7286352, 43.1948481],
@@ -76925,7 +76925,7 @@
     "place": {
       "name": "Waterville",
       "state": "ME",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15828,
       "coord": [-69.6313607, 44.5524176],
@@ -76952,7 +76952,7 @@
     "place": {
       "name": "Waterville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6003,
       "coord": [-83.7182701, 41.5008859],
@@ -76971,7 +76971,7 @@
     "place": {
       "name": "Watervliet",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10375,
       "coord": [-73.7012299, 42.7300784],
@@ -77006,7 +77006,7 @@
     "place": {
       "name": "Watseka",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4679,
       "coord": [-87.7364218, 40.7761465],
@@ -77025,7 +77025,7 @@
     "place": {
       "name": "Watson Lake",
       "state": "YT",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1133,
       "coord": [-128.7068037, 60.0624306],
@@ -77044,7 +77044,7 @@
     "place": {
       "name": "Waukee",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23940,
       "coord": [-93.8845129, 41.6118485],
@@ -77063,7 +77063,7 @@
     "place": {
       "name": "Waukegan",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 89321,
       "coord": [-87.8447938, 42.3636331],
@@ -77104,7 +77104,7 @@
     "place": {
       "name": "Waukesha",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 71158,
       "coord": [-88.2314813, 43.0116784],
@@ -77123,7 +77123,7 @@
     "place": {
       "name": "Waukon",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3827,
       "coord": [-91.4757884, 43.2694242],
@@ -77142,7 +77142,7 @@
     "place": {
       "name": "Waupaca",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6282,
       "coord": [-89.0859464, 44.3580348],
@@ -77161,7 +77161,7 @@
     "place": {
       "name": "Wausau",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 39575,
       "coord": [-89.6298239, 44.9596017],
@@ -77196,7 +77196,7 @@
     "place": {
       "name": "Waverly",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10394,
       "coord": [-92.4746033, 42.7258451],
@@ -77215,7 +77215,7 @@
     "place": {
       "name": "Waverly",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4279,
       "coord": [-96.528167, 40.91742],
@@ -77234,7 +77234,7 @@
     "place": {
       "name": "Waverly",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4165,
       "coord": [-82.9854553, 39.126735],
@@ -77261,7 +77261,7 @@
     "place": {
       "name": "Waxhaw",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20534,
       "coord": [-80.7440174, 34.9248125],
@@ -77288,7 +77288,7 @@
     "place": {
       "name": "Wayland",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 964,
       "coord": [-91.6608311, 41.1472063],
@@ -77307,7 +77307,7 @@
     "place": {
       "name": "Wayne",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17713,
       "coord": [-83.2844172, 42.2682408],
@@ -77340,7 +77340,7 @@
     "place": {
       "name": "Wayne",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5973,
       "coord": [-97.0178768, 42.2303215],
@@ -77359,7 +77359,7 @@
     "place": {
       "name": "Waynesburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3987,
       "coord": [-80.1792299, 39.8964641],
@@ -77378,7 +77378,7 @@
     "place": {
       "name": "Waynesville",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5406,
       "coord": [-92.2266876, 37.8141419],
@@ -77397,7 +77397,7 @@
     "place": {
       "name": "Waynesville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2669,
       "coord": [-84.086601, 39.5297824],
@@ -77416,7 +77416,7 @@
     "place": {
       "name": "Weatherford",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12076,
       "coord": [-98.7075744, 35.5261633],
@@ -77435,7 +77435,7 @@
     "place": {
       "name": "Weatherford",
       "state": "TX",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 33547,
       "coord": [-97.7970748, 32.7589648],
@@ -77454,7 +77454,7 @@
     "place": {
       "name": "Webberville",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1288,
       "coord": [-84.174432, 42.6668257],
@@ -77473,7 +77473,7 @@
     "place": {
       "name": "Webster City",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7825,
       "coord": [-93.8183858, 42.4695666],
@@ -77492,7 +77492,7 @@
     "place": {
       "name": "Webster Groves",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24010,
       "coord": [-90.3564329, 38.592339],
@@ -77511,7 +77511,7 @@
     "place": {
       "name": "Weedsport",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1788,
       "coord": [-76.5627197, 43.048677],
@@ -77530,7 +77530,7 @@
     "place": {
       "name": "Weirton",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19163,
       "coord": [-80.5899788, 40.4002396],
@@ -77553,7 +77553,7 @@
     "place": {
       "name": "Welcome",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 710,
       "coord": [-94.6187863, 43.6671139],
@@ -77572,7 +77572,7 @@
     "place": {
       "name": "Wellington",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11047,
       "coord": [-105.008585, 40.7038712],
@@ -77591,7 +77591,7 @@
     "place": {
       "name": "Wellington",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7715,
       "coord": [-97.3999395, 37.2675076],
@@ -77610,7 +77610,7 @@
     "place": {
       "name": "Wellington",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4799,
       "coord": [-82.2179354, 41.1689421],
@@ -77629,7 +77629,7 @@
     "place": {
       "name": "Wells",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2410,
       "coord": [-93.725614, 43.744063],
@@ -77648,7 +77648,7 @@
     "place": {
       "name": "Wellsboro",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3472,
       "coord": [-77.3005305, 41.7486838],
@@ -77667,7 +77667,7 @@
     "place": {
       "name": "Wellston",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5412,
       "coord": [-82.5329377, 39.1234054],
@@ -77686,7 +77686,7 @@
     "place": {
       "name": "Wellsville",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4060,
       "coord": [-111.933834, 41.6385432],
@@ -77705,7 +77705,7 @@
     "place": {
       "name": "Welsh",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3333,
       "coord": [-92.8221303, 30.2368977],
@@ -77724,7 +77724,7 @@
     "place": {
       "name": "West Allis",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 59861,
       "coord": [-88.0070315, 43.0166806],
@@ -77751,7 +77751,7 @@
     "place": {
       "name": "West Baton Rouge Parish",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 27199,
       "coord": [-91.3261882, 30.4514623],
@@ -77770,7 +77770,7 @@
     "place": {
       "name": "West Bend",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 791,
       "coord": [-94.4450174, 42.9577623],
@@ -77789,7 +77789,7 @@
     "place": {
       "name": "West Bend",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 31752,
       "coord": [-88.1834277, 43.4252776],
@@ -77808,7 +77808,7 @@
     "place": {
       "name": "West Bountiful",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5917,
       "coord": [-111.901786, 40.8938148],
@@ -77827,7 +77827,7 @@
     "place": {
       "name": "West Branch",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2351,
       "coord": [-84.238613, 44.276408],
@@ -77862,7 +77862,7 @@
     "place": {
       "name": "West Burlington",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3197,
       "coord": [-91.1565496, 40.825083],
@@ -77881,7 +77881,7 @@
     "place": {
       "name": "West Carrollton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13129,
       "coord": [-84.2521632, 39.6722812],
@@ -77900,7 +77900,7 @@
     "place": {
       "name": "West Chester",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18671,
       "coord": [-75.6059638, 39.9597213],
@@ -77927,7 +77927,7 @@
     "place": {
       "name": "West Chicago",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25614,
       "coord": [-88.2039607, 41.8847507],
@@ -77946,7 +77946,7 @@
     "place": {
       "name": "West Des Moines",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 65606,
       "coord": [-93.7595281, 41.5645337],
@@ -77965,7 +77965,7 @@
     "place": {
       "name": "West Fargo",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 38626,
       "coord": [-96.900362, 46.874967],
@@ -77984,7 +77984,7 @@
     "place": {
       "name": "West Frankfort",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7275,
       "coord": [-88.9022902, 37.9000495],
@@ -78003,7 +78003,7 @@
     "place": {
       "name": "West Grey",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 13131,
       "coord": [-80.88357696068783, 44.15537915],
@@ -78022,7 +78022,7 @@
     "place": {
       "name": "West Grove",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2775,
       "coord": [-75.8283272548101, 39.82055685],
@@ -78041,7 +78041,7 @@
     "place": {
       "name": "West Hartford",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 64083,
       "coord": [-72.7420399, 41.7620447],
@@ -78060,7 +78060,7 @@
     "place": {
       "name": "West Haven",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 55584,
       "coord": [-72.9470471, 41.2706527],
@@ -78095,7 +78095,7 @@
     "place": {
       "name": "West Hollywood",
       "state": "CA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 35757,
       "coord": [-118.3692894, 34.0923014],
@@ -78114,7 +78114,7 @@
     "place": {
       "name": "West Homestead",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1872,
       "coord": [-79.9119946, 40.3939581],
@@ -78133,7 +78133,7 @@
     "place": {
       "name": "West Jefferson",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1279,
       "coord": [-81.4928829, 36.4037364],
@@ -78152,7 +78152,7 @@
     "place": {
       "name": "West Lafayette",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 44595,
       "coord": [-86.9080655, 40.4258686],
@@ -78179,7 +78179,7 @@
     "place": {
       "name": "West Liberty",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3858,
       "coord": [-91.2637695, 41.5700231],
@@ -78198,7 +78198,7 @@
     "place": {
       "name": "West Liberty",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1770,
       "coord": [-83.7557663, 40.2522771],
@@ -78217,7 +78217,7 @@
     "place": {
       "name": "West Linn",
       "state": "OR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27373,
       "coord": [-122.612314, 45.3656761],
@@ -78250,7 +78250,7 @@
     "place": {
       "name": "West Memphis",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24520,
       "coord": [-90.1845388, 35.1464797],
@@ -78277,7 +78277,7 @@
     "place": {
       "name": "West Middletown",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 109,
       "coord": [-80.4272882, 40.2428487],
@@ -78304,7 +78304,7 @@
     "place": {
       "name": "West Milton",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4697,
       "coord": [-84.3280022, 39.9625534],
@@ -78323,7 +78323,7 @@
     "place": {
       "name": "West Newton",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2665,
       "coord": [-79.766983, 40.2098343],
@@ -78342,7 +78342,7 @@
     "place": {
       "name": "West Nipissing",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 14583,
       "coord": [-80.123348, 46.4112427],
@@ -78361,7 +78361,7 @@
     "place": {
       "name": "West Palm Beach",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 111955,
       "coord": [-80.0532942, 26.715364],
@@ -78396,7 +78396,7 @@
     "place": {
       "name": "West Plains",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12184,
       "coord": [-91.8525756, 36.7281652],
@@ -78415,7 +78415,7 @@
     "place": {
       "name": "West Reading",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4553,
       "coord": [-75.9474322, 40.3337038],
@@ -78442,7 +78442,7 @@
     "place": {
       "name": "West Saint Paul",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20822,
       "coord": [-93.0802073, 44.9101545],
@@ -78469,7 +78469,7 @@
     "place": {
       "name": "West Salem",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5277,
       "coord": [-91.0812465, 43.8991322],
@@ -78488,7 +78488,7 @@
     "place": {
       "name": "West Union",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2490,
       "coord": [-91.8076644, 42.9624184],
@@ -78507,7 +78507,7 @@
     "place": {
       "name": "West Unity",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1763,
       "coord": [-84.4349491, 41.586162],
@@ -78526,7 +78526,7 @@
     "place": {
       "name": "West Yellowstone",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1272,
       "coord": [-111.101169, 44.6632505],
@@ -78545,7 +78545,7 @@
     "place": {
       "name": "Westbrook",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6769,
       "coord": [-72.4487866, 41.2860314],
@@ -78564,7 +78564,7 @@
     "place": {
       "name": "Westchester",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16892,
       "coord": [-87.8820048, 41.8505866],
@@ -78583,7 +78583,7 @@
     "place": {
       "name": "Westerly",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23359,
       "coord": [-71.829886, 41.3812001],
@@ -78602,7 +78602,7 @@
     "place": {
       "name": "Western Springs",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13629,
       "coord": [-87.900671, 41.8096132],
@@ -78621,7 +78621,7 @@
     "place": {
       "name": "Westfield",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2993,
       "coord": [-79.578103, 42.32228],
@@ -78648,7 +78648,7 @@
     "place": {
       "name": "Westland",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 85420,
       "coord": [-83.4005321, 42.3238056],
@@ -78667,7 +78667,7 @@
     "place": {
       "name": "Westminster",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19960,
       "coord": [-76.9959168, 39.5751717],
@@ -78686,7 +78686,7 @@
     "place": {
       "name": "Westminster",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2353,
       "coord": [-83.0965425, 34.6648197],
@@ -78705,7 +78705,7 @@
     "place": {
       "name": "Westmont",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24429,
       "coord": [-87.9751964, 41.7950525],
@@ -78740,7 +78740,7 @@
     "place": {
       "name": "Weston",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1756,
       "coord": [-94.9031821, 39.4087949],
@@ -78759,7 +78759,7 @@
     "place": {
       "name": "Weston",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15723,
       "coord": [-89.5725724, 44.9055006],
@@ -78783,7 +78783,7 @@
     "place": {
       "name": "Weston",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3943,
       "coord": [-80.467313, 39.0384274],
@@ -78802,7 +78802,7 @@
     "place": {
       "name": "Westover",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3995,
       "coord": [-79.9697862, 39.6345259],
@@ -78821,7 +78821,7 @@
     "place": {
       "name": "Westport",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27141,
       "coord": [-73.3578955, 41.1414855],
@@ -78840,7 +78840,7 @@
     "place": {
       "name": "Westwood",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1750,
       "coord": [-94.6169013, 39.0405608],
@@ -78859,7 +78859,7 @@
     "place": {
       "name": "Wethersfield",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27298,
       "coord": [-72.6525922, 41.7142665],
@@ -78878,7 +78878,7 @@
     "place": {
       "name": "Wetumpka",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7220,
       "coord": [-86.2045442, 32.5378668],
@@ -78897,7 +78897,7 @@
     "place": {
       "name": "Wheat Ridge",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 32398,
       "coord": [-105.0772063, 39.766098],
@@ -78928,7 +78928,7 @@
     "place": {
       "name": "Wheaton",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 53126,
       "coord": [-88.1101709, 41.8646959],
@@ -78947,7 +78947,7 @@
     "place": {
       "name": "Wheeling",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 39137,
       "coord": [-87.9310944, 42.138889],
@@ -78966,7 +78966,7 @@
     "place": {
       "name": "Wheeling",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27062,
       "coord": [-80.7209149, 40.0639616],
@@ -78985,7 +78985,7 @@
     "place": {
       "name": "White Bear Lake",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 24883,
       "coord": [-93.0069304, 45.0838098],
@@ -79004,7 +79004,7 @@
     "place": {
       "name": "White Cloud",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1479,
       "coord": [-85.771997, 43.550297],
@@ -79023,7 +79023,7 @@
     "place": {
       "name": "White Haven",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1163,
       "coord": [-75.774082, 41.06064],
@@ -79042,7 +79042,7 @@
     "place": {
       "name": "White Sulphur Springs",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2231,
       "coord": [-80.2975734, 37.7965149],
@@ -79061,7 +79061,7 @@
     "place": {
       "name": "Whitefish",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 7751,
       "coord": [-114.334624, 48.4108018],
@@ -79080,7 +79080,7 @@
     "place": {
       "name": "Whitehall",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20127,
       "coord": [-82.8854559, 39.9667308],
@@ -79099,7 +79099,7 @@
     "place": {
       "name": "Whitehorse",
       "state": "YT",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 28201,
       "coord": [-135.054932, 60.721571],
@@ -79126,7 +79126,7 @@
     "place": {
       "name": "Whitemarsh Township",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19707,
       "coord": [-75.2165658, 40.1220543],
@@ -79145,7 +79145,7 @@
     "place": {
       "name": "Whitestone",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 1075,
       "coord": [-80.05555377570082, 45.6857252],
@@ -79164,7 +79164,7 @@
     "place": {
       "name": "Whitewater",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14889,
       "coord": [-88.7292679, 42.8336422],
@@ -79183,7 +79183,7 @@
     "place": {
       "name": "Whiting",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4559,
       "coord": [-87.4944873, 41.6797578],
@@ -79202,7 +79202,7 @@
     "place": {
       "name": "Wichita",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 389877,
       "coord": [-97.3375448, 37.6922361],
@@ -79221,7 +79221,7 @@
     "place": {
       "name": "Wickenburg",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8092,
       "coord": [-112.7301353, 33.9680962],
@@ -79240,7 +79240,7 @@
     "place": {
       "name": "Wilder",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3176,
       "coord": [-84.4867731, 39.0564732],
@@ -79259,7 +79259,7 @@
     "place": {
       "name": "Wilkes-Barre",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 44328,
       "coord": [-75.8817316, 41.2464824],
@@ -79278,7 +79278,7 @@
     "place": {
       "name": "Wilkinsburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14349,
       "coord": [-79.8819609, 40.4418068],
@@ -79297,7 +79297,7 @@
     "place": {
       "name": "Willard",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1978,
       "coord": [-112.03819, 41.4085496],
@@ -79316,7 +79316,7 @@
     "place": {
       "name": "Williams Bay",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2953,
       "coord": [-88.5409333, 42.5780721],
@@ -79349,7 +79349,7 @@
     "place": {
       "name": "Williams",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3202,
       "coord": [-112.1884252, 35.2507],
@@ -79368,7 +79368,7 @@
     "place": {
       "name": "Williamsburg",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3346,
       "coord": [-92.0095079, 41.6612394],
@@ -79387,7 +79387,7 @@
     "place": {
       "name": "Williamsport",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 27754,
       "coord": [-77.0027671, 41.2493292],
@@ -79406,7 +79406,7 @@
     "place": {
       "name": "Williamston",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3819,
       "coord": [-84.2832798, 42.689151],
@@ -79441,7 +79441,7 @@
     "place": {
       "name": "Williamston",
       "state": "SC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4043,
       "coord": [-82.4779053, 34.6184471],
@@ -79460,7 +79460,7 @@
     "place": {
       "name": "Williamstown Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5286,
       "coord": [-84.3150662641554, 42.7264574],
@@ -79479,7 +79479,7 @@
     "place": {
       "name": "Williamstown",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2997,
       "coord": [-81.4488545, 39.4000046],
@@ -79498,7 +79498,7 @@
     "place": {
       "name": "Williston",
       "state": "ND",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29160,
       "coord": [-103.621814, 48.1465457],
@@ -79517,7 +79517,7 @@
     "place": {
       "name": "Willmar",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 21015,
       "coord": [-95.0435373, 45.1219492],
@@ -79544,7 +79544,7 @@
     "place": {
       "name": "Willowbrook",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9236,
       "coord": [-87.9358931, 41.7697533],
@@ -79563,7 +79563,7 @@
     "place": {
       "name": "Wilmerding",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1781,
       "coord": [-79.8100473, 40.3909023],
@@ -79582,7 +79582,7 @@
     "place": {
       "name": "Wilmette",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 28170,
       "coord": [-87.7193768, 42.0757315],
@@ -79617,7 +79617,7 @@
     "place": {
       "name": "Wilmington",
       "state": "DE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 70898,
       "coord": [-75.546589, 39.7459468],
@@ -79636,7 +79636,7 @@
     "place": {
       "name": "Wilmington",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5664,
       "coord": [-88.146143, 41.307515],
@@ -79655,7 +79655,7 @@
     "place": {
       "name": "Wilmington",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 123744,
       "coord": [-77.9447107, 34.2257282],
@@ -79678,7 +79678,7 @@
     "place": {
       "name": "Wilmington",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12664,
       "coord": [-83.8285375, 39.4453393],
@@ -79710,7 +79710,7 @@
     "place": {
       "name": "Wilson",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 49459,
       "coord": [-77.9155395, 35.7212689],
@@ -79745,7 +79745,7 @@
     "place": {
       "name": "Wilsonville",
       "state": "AL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1857,
       "coord": [-86.4835916, 33.234281],
@@ -79764,7 +79764,7 @@
     "place": {
       "name": "Wilton",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18503,
       "coord": [-73.4378988, 41.1953739],
@@ -79783,7 +79783,7 @@
     "place": {
       "name": "Winchester",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19134,
       "coord": [-84.1796503, 37.990079],
@@ -79802,7 +79802,7 @@
     "place": {
       "name": "Windom",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4798,
       "coord": [-95.1169366, 43.8663464],
@@ -79821,7 +79821,7 @@
     "place": {
       "name": "Windsor Heights",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5252,
       "coord": [-93.7087635, 41.6002144],
@@ -79840,7 +79840,7 @@
     "place": {
       "name": "Windsor Locks",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12613,
       "coord": [-72.643631, 41.9281305],
@@ -79859,7 +79859,7 @@
     "place": {
       "name": "Windsor",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 29492,
       "coord": [-72.6437022, 41.8525984],
@@ -79894,7 +79894,7 @@
     "place": {
       "name": "Windsor",
       "state": "MO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2775,
       "coord": [-93.5221545, 38.5322401],
@@ -79913,7 +79913,7 @@
     "place": {
       "name": "Windsor",
       "state": "ON",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 229660,
       "coord": [-82.9780695, 42.2858536],
@@ -79946,7 +79946,7 @@
     "place": {
       "name": "Winfield",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1033,
       "coord": [-91.4379843, 41.1287685],
@@ -79965,7 +79965,7 @@
     "place": {
       "name": "Winfield",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11777,
       "coord": [-96.9955919, 37.2397486],
@@ -79984,7 +79984,7 @@
     "place": {
       "name": "Winfield",
       "state": "WV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2397,
       "coord": [-81.8934676, 38.5331448],
@@ -80003,7 +80003,7 @@
     "place": {
       "name": "Wingate",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4055,
       "coord": [-80.4492319, 34.9843176],
@@ -80022,7 +80022,7 @@
     "place": {
       "name": "Winnebago County",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 171730,
       "coord": [-88.6516527, 44.0697014],
@@ -80041,7 +80041,7 @@
     "place": {
       "name": "Winnebago",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2940,
       "coord": [-89.242852, 42.266244],
@@ -80060,7 +80060,7 @@
     "place": {
       "name": "Winneconne",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2537,
       "coord": [-88.7126108, 44.1108154],
@@ -80079,7 +80079,7 @@
     "place": {
       "name": "Winnemucca",
       "state": "NV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8431,
       "coord": [-117.734802, 40.9724295],
@@ -80098,7 +80098,7 @@
     "place": {
       "name": "Winnetka",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12744,
       "coord": [-87.7365286, 42.1080703],
@@ -80125,7 +80125,7 @@
     "place": {
       "name": "Winnipeg",
       "state": "MB",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 749534,
       "coord": [-97.1384584, 49.8955367],
@@ -80158,7 +80158,7 @@
     "place": {
       "name": "Winnsboro",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 4862,
       "coord": [-91.7226934, 32.1618782],
@@ -80177,7 +80177,7 @@
     "place": {
       "name": "Winona",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26594,
       "coord": [-91.6392294, 44.0500054],
@@ -80196,7 +80196,7 @@
     "place": {
       "name": "Winslow",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9005,
       "coord": [-110.72575546422247, 35.016918950000004],
@@ -80215,7 +80215,7 @@
     "place": {
       "name": "Winston-Salem",
       "state": "NC",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 247945,
       "coord": [-80.2440518, 36.0998131],
@@ -80234,7 +80234,7 @@
     "place": {
       "name": "Winter Haven",
       "state": "FL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 44955,
       "coord": [-81.7328568, 28.0222435],
@@ -80253,7 +80253,7 @@
     "place": {
       "name": "Winter Park",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1033,
       "coord": [-105.780608154388, 39.882398],
@@ -80272,7 +80272,7 @@
     "place": {
       "name": "Winterset",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 5353,
       "coord": [-94.0135687, 41.3347631],
@@ -80291,7 +80291,7 @@
     "place": {
       "name": "Winterthur",
       "state": "ZH",
-      "country": "CH",
+      "country": "Switzerland",
       "type": "city",
       "pop": 111840,
       "coord": [8.7291498, 47.4991723],
@@ -80326,7 +80326,7 @@
     "place": {
       "name": "Winthrop Harbor",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 6705,
       "coord": [-87.8238485, 42.478934],
@@ -80345,7 +80345,7 @@
     "place": {
       "name": "Winthrop",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1332,
       "coord": [-94.3663674, 44.5430195],
@@ -80364,7 +80364,7 @@
     "place": {
       "name": "Wisconsin Dells",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2942,
       "coord": [-89.7715646, 43.6256168],
@@ -80391,7 +80391,7 @@
     "place": {
       "name": "Wisconsin Rapids",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 18877,
       "coord": [-89.8228767, 44.3917589],
@@ -80426,7 +80426,7 @@
     "place": {
       "name": "Wittenberg",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1011,
       "coord": [-89.1686531, 44.8227201],
@@ -80445,7 +80445,7 @@
     "place": {
       "name": "Wixom",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 17193,
       "coord": [-83.5363637, 42.5246873],
@@ -80464,7 +80464,7 @@
     "place": {
       "name": "Wolcott",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 16142,
       "coord": [-72.9867718, 41.6023196],
@@ -80483,7 +80483,7 @@
     "place": {
       "name": "Wolf Point",
       "state": "MT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2517,
       "coord": [-105.640557, 48.090574],
@@ -80502,7 +80502,7 @@
     "place": {
       "name": "Wonder Lake",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3973,
       "coord": [-88.3473126, 42.3852983],
@@ -80529,7 +80529,7 @@
     "place": {
       "name": "Wood Dale",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14012,
       "coord": [-87.9789562, 41.9633625],
@@ -80548,7 +80548,7 @@
     "place": {
       "name": "Wood River",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10464,
       "coord": [-90.0976069, 38.861159],
@@ -80567,7 +80567,7 @@
     "place": {
       "name": "Woodbridge",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 9087,
       "coord": [-73.0084385, 41.352597],
@@ -80586,7 +80586,7 @@
     "place": {
       "name": "Woodburn",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1551,
       "coord": [-84.8532963, 41.1253271],
@@ -80613,7 +80613,7 @@
     "place": {
       "name": "Woodbury",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 75102,
       "coord": [-92.9339449, 44.919896],
@@ -80632,7 +80632,7 @@
     "place": {
       "name": "Woodford County",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 38467,
       "coord": [-89.2074215, 40.8145359],
@@ -80651,7 +80651,7 @@
     "place": {
       "name": "Woodford County",
       "state": "KY",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 26871,
       "coord": [-84.7404532, 38.0686424],
@@ -80670,7 +80670,7 @@
     "place": {
       "name": "Woodlawn",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3916,
       "coord": [-84.4701407, 39.2519108],
@@ -80689,7 +80689,7 @@
     "place": {
       "name": "Woods Cross",
       "state": "UT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11410,
       "coord": [-111.892159, 40.8716501],
@@ -80708,7 +80708,7 @@
     "place": {
       "name": "Woodsboro",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1092,
       "coord": [-77.314706, 39.5331563],
@@ -80727,7 +80727,7 @@
     "place": {
       "name": "Woodstock",
       "state": "CT",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 8221,
       "coord": [-71.9739626, 41.9484307],
@@ -80754,7 +80754,7 @@
     "place": {
       "name": "Woodstock",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 287,
       "coord": [-83.5274254, 40.1739475],
@@ -80773,7 +80773,7 @@
     "place": {
       "name": "Woodville",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1376,
       "coord": [-92.2925599, 44.9511414],
@@ -80792,7 +80792,7 @@
     "place": {
       "name": "Woodward",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1346,
       "coord": [-93.9218956, 41.8569299],
@@ -80811,7 +80811,7 @@
     "place": {
       "name": "Woonsocket",
       "state": "RI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 41751,
       "coord": [-71.5147839, 42.0028761],
@@ -80830,7 +80830,7 @@
     "place": {
       "name": "Wooster",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 26557,
       "coord": [-81.9397733, 40.7980976],
@@ -80849,7 +80849,7 @@
     "place": {
       "name": "Worcester County",
       "state": "MD",
-      "country": "US",
+      "country": "United States",
       "type": "county",
       "pop": 52460,
       "coord": [-75.3319465, 38.2231182],
@@ -80868,7 +80868,7 @@
     "place": {
       "name": "Worcester",
       "state": "MA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 206518,
       "coord": [-71.8018877, 42.2625621],
@@ -80903,7 +80903,7 @@
     "place": {
       "name": "Wormleysburg",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3043,
       "coord": [-76.913863, 40.2628669],
@@ -80927,7 +80927,7 @@
     "place": {
       "name": "Worth",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10970,
       "coord": [-87.7974139, 41.6899779],
@@ -80946,7 +80946,7 @@
     "place": {
       "name": "Worthington",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 13947,
       "coord": [-95.5956434, 43.6205056],
@@ -80965,7 +80965,7 @@
     "place": {
       "name": "Worthington",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 14786,
       "coord": [-83.0179593, 40.0930945],
@@ -80992,7 +80992,7 @@
     "place": {
       "name": "Wrangell",
       "state": "AK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2127,
       "coord": [-132.381885, 56.470843],
@@ -81011,7 +81011,7 @@
     "place": {
       "name": "Wray",
       "state": "CO",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 2358,
       "coord": [-102.223253, 40.0758822],
@@ -81030,7 +81030,7 @@
     "place": {
       "name": "Wrightstown",
       "state": "WI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3179,
       "coord": [-88.1684289, 44.3310901],
@@ -81049,7 +81049,7 @@
     "place": {
       "name": "Wyandotte",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25058,
       "coord": [-83.1506436, 42.200409],
@@ -81076,7 +81076,7 @@
     "place": {
       "name": "Wyoming",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 76501,
       "coord": [-85.7057035, 42.9132581],
@@ -81095,7 +81095,7 @@
     "place": {
       "name": "Wyomissing",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 11114,
       "coord": [-75.9652117, 40.329537],
@@ -81114,7 +81114,7 @@
     "place": {
       "name": "Xenia",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25441,
       "coord": [-83.9296526, 39.6847822],
@@ -81133,7 +81133,7 @@
     "place": {
       "name": "Yakima",
       "state": "WA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 93637,
       "coord": [-120.510842, 46.601557],
@@ -81152,7 +81152,7 @@
     "place": {
       "name": "Yale",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1903,
       "coord": [-82.798263, 43.130026],
@@ -81171,7 +81171,7 @@
     "place": {
       "name": "Yankton",
       "state": "SD",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 15411,
       "coord": [-97.3967011, 42.8712938],
@@ -81190,7 +81190,7 @@
     "place": {
       "name": "Yates Center",
       "state": "KS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1352,
       "coord": [-95.7326925, 37.881541],
@@ -81209,7 +81209,7 @@
     "place": {
       "name": "Yazoo City",
       "state": "MS",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 10316,
       "coord": [-90.4056469, 32.8550965],
@@ -81228,7 +81228,7 @@
     "place": {
       "name": "Yellow Springs",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3697,
       "coord": [-83.8925234, 39.8045432],
@@ -81255,7 +81255,7 @@
     "place": {
       "name": "Yellowknife",
       "state": "NT",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 19569,
       "coord": [-114.377385, 62.4540807],
@@ -81282,7 +81282,7 @@
     "place": {
       "name": "Yellville",
       "state": "AR",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1178,
       "coord": [-92.6848876, 36.2261815],
@@ -81301,7 +81301,7 @@
     "place": {
       "name": "Yerington",
       "state": "NV",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3121,
       "coord": [-119.162989, 38.9855429],
@@ -81320,7 +81320,7 @@
     "place": {
       "name": "Yoe",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1058,
       "coord": [-76.6369116, 39.9089887],
@@ -81339,7 +81339,7 @@
     "place": {
       "name": "Yonkers",
       "state": "NY",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 211569,
       "coord": [-73.8987469, 40.9312099],
@@ -81370,7 +81370,7 @@
     "place": {
       "name": "York",
       "state": "England",
-      "country": "UK",
+      "country": "United Kingdom",
       "type": "city",
       "pop": 141685,
       "coord": [-1.0815361, 53.9590555],
@@ -81397,7 +81397,7 @@
     "place": {
       "name": "York",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 43932,
       "coord": [-76.727707, 39.9624624],
@@ -81416,7 +81416,7 @@
     "place": {
       "name": "Yorkton",
       "state": "SK",
-      "country": "CA",
+      "country": "Canada",
       "type": "city",
       "pop": 16343,
       "coord": [-102.461243, 51.212045],
@@ -81435,7 +81435,7 @@
     "place": {
       "name": "Yorkville",
       "state": "IL",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 22594,
       "coord": [-88.4472948, 41.6411409],
@@ -81483,7 +81483,7 @@
     "place": {
       "name": "Youngstown",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 60068,
       "coord": [-80.6520161, 41.1035786],
@@ -81510,7 +81510,7 @@
     "place": {
       "name": "Ypsilanti Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 55670,
       "coord": [-83.608886, 42.2033048],
@@ -81529,7 +81529,7 @@
     "place": {
       "name": "Ypsilanti",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 20648,
       "coord": [-83.613055, 42.2410562],
@@ -81570,7 +81570,7 @@
     "place": {
       "name": "Yukon",
       "state": "OK",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 23630,
       "coord": [-97.7625386, 35.5067259],
@@ -81589,7 +81589,7 @@
     "place": {
       "name": "Yuma",
       "state": "AZ",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 95548,
       "coord": [-114.624631, 32.705784],
@@ -81608,7 +81608,7 @@
     "place": {
       "name": "Yutan",
       "state": "NE",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 1347,
       "coord": [-96.3972555, 41.244922],
@@ -81627,7 +81627,7 @@
     "place": {
       "name": "Zachary",
       "state": "LA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 19316,
       "coord": [-91.1564961, 30.6485191],
@@ -81646,7 +81646,7 @@
     "place": {
       "name": "Zanesville",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 25158,
       "coord": [-82.0131924, 39.9403453],
@@ -81665,7 +81665,7 @@
     "place": {
       "name": "Zearing",
       "state": "IA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 528,
       "coord": [-93.2970164, 42.1612414],
@@ -81684,7 +81684,7 @@
     "place": {
       "name": "Zeeland Charter Township",
       "state": "MI",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 12008,
       "coord": [-85.9482444347645, 42.8113823],
@@ -81703,7 +81703,7 @@
     "place": {
       "name": "Zelienople",
       "state": "PA",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3870,
       "coord": [-80.1370795, 40.7957622],
@@ -81730,7 +81730,7 @@
     "place": {
       "name": "Zingst",
       "state": "MV",
-      "country": "DE",
+      "country": "Germany",
       "type": "city",
       "pop": 3098,
       "coord": [12.6821366, 54.4387302],
@@ -81749,7 +81749,7 @@
     "place": {
       "name": "Zionsville",
       "state": "IN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 30693,
       "coord": [-86.2616968, 39.950724],
@@ -81768,7 +81768,7 @@
     "place": {
       "name": "Zoar",
       "state": "OH",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 172,
       "coord": [-81.4223375, 40.6142286],
@@ -81795,7 +81795,7 @@
     "place": {
       "name": "Zuid-Holland",
       "state": "ZH",
-      "country": "NL",
+      "country": "Netherlands",
       "type": "state",
       "pop": 3804906,
       "coord": [4.100160336309779, 51.74944829197647],
@@ -81814,7 +81814,7 @@
     "place": {
       "name": "Zumbro Falls",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 155,
       "coord": [-92.4219702, 44.283207],
@@ -81833,7 +81833,7 @@
     "place": {
       "name": "Zumbrota",
       "state": "MN",
-      "country": "US",
+      "country": "United States",
       "type": "city",
       "pop": 3726,
       "coord": [-92.6708962305112, 44.29071725],
@@ -81852,7 +81852,7 @@
     "place": {
       "name": "Örebro",
       "state": "Örebro",
-      "country": "SE",
+      "country": "Sweden",
       "type": "city",
       "pop": 155989,
       "coord": [15.2151181, 59.2747287],

--- a/scripts/lib/optionValues.ts
+++ b/scripts/lib/optionValues.ts
@@ -2,7 +2,6 @@ import fs from "fs/promises";
 
 import { sortBy, without } from "lodash-es";
 
-import { COUNTRY_MAPPING } from "../../src/js/model/data";
 import {
   RawCoreLandUsePolicy,
   UNKNOWN_YEAR,
@@ -34,7 +33,7 @@ class OptionValues {
 
   #addPlace(place: RawPlace): void {
     this.placeType.add(place.type);
-    this.country.add(COUNTRY_MAPPING[place.country] ?? place.country);
+    this.country.add(place.country);
   }
 
   #addDate(date: string | null): void {

--- a/scripts/syncDirectus.ts
+++ b/scripts/syncDirectus.ts
@@ -35,6 +35,7 @@ import {
   ExtendedBenefitDistrict,
 } from "./lib/data";
 import { saveOptionValues } from "./lib/optionValues";
+import { COUNTRY_MAPPING } from "../src/js/model/data";
 
 // --------------------------------------------------------------------------
 // Read Directus
@@ -446,7 +447,8 @@ function combineData(
           place: {
             name: place.name!,
             state: place.state!,
-            country: place.country_code!,
+            country:
+              COUNTRY_MAPPING[place.country_code!] ?? place.country_code!,
             type: place.type!,
             pop: place.population!,
             repeal: place.complete_minimums_repeal!,

--- a/src/js/model/data.ts
+++ b/src/js/model/data.ts
@@ -57,7 +57,6 @@ export function placeIdToUrl(v: string): string {
 export function processPlace(placeId: PlaceId, raw: RawPlace): ProcessedPlace {
   return {
     ...raw,
-    country: COUNTRY_MAPPING[raw.country] ?? raw.country,
     url: placeIdToUrl(placeId),
   };
 }

--- a/tests/app/scorecard.test.ts
+++ b/tests/app/scorecard.test.ts
@@ -48,7 +48,7 @@ test("generateScorecard()", () => {
   const place: ProcessedPlace = {
     name: "My City",
     state: "AZ",
-    country: "US",
+    country: "United States",
     type: "city",
     pop: 245132,
     repeal: true,

--- a/tests/scripts/generateDataSet.test.ts
+++ b/tests/scripts/generateDataSet.test.ts
@@ -35,7 +35,7 @@ test("generate CSVs", async ({}, testInfo) => {
       place: {
         name: "My City",
         state: "NY",
-        country: "US",
+        country: "United States",
         type: "city",
         repeal: true,
         pop: 24104,
@@ -69,7 +69,7 @@ test("generate CSVs", async ({}, testInfo) => {
       place: {
         name: "Another Place",
         state: "CA",
-        country: "US",
+        country: "United States",
         type: "county",
         repeal: false,
         pop: 414,
@@ -93,7 +93,7 @@ test("generate CSVs", async ({}, testInfo) => {
       place: {
         name: "Place with PBD",
         state: "GDL",
-        country: "MX",
+        country: "Mexico",
         type: "city",
         repeal: false,
         pop: 5141414,

--- a/tests/scripts/generateDataSet.test.ts-snapshots/benefit-district.csv
+++ b/tests/scripts/generateDataSet.test.ts-snapshots/benefit-district.csv
@@ -1,2 +1,2 @@
 place,state,country,population,place_type,lat,long,status,reform_date,summary,num_citations,reporter,prn_url
-Place with PBD,GDL,MX,5141414,city,30.23,90.3,proposed,,A really cool district,0,Donald Shoup,https://parkingreform.org/place-with-pbd.html
+Place with PBD,GDL,Mexico,5141414,city,30.23,90.3,proposed,,A really cool district,0,Donald Shoup,https://parkingreform.org/place-with-pbd.html

--- a/tests/scripts/generateDataSet.test.ts-snapshots/maximums.csv
+++ b/tests/scripts/generateDataSet.test.ts-snapshots/maximums.csv
@@ -1,3 +1,3 @@
 place,state,country,population,place_type,lat,long,all_minimums_removed,status,reform_date,scope,land_uses,requirements,summary,num_citations,reporter,prn_url
-My City,NY,US,24104,city,14.23,44.23,TRUE,adopted,2022-02-13,citywide,commercial; other,by right,Maximums summary #1,2,Donald Shoup,https://parkingreform.org/my-city-details.html
-My City,NY,US,24104,city,14.23,44.23,TRUE,repealed,,regional,other,,Maximums summary #2,1,Donald Shoup,https://parkingreform.org/my-city-details.html
+My City,NY,United States,24104,city,14.23,44.23,TRUE,adopted,2022-02-13,citywide,commercial; other,by right,Maximums summary #1,2,Donald Shoup,https://parkingreform.org/my-city-details.html
+My City,NY,United States,24104,city,14.23,44.23,TRUE,repealed,,regional,other,,Maximums summary #2,1,Donald Shoup,https://parkingreform.org/my-city-details.html

--- a/tests/scripts/generateDataSet.test.ts-snapshots/overview-adopted.csv
+++ b/tests/scripts/generateDataSet.test.ts-snapshots/overview-adopted.csv
@@ -1,2 +1,2 @@
 place,state,country,place_type,population,lat,long,all_minimums_removed,minimums_removal,minimums_reduction,maximums,benefit_districts,prn_url
-My City,NY,US,city,24104,14.23,44.23,TRUE,FALSE,FALSE,TRUE,FALSE,https://parkingreform.org/my-city-details.html
+My City,NY,United States,city,24104,14.23,44.23,TRUE,FALSE,FALSE,TRUE,FALSE,https://parkingreform.org/my-city-details.html

--- a/tests/scripts/generateDataSet.test.ts-snapshots/overview-proposed.csv
+++ b/tests/scripts/generateDataSet.test.ts-snapshots/overview-proposed.csv
@@ -1,3 +1,3 @@
 place,state,country,place_type,population,lat,long,minimums_removal,minimums_reduction,maximums,benefit_districts,prn_url
-Another Place,CA,US,county,414,24.23,80.3,TRUE,FALSE,FALSE,FALSE,https://parkingreform.org/another-place.html
-Place with PBD,GDL,MX,city,5141414,30.23,90.3,FALSE,FALSE,FALSE,TRUE,https://parkingreform.org/place-with-pbd.html
+Another Place,CA,United States,county,414,24.23,80.3,TRUE,FALSE,FALSE,FALSE,https://parkingreform.org/another-place.html
+Place with PBD,GDL,Mexico,city,5141414,30.23,90.3,FALSE,FALSE,FALSE,TRUE,https://parkingreform.org/place-with-pbd.html

--- a/tests/scripts/generateDataSet.test.ts-snapshots/overview-repealed.csv
+++ b/tests/scripts/generateDataSet.test.ts-snapshots/overview-repealed.csv
@@ -1,2 +1,2 @@
 place,state,country,place_type,population,lat,long,minimums_removal,minimums_reduction,maximums,benefit_districts,prn_url
-My City,NY,US,city,24104,14.23,44.23,FALSE,FALSE,TRUE,FALSE,https://parkingreform.org/my-city-details.html
+My City,NY,United States,city,24104,14.23,44.23,FALSE,FALSE,TRUE,FALSE,https://parkingreform.org/my-city-details.html

--- a/tests/scripts/optionValues.test.ts
+++ b/tests/scripts/optionValues.test.ts
@@ -18,7 +18,7 @@ test("determineOptionValues()", () => {
     {
       place: {
         ...commonPlace,
-        country: "US",
+        country: "United States",
         type: "city",
       },
       rm_min: [
@@ -41,7 +41,7 @@ test("determineOptionValues()", () => {
     {
       place: {
         ...commonPlace,
-        country: "BR",
+        country: "Brazil",
         type: "country",
       },
       reduce_min: [


### PR DESCRIPTION
Prework for https://github.com/ParkingReformNetwork/reform-map/issues/484. I realized it is much clearer for the user to use the full country code, as initials like `CI` (Cook Islands) are not clear. Turns out, our app code already used the full name! This PR only changes our `data/core.json` file, which is more about refactoring.

Our URL encoder for sharing links still uses the code.