### PR TITLE
Use a new, safer URL encoding

### DIFF
--- a/src/js/model/placeId.ts
+++ b/src/js/model/placeId.ts
@@ -42,11 +42,15 @@ export function stripCountryFromPlaceId(placeId: PlaceId): string {
 
 /**
  * Normalize the place ID for being used in a URL.
- *
- * This strips the country so that our historical details pages keep working.
  */
 export function encodePlaceId(placeId: PlaceId): string {
-  return stripCountryFromPlaceId(placeId).replace(/ /g, "").replace(",", "_");
+  return placeId
+    .normalize('NFD')  // Decompose characters (ã → a + ˜)
+    .replace(/[\u0300-\u036f]/g, '')  // Remove combining diacritics
+    .toLowerCase()
+    .replace(/'/g, '') // Remove '
+    .replace(/[^a-z0-9]+/g, '-')  // Replace non-alphanumeric with hyphens
+    .replace(/^-+|-+$/g, '');  // Trim hyphens
 }
 
 export function encodedPlaceToUrl(encodedPlace: string): string {

--- a/tests/app/placeId.test.ts
+++ b/tests/app/placeId.test.ts
@@ -104,9 +104,10 @@ test("stripCountryFromPlaceId", () => {
 });
 
 test("encodePlaceId", () => {
-  expect(encodePlaceId("Tucson, AZ")).toEqual("Tucson_AZ");
-  expect(encodePlaceId("St. Lucia, AZ")).toEqual("St.Lucia_AZ");
-  expect(encodePlaceId("St. Lucia, AZ, United States")).toEqual("St.Lucia_AZ");
+  expect(encodePlaceId("Tucson, Arizona, United States")).toEqual("tucson-arizona-united-states");
+  expect(encodePlaceId("São Paulo, Brazil")).toEqual("sao-paulo-brazil");
+  expect(encodePlaceId("Creek's Hill, Montréal")).toEqual("creeks-hill-montreal");
+  expect(encodePlaceId("Șäñțô  ,")).toEqual("santo");
 });
 
 test("encodedPlaceToUrl", () => {


### PR DESCRIPTION
Our old URLs were weird:

* capital letters
* used `_` rather than `-`
* discouraged characters like `'` and `ã`

Claude wrote some code to use a more reliable format. Thanks to https://github.com/ParkingReformNetwork/reform-map/pull/806, this only impacts brand new places.