### PR TITLE
Search splits out place, state, and country

### DIFF
--- a/src/js/search.ts
+++ b/src/js/search.ts
@@ -44,10 +44,17 @@ function initSearchPopup(): SearchPopupObservable {
 }
 
 export default function initSearch(filterManager: PlaceFilterManager): void {
-  const places = Object.keys(filterManager.entries).map((placeId) => ({
-    value: placeId,
-    label: placeId,
-  }));
+  const places = Object.entries(filterManager.entries).map(
+    ([placeId, entry]) => ({
+      value: placeId,
+      label: placeId,
+      customProperties: {
+        place: entry.place.name,
+        state: entry.place.state ?? "",
+        country: entry.place.country,
+      },
+    }),
+  );
   const htmlElement = document.querySelector(".search");
   if (!htmlElement) return;
 
@@ -59,6 +66,11 @@ export default function initSearch(filterManager: PlaceFilterManager): void {
     allowHTML: false,
     itemSelectText: "",
     searchEnabled: true,
+    searchFields: [
+      "customProperties.place",
+      "customProperties.state",
+      "customProperties.country",
+    ],
   });
 
   // Set initial state.


### PR DESCRIPTION
Part of https://github.com/ParkingReformNetwork/reform-map/issues/484. We want the country to be included in search. But we can improve Choices.js's algorithm by treating the place, state, and country as distinct strings so that you can do something like type "Germany" and get all places in Germany.

This doesn't yet change the value we show to the user, which will be a follow up.