### PR TITLE
Add script to generate client-side redirects

### DIFF
--- a/.github/workflows/deploy-static-pages.yaml
+++ b/.github/workflows/deploy-static-pages.yaml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Generate HTML pages
         run: npm run gen-html
+      - name: Generate redirects
+        run: npm run gen-redirects
       - name: Archive city_detail/ contents
         run: |
           cd city_detail

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -26,4 +26,5 @@ jobs:
       - name: Check static generation works
         run: |
           npm run gen-html
+          npm run gen-redirects
           npm run gen-data-set

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint": "prettier --check . && eslint scripts/ tests/ src/",
     "gen-data-set": "tsx scripts/generateDataSet.ts",
     "gen-html": "tsx node_modules/@11ty/eleventy/cmd.cjs --config=eleventy.config.ts",
+    "gen-redirects": "tsx scripts/generateRedirects.ts",
     "sync-directus": "tsx scripts/syncDirectus.ts",
     "broken-links": "tsx scripts/brokenLinks.ts",
     "serve-dist": "cd dist; http-server",

--- a/scripts/generateRedirects.ts
+++ b/scripts/generateRedirects.ts
@@ -1,0 +1,88 @@
+/* eslint-disable no-console */
+
+import * as fs from "fs/promises";
+import * as path from "path";
+
+const REDIRECTS = {
+  NewZealand_NZ: "NewZealand",
+} as const;
+
+const BASE_URL = "https://parkingreform.org/mandates-map/city_detail/";
+const OUTPUT_DIR = "city_detail";
+
+function createRedirectHTML(targetUrl: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="refresh" content="0; url=${targetUrl}">
+    <link rel="canonical" href="${targetUrl}">
+    <title>Redirecting...</title>
+    <style>
+        body { 
+            font-family: Arial, sans-serif; 
+            text-align: center; 
+            padding: 50px; 
+            background-color: #f5f5f5; 
+        }
+        .redirect-message { 
+            max-width: 600px; 
+            margin: 0 auto; 
+            padding: 20px; 
+            background: white; 
+            border-radius: 8px; 
+            box-shadow: 0 2px 10px rgba(0,0,0,0.1); 
+        }
+    </style>
+</head>
+<body>
+    <div class="redirect-message">
+        <h1>Redirecting...</h1>
+        <p>You are being redirected to: <a href="${targetUrl}">${targetUrl}</a></p>
+        <p>If you are not redirected automatically, please click the link above.</p>
+    </div>
+    <script>
+        // Immediate redirect
+        window.location.replace("${targetUrl}");
+    </script>
+</body>
+</html>`;
+}
+
+async function main(): Promise<void> {
+  let successCount = 0;
+  let errorCount = 0;
+  await Promise.all(
+    Object.entries(REDIRECTS).map(async ([oldPath, newPath]) => {
+      const targetUrl = `${BASE_URL}${newPath}.html`;
+      const htmlContent = createRedirectHTML(targetUrl);
+      const filePath = path.join(OUTPUT_DIR, `${oldPath}.html`);
+
+      try {
+        await fs.writeFile(filePath, htmlContent, "utf8");
+        successCount += 1;
+      } catch (error) {
+        console.error(`❌ Failed to create redirect for ${oldPath}:`, error);
+        errorCount += 1;
+      }
+    }),
+  );
+
+  console.log("\n📊 Summary:");
+  console.log(`✅ Successfully created: ${successCount} redirects`);
+  if (errorCount > 0) {
+    console.log(`❌ Failed: ${errorCount} redirects`);
+  }
+
+  if (successCount > 0) {
+    console.log(`\n📁 Files written to: ${path.resolve(OUTPUT_DIR)}`);
+  }
+}
+
+if (process.env.NODE_ENV !== "test") {
+  main().catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
This is to unblock https://github.com/ParkingReformNetwork/reform-map/issues/484 and to also fix some existing legacy pages we have that should be redirected. 

We prefer server-side redirects, but I'm going to start with client-side redirects until everything is fully stable. Then, we will graduate to server-side redirects.

This first PR only adds the generic infrastructure. A follow up will find all files that need redirects currently.