### PR TITLE
Make app resilient to PlaceId having a country

### DIFF
--- a/eleventy.config.ts
+++ b/eleventy.config.ts
@@ -11,7 +11,7 @@ import {
   ProcessedCompleteLandUsePolicy,
   readProcessedCompleteData,
 } from "./scripts/lib/data.js";
-import { escapePlaceId } from "./src/js/model/data.js";
+import { escapePlaceId } from "./src/js/model/placeId.js";
 import { ReformStatus } from "./src/js/model/types.js";
 
 function dateLabel(status: ReformStatus): string {

--- a/scripts/syncDirectus.ts
+++ b/scripts/syncDirectus.ts
@@ -36,6 +36,7 @@ import {
 } from "./lib/data";
 import { saveOptionValues } from "./lib/optionValues";
 import { COUNTRY_MAPPING } from "../src/js/model/data";
+import { determinePlaceId } from "../src/js/model/placeId";
 
 // --------------------------------------------------------------------------
 // Read Directus
@@ -61,9 +62,7 @@ async function readPlacesAndEnsureCoordinates(
   const directusIdToStringId: Record<number, PlaceStringId> = {};
   const stringIdToPlace: Record<PlaceStringId, Partial<DirectusPlace>> = {};
   for (const record of records) {
-    const stringId = record.state
-      ? `${record.name}, ${record.state}`
-      : record.name;
+    const stringId = determinePlaceId(record);
 
     if (!record.coordinates) {
       console.log(`Getting coordinates for ${stringId}`);

--- a/src/js/filter-features/counters.ts
+++ b/src/js/filter-features/counters.ts
@@ -7,7 +7,8 @@ import {
   PolicyTypeFilter,
 } from "../state/FilterState";
 import { PlaceId, PlaceType, PolicyType, ReformStatus } from "../model/types";
-import { placeIdToUrl, COUNTRIES_PREFIXED_BY_THE } from "../model/data";
+import { COUNTRIES_PREFIXED_BY_THE } from "../model/data";
+import { placeIdToUrl } from "../model/placeId";
 import type { ViewState } from "../layout/viewToggle";
 
 export function determinePlaceDescription(

--- a/src/js/map-features/markers.ts
+++ b/src/js/map-features/markers.ts
@@ -5,6 +5,7 @@ import { PlaceFilterManager } from "../state/FilterState";
 import { ViewStateObservable } from "../layout/viewToggle";
 import type { PlaceId } from "../model/types";
 import { radiusGivenZoom, determineIsPrimary } from "./markerUtils";
+import { stripCountryFromPlaceId } from "../model/placeId";
 
 const PRIMARY_MARKER_STYLE = {
   weight: 1,
@@ -21,10 +22,13 @@ const SECONDARY_MARKER_STYLE = {
   fillOpacity: 1,
 } as const;
 
+/** We store the placeId on the marker to know which place a Marker corresponds to. */
+export type MarkerWithPlaceId = CircleMarker & { placeId: PlaceId };
+
 function updatePlaceVisibility(
   currentlyVisiblePlaceIds: Set<string>,
   newVisiblePlaceIds: Set<PlaceId>,
-  placesToMarkers: Record<string, CircleMarker>,
+  placesToMarkers: Record<string, MarkerWithPlaceId>,
   markerGroup: FeatureGroup,
 ): void {
   // Remove markers no longer visible.
@@ -48,17 +52,21 @@ export default function initPlaceMarkers(
   map: Map,
   viewToggle: ViewStateObservable,
 ): FeatureGroup {
-  const placesToMarkers: Record<string, CircleMarker> = Object.entries(
+  const placesToMarkers: Record<string, MarkerWithPlaceId> = Object.entries(
     filterManager.entries,
-  ).reduce((acc: Record<string, CircleMarker>, [placeId, entry]) => {
+  ).reduce((acc: Record<string, MarkerWithPlaceId>, [placeId, entry]) => {
     const [long, lat] = entry.place.coord;
     const isPrimary = determineIsPrimary(entry);
     const style = isPrimary ? PRIMARY_MARKER_STYLE : SECONDARY_MARKER_STYLE;
     const marker = new CircleMarker([lat, long], {
       ...style,
       radius: radiusGivenZoom({ zoom: map.getZoom(), isPrimary }),
-    });
-    marker.bindTooltip(placeId);
+    }) as MarkerWithPlaceId;
+    marker.placeId = placeId;
+
+    // The tooltip is the text shown on hover. We strip the country
+    // to make it less verbose.
+    marker.bindTooltip(stripCountryFromPlaceId(placeId));
 
     acc[placeId] = marker;
     return acc;

--- a/src/js/map-features/scorecard.ts
+++ b/src/js/map-features/scorecard.ts
@@ -6,6 +6,7 @@ import Observable from "../state/Observable";
 import { PlaceFilterManager } from "../state/FilterState";
 import { ViewStateObservable } from "../layout/viewToggle";
 import { determinePolicyTypeStatuses } from "../model/data";
+import type { MarkerWithPlaceId } from "./markers";
 
 export function generateScorecard(
   entry: ProcessedCoreEntry,
@@ -109,7 +110,7 @@ export default function initScorecard(
 
   // Clicking a city marker opens up the scorecard.
   markerGroup.on("click", (e) => {
-    const placeId = e.sourceTarget.getTooltip().getContent();
+    const placeId = (e.sourceTarget as MarkerWithPlaceId).placeId;
     scorecardState.setValue({
       type: "visible",
       placeId,

--- a/src/js/model/data.ts
+++ b/src/js/model/data.ts
@@ -1,3 +1,4 @@
+import { placeIdToUrl } from "./placeId";
 import {
   PlaceId,
   ProcessedCoreEntry,
@@ -45,14 +46,6 @@ export const COUNTRY_MAPPING: Partial<Record<string, string>> = {
   US: "United States",
   ZA: "South Africa",
 };
-
-export function escapePlaceId(v: string): string {
-  return v.replace(/ /g, "").replace(",", "_");
-}
-
-export function placeIdToUrl(v: string): string {
-  return `https://parkingreform.org/mandates-map/city_detail/${escapePlaceId(v)}.html`;
-}
 
 export function processPlace(placeId: PlaceId, raw: RawPlace): ProcessedPlace {
   return {

--- a/src/js/model/placeId.ts
+++ b/src/js/model/placeId.ts
@@ -1,0 +1,27 @@
+import type { PlaceId } from "./types";
+
+export function determinePlaceId(place: {
+  name: string;
+  state: string | null;
+}): PlaceId {
+  const { name, state } = place;
+  return state ? `${name}, ${state}` : name;
+}
+
+export function stripCountryFromPlaceId(placeId: PlaceId): string {
+  const [place, state, ..._rest] = placeId.split(", ");
+  return state ? `${place}, ${state}` : place;
+}
+
+/**
+ * Normalize the place ID for being used in a URL.
+ *
+ * This strips the country so that our historical details pages keep working.
+ */
+export function escapePlaceId(placeId: PlaceId): string {
+  return stripCountryFromPlaceId(placeId).replace(/ /g, "").replace(",", "_");
+}
+
+export function placeIdToUrl(placeId: PlaceId): string {
+  return `https://parkingreform.org/mandates-map/city_detail/${escapePlaceId(placeId)}.html`;
+}

--- a/tests/app/data.test.ts
+++ b/tests/app/data.test.ts
@@ -1,21 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import {
-  escapePlaceId,
-  placeIdToUrl,
-  getFilteredIndexes,
-} from "../../src/js/model/data";
-
-test("escapePlaceID", () => {
-  expect(escapePlaceId("Tucson, AZ")).toEqual("Tucson_AZ");
-  expect(escapePlaceId("St. Lucia, AZ")).toEqual("St.Lucia_AZ");
-});
-
-test("placeIdToUrl", () => {
-  expect(placeIdToUrl("Tucson, AZ")).toEqual(
-    "https://parkingreform.org/mandates-map/city_detail/Tucson_AZ.html",
-  );
-});
+import { getFilteredIndexes } from "../../src/js/model/data";
 
 test("getFilteredIndexes", () => {
   expect(getFilteredIndexes(["a", "b", "c"], (x) => x !== "b")).toEqual([0, 2]);

--- a/tests/app/placeId.test.ts
+++ b/tests/app/placeId.test.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+import {
+  escapePlaceId,
+  placeIdToUrl,
+  determinePlaceId,
+  stripCountryFromPlaceId,
+} from "../../src/js/model/placeId";
+
+test("determinePlaceId", () => {
+  expect(determinePlaceId({ name: "Tucson", state: "AZ" })).toEqual(
+    "Tucson, AZ",
+  );
+  expect(determinePlaceId({ name: "Tucson", state: null })).toEqual("Tucson");
+});
+
+test("stripCountryFromPlaceId", () => {
+  expect(stripCountryFromPlaceId("Tucson")).toEqual("Tucson");
+  expect(stripCountryFromPlaceId("Tucson, AZ")).toEqual("Tucson, AZ");
+  expect(stripCountryFromPlaceId("Tucson, AZ, United States")).toEqual(
+    "Tucson, AZ",
+  );
+  expect(
+    stripCountryFromPlaceId("Tucson, AZ, United States, another string"),
+  ).toEqual("Tucson, AZ");
+});
+
+test("escapePlaceID", () => {
+  expect(escapePlaceId("Tucson, AZ")).toEqual("Tucson_AZ");
+  expect(escapePlaceId("St. Lucia, AZ")).toEqual("St.Lucia_AZ");
+  expect(escapePlaceId("St. Lucia, AZ, United States")).toEqual("St.Lucia_AZ");
+});
+
+test("placeIdToUrl", () => {
+  expect(placeIdToUrl("Tucson, AZ")).toEqual(
+    "https://parkingreform.org/mandates-map/city_detail/Tucson_AZ.html",
+  );
+});


### PR DESCRIPTION
Prep for https://github.com/ParkingReformNetwork/reform-map/issues/484. This fixes two places that would break when we add the country to the place ID:

* Scorecards and markers. We want to avoid the country being in the marker's tooltip because it's overly verbose. But the scorecard wad epending on the tooltip to determine what place the marker corresponds to. This is now decoupled.
* URL for the details page. We shouldn't change the URL to incorporate the country until we have redirects set up and the change is fully ready.