### PR TITLE
Sync improved data modeling for states and non-US places

### DIFF
--- a/data/core.json
+++ b/data/core.json
@@ -2549,7 +2549,7 @@
   "Armadale, Western Australia, Australia": {
     "place": {
       "name": "Armadale",
-      "state": "WA",
+      "state": "Western Australia",
       "country": "Australia",
       "type": "city",
       "encoded": "Armadale_WA",
@@ -3277,7 +3277,7 @@
   "Augsburg, Bavaria, Germany": {
     "place": {
       "name": "Augsburg",
-      "state": "BY",
+      "state": "Bavaria",
       "country": "Germany",
       "type": "city",
       "encoded": "Augsburg_BY",
@@ -4356,7 +4356,7 @@
   "Basel, Basel-Stadt, Switzerland": {
     "place": {
       "name": "Basel",
-      "state": "BS",
+      "state": "Basel-Stadt",
       "country": "Switzerland",
       "type": "city",
       "encoded": "Basel_BS",
@@ -5050,7 +5050,7 @@
   "Beijing, China": {
     "place": {
       "name": "Beijing",
-      "state": "BJ",
+      "state": null,
       "country": "China",
       "type": "city",
       "encoded": "Beijing_BJ",
@@ -6147,26 +6147,6 @@
       }
     ]
   },
-  "Berlin, Germany": {
-    "place": {
-      "name": "Berlin",
-      "state": "BE",
-      "country": "Germany",
-      "type": "city",
-      "encoded": "Berlin_BE",
-      "pop": 3576873,
-      "coord": [13.4349112, 52.5103817],
-      "repeal": true
-    },
-    "rm_min": [
-      {
-        "status": "adopted",
-        "scope": ["citywide"],
-        "land": ["all uses"],
-        "date": "1997"
-      }
-    ]
-  },
   "Berlin, CT, United States": {
     "place": {
       "name": "Berlin",
@@ -6184,6 +6164,26 @@
         "scope": ["city center / business district", "citywide"],
         "land": ["all uses", "other", "residential, all uses"],
         "date": "2020-08-20"
+      }
+    ]
+  },
+  "Berlin, Germany": {
+    "place": {
+      "name": "Berlin",
+      "state": null,
+      "country": "Germany",
+      "type": "city",
+      "encoded": "Berlin_BE",
+      "pop": 3576873,
+      "coord": [13.4349112, 52.5103817],
+      "repeal": true
+    },
+    "rm_min": [
+      {
+        "status": "adopted",
+        "scope": ["citywide"],
+        "land": ["all uses"],
+        "date": "1997"
       }
     ]
   },
@@ -7660,7 +7660,7 @@
   "Bonn, North Rhine-Westphalia, Germany": {
     "place": {
       "name": "Bonn",
-      "state": "NW",
+      "state": "North Rhine-Westphalia",
       "country": "Germany",
       "type": "city",
       "encoded": "Bonn_NW",
@@ -8510,7 +8510,7 @@
   "Bremerhaven, Bremen, Germany": {
     "place": {
       "name": "Bremerhaven",
-      "state": "HB",
+      "state": "Bremen",
       "country": "Germany",
       "type": "city",
       "encoded": "Bremerhaven_HB",
@@ -8846,7 +8846,7 @@
   "Brisbane, Queensland, Australia": {
     "place": {
       "name": "Brisbane",
-      "state": "QLD",
+      "state": "Queensland",
       "country": "Australia",
       "type": "city",
       "encoded": "Brisbane_QLD",
@@ -9883,7 +9883,7 @@
   "Burnie, Tasmania, Australia": {
     "place": {
       "name": "Burnie",
-      "state": "TAS",
+      "state": "Tasmania",
       "country": "Australia",
       "type": "city",
       "encoded": "Burnie_TAS",
@@ -10235,7 +10235,7 @@
   "California, United States": {
     "place": {
       "name": "California",
-      "state": "CA",
+      "state": null,
       "country": "United States",
       "type": "state",
       "encoded": "California_CA",
@@ -11047,7 +11047,7 @@
   "Cape Town, Western Cape, South Africa": {
     "place": {
       "name": "Cape Town",
-      "state": "WC",
+      "state": "Western Cape",
       "country": "South Africa",
       "type": "city",
       "encoded": "CapeTown_WC",
@@ -14102,7 +14102,7 @@
   "Chur, Grisons, Switzerland": {
     "place": {
       "name": "Chur",
-      "state": "GR",
+      "state": "Grisons",
       "country": "Switzerland",
       "type": "city",
       "encoded": "Chur_GR",
@@ -15882,7 +15882,7 @@
   "Colorado, United States": {
     "place": {
       "name": "Colorado",
-      "state": "CO",
+      "state": null,
       "country": "United States",
       "type": "state",
       "encoded": "Colorado_CO",
@@ -16497,7 +16497,7 @@
   "Connecticut, United States": {
     "place": {
       "name": "Connecticut",
-      "state": "CT",
+      "state": null,
       "country": "United States",
       "type": "state",
       "encoded": "Connecticut_CT",
@@ -17150,7 +17150,7 @@
   "Cottbus, Brandenburg, Germany": {
     "place": {
       "name": "Cottbus",
-      "state": "BB",
+      "state": "Brandenburg",
       "country": "Germany",
       "type": "city",
       "encoded": "Cottbus_BB",
@@ -20000,7 +20000,7 @@
   "Derwent Valley, Tasmania, Australia": {
     "place": {
       "name": "Derwent Valley",
-      "state": "TAS",
+      "state": "Tasmania",
       "country": "Australia",
       "type": "city",
       "encoded": "DerwentValley_TAS",
@@ -20306,7 +20306,7 @@
   "Dietzenbach, Hesse, Germany": {
     "place": {
       "name": "Dietzenbach",
-      "state": "HE",
+      "state": "Hesse",
       "country": "Germany",
       "type": "city",
       "encoded": "Dietzenbach_HE",
@@ -20574,7 +20574,7 @@
   "Dorset, Tasmania, Australia": {
     "place": {
       "name": "Dorset",
-      "state": "TAS",
+      "state": "Tasmania",
       "country": "Australia",
       "type": "city",
       "encoded": "Dorset_TAS",
@@ -20899,7 +20899,7 @@
   "Dresden, Saxony, Germany": {
     "place": {
       "name": "Dresden",
-      "state": "SN",
+      "state": "Saxony",
       "country": "Germany",
       "type": "city",
       "encoded": "Dresden_SN",
@@ -26137,7 +26137,7 @@
   "Flensburg, Schleswig-Holstein, Germany": {
     "place": {
       "name": "Flensburg",
-      "state": "SH",
+      "state": "Schleswig-Holstein",
       "country": "Germany",
       "type": "city",
       "encoded": "Flensburg_SH",
@@ -26317,7 +26317,7 @@
   "Florida, United States": {
     "place": {
       "name": "Florida",
-      "state": "FL",
+      "state": null,
       "country": "United States",
       "type": "state",
       "encoded": "Florida_FL",
@@ -27624,7 +27624,7 @@
   "Frankfurt, Hesse, Germany": {
     "place": {
       "name": "Frankfurt",
-      "state": "HE",
+      "state": "Hesse",
       "country": "Germany",
       "type": "city",
       "encoded": "Frankfurt_HE",
@@ -28109,7 +28109,7 @@
   "Fremantle, Western Australia, Australia": {
     "place": {
       "name": "Fremantle",
-      "state": "WA",
+      "state": "Western Australia",
       "country": "Australia",
       "type": "city",
       "encoded": "Fremantle_WA",
@@ -35165,7 +35165,7 @@
   "Hobart, Tasmania, Australia": {
     "place": {
       "name": "Hobart",
-      "state": "TAS",
+      "state": "Tasmania",
       "country": "Australia",
       "type": "city",
       "encoded": "Hobart_TAS",
@@ -35425,7 +35425,7 @@
   "Hong Kong, China": {
     "place": {
       "name": "Hong Kong",
-      "state": "HK",
+      "state": null,
       "country": "China",
       "type": "state",
       "encoded": "HongKong_HK",
@@ -36724,7 +36724,7 @@
   "Ingolstadt, Bavaria, Germany": {
     "place": {
       "name": "Ingolstadt",
-      "state": "BY",
+      "state": "Bavaria",
       "country": "Germany",
       "type": "city",
       "encoded": "Ingolstadt_BY",
@@ -38037,7 +38037,7 @@
   "Johannesburg, Gauteng, South Africa": {
     "place": {
       "name": "Johannesburg",
-      "state": "GP",
+      "state": "Gauteng",
       "country": "South Africa",
       "type": "city",
       "encoded": "Johannesburg_GP",
@@ -38433,7 +38433,7 @@
   "Jönköping, Jönköping County, Sweden": {
     "place": {
       "name": "Jönköping",
-      "state": "Jönköping",
+      "state": "Jönköping County",
       "country": "Sweden",
       "type": "city",
       "encoded": "Jönköping_Jönköping",
@@ -38727,7 +38727,7 @@
   "Kassel, Hesse, Germany": {
     "place": {
       "name": "Kassel",
-      "state": "HE",
+      "state": "Hesse",
       "country": "Germany",
       "type": "city",
       "encoded": "Kassel_HE",
@@ -38855,7 +38855,7 @@
   "Kempten, Bavaria, Germany": {
     "place": {
       "name": "Kempten",
-      "state": "BY",
+      "state": "Bavaria",
       "country": "Germany",
       "type": "city",
       "encoded": "Kempten_BY",
@@ -39863,7 +39863,7 @@
   "Koblenz, Rhineland-Palatinate, Germany": {
     "place": {
       "name": "Koblenz",
-      "state": "RP",
+      "state": "Rhineland-Palatinate",
       "country": "Germany",
       "type": "city",
       "encoded": "Koblenz_RP",
@@ -39939,7 +39939,7 @@
   "Konstanz, Baden-Württemberg, Germany": {
     "place": {
       "name": "Konstanz",
-      "state": "BW",
+      "state": "Baden-Württemberg",
       "country": "Germany",
       "type": "city",
       "encoded": "Konstanz_BW",
@@ -41520,7 +41520,7 @@
   "Landshut, Bavaria, Germany": {
     "place": {
       "name": "Landshut",
-      "state": "BY",
+      "state": "Bavaria",
       "country": "Germany",
       "type": "city",
       "encoded": "Landshut_BY",
@@ -43346,7 +43346,7 @@
   "Lindau, Bavaria, Germany": {
     "place": {
       "name": "Lindau",
-      "state": "BY",
+      "state": "Bavaria",
       "country": "Germany",
       "type": "city",
       "encoded": "Lindau_BY",
@@ -45339,7 +45339,7 @@
   "Maharashtra, India": {
     "place": {
       "name": "Maharashtra",
-      "state": "MH",
+      "state": null,
       "country": "India",
       "type": "state",
       "encoded": "Maharashtra_MH",
@@ -45411,7 +45411,7 @@
   "Maine, United States": {
     "place": {
       "name": "Maine",
-      "state": "ME",
+      "state": null,
       "country": "United States",
       "type": "state",
       "encoded": "Maine_ME",
@@ -48569,7 +48569,7 @@
   "Mexico City, Mexico": {
     "place": {
       "name": "Mexico City",
-      "state": "DF",
+      "state": null,
       "country": "Mexico",
       "type": "city",
       "encoded": "MexicoCity_DF",
@@ -50384,7 +50384,7 @@
   "Montana, United States": {
     "place": {
       "name": "Montana",
-      "state": "MT",
+      "state": null,
       "country": "United States",
       "type": "state",
       "encoded": "Montana_MT",
@@ -52649,7 +52649,7 @@
   "München, Bavaria, Germany": {
     "place": {
       "name": "München",
-      "state": "BY",
+      "state": "Bavaria",
       "country": "Germany",
       "type": "city",
       "encoded": "München_BY",
@@ -52669,7 +52669,7 @@
   "Münster, North Rhine-Westphalia, Germany": {
     "place": {
       "name": "Münster",
-      "state": "NW",
+      "state": "North Rhine-Westphalia",
       "country": "Germany",
       "type": "city",
       "encoded": "Münster_NW",
@@ -53723,7 +53723,7 @@
   "New Hampshire, United States": {
     "place": {
       "name": "New Hampshire",
-      "state": "NH",
+      "state": null,
       "country": "United States",
       "type": "state",
       "encoded": "NewHampshire_NH",
@@ -55214,7 +55214,7 @@
   "North Carolina, United States": {
     "place": {
       "name": "North Carolina",
-      "state": "NC",
+      "state": null,
       "country": "United States",
       "type": "state",
       "encoded": "NorthCarolina_NC",
@@ -55715,7 +55715,7 @@
   "Northern Territory, Australia": {
     "place": {
       "name": "Northern Territory",
-      "state": "NT",
+      "state": null,
       "country": "Australia",
       "type": "state",
       "encoded": "NorthernTerritory_NT",
@@ -56161,7 +56161,7 @@
   "Nürnberg, Bavaria, Germany": {
     "place": {
       "name": "Nürnberg",
-      "state": "BY",
+      "state": "Bavaria",
       "country": "Germany",
       "type": "city",
       "encoded": "Nürnberg_BY",
@@ -56637,7 +56637,7 @@
   "Ochtrup, North Rhine-Westphalia, Germany": {
     "place": {
       "name": "Ochtrup",
-      "state": "NW",
+      "state": "North Rhine-Westphalia",
       "country": "Germany",
       "type": "city",
       "encoded": "Ochtrup_NW",
@@ -56851,7 +56851,7 @@
   "Oklahoma, United States": {
     "place": {
       "name": "Oklahoma",
-      "state": "OK",
+      "state": null,
       "country": "United States",
       "type": "state",
       "encoded": "Oklahoma_OK",
@@ -57467,7 +57467,7 @@
   "Oregon, United States": {
     "place": {
       "name": "Oregon",
-      "state": "OR",
+      "state": null,
       "country": "United States",
       "type": "state",
       "encoded": "Oregon_OR",
@@ -59222,7 +59222,7 @@
   "Passau, Bavaria, Germany": {
     "place": {
       "name": "Passau",
-      "state": "BY",
+      "state": "Bavaria",
       "country": "Germany",
       "type": "city",
       "encoded": "Passau_BY",
@@ -60067,7 +60067,7 @@
   "Perth, Western Australia, Australia": {
     "place": {
       "name": "Perth",
-      "state": "WA",
+      "state": "Western Australia",
       "country": "Australia",
       "type": "city",
       "encoded": "Perth_WA",
@@ -63676,7 +63676,7 @@
   "Regensburg, Bavaria, Germany": {
     "place": {
       "name": "Regensburg",
-      "state": "BY",
+      "state": "Bavaria",
       "country": "Germany",
       "type": "city",
       "encoded": "Regensburg_BY",
@@ -63810,7 +63810,7 @@
   "Reykjavík, Iceland": {
     "place": {
       "name": "Reykjavík",
-      "state": "Höfuðborgarsvæðið",
+      "state": null,
       "country": "Iceland",
       "type": "city",
       "encoded": "Reykjavík_Höfuðborgarsvæðið",
@@ -64398,7 +64398,7 @@
   "Rio de Janeiro, Rio de Janeiro, Brazil": {
     "place": {
       "name": "Rio de Janeiro",
-      "state": "RJ",
+      "state": "Rio de Janeiro",
       "country": "Brazil",
       "type": "city",
       "encoded": "RiodeJaneiro_RJ",
@@ -65618,7 +65618,7 @@
   "Rosenheim, Bavaria, Germany": {
     "place": {
       "name": "Rosenheim",
-      "state": "BY",
+      "state": "Bavaria",
       "country": "Germany",
       "type": "city",
       "encoded": "Rosenheim_BY",
@@ -65750,7 +65750,7 @@
   "Rostock, Mecklenburg-Vorpommern, Germany": {
     "place": {
       "name": "Rostock",
-      "state": "MV",
+      "state": "Mecklenburg-Vorpommern",
       "country": "Germany",
       "type": "city",
       "encoded": "Rostock_MV",
@@ -66997,7 +66997,7 @@
   "San Pedro Garza García, Nuevo León, Mexico": {
     "place": {
       "name": "San Pedro Garza García",
-      "state": "NL",
+      "state": "Nuevo León",
       "country": "Mexico",
       "type": "city",
       "encoded": "SanPedroGarzaGarcía_NL",
@@ -67532,7 +67532,7 @@
   "Sassnitz, Mecklenburg-Vorpommern, Germany": {
     "place": {
       "name": "Sassnitz",
-      "state": "MV",
+      "state": "Mecklenburg-Vorpommern",
       "country": "Germany",
       "type": "city",
       "encoded": "Sassnitz_MV",
@@ -68426,7 +68426,7 @@
   "Seoul, Korea": {
     "place": {
       "name": "Seoul",
-      "state": "Seoul Special Metropolitan City",
+      "state": null,
       "country": "Korea",
       "type": "city",
       "encoded": "Seoul_SeoulSpecialMetropolitanCity",
@@ -70490,7 +70490,7 @@
   "South Australia, Australia": {
     "place": {
       "name": "South Australia",
-      "state": "SA",
+      "state": null,
       "country": "Australia",
       "type": "state",
       "encoded": "SouthAustralia_SA",
@@ -70849,7 +70849,7 @@
   "South Perth, Western Australia, Australia": {
     "place": {
       "name": "South Perth",
-      "state": "WA",
+      "state": "Western Australia",
       "country": "Australia",
       "type": "city",
       "encoded": "SouthPerth_WA",
@@ -73344,7 +73344,7 @@
   "Stirling, Western Australia, Australia": {
     "place": {
       "name": "Stirling",
-      "state": "WA",
+      "state": "Western Australia",
       "country": "Australia",
       "type": "city",
       "encoded": "Stirling_WA",
@@ -73826,7 +73826,7 @@
   "Stuttgart, Baden-Württemberg, Germany": {
     "place": {
       "name": "Stuttgart",
-      "state": "BW",
+      "state": "Baden-Württemberg",
       "country": "Germany",
       "type": "city",
       "encoded": "Stuttgart_BW",
@@ -73854,7 +73854,7 @@
   "Subiaco, Western Australia, Australia": {
     "place": {
       "name": "Subiaco",
-      "state": "WA",
+      "state": "Western Australia",
       "country": "Australia",
       "type": "city",
       "encoded": "Subiaco_WA",
@@ -74696,7 +74696,7 @@
   "São Paulo, São Paulo, Brazil": {
     "place": {
       "name": "São Paulo",
-      "state": "SP",
+      "state": "São Paulo",
       "country": "Brazil",
       "type": "city",
       "encoded": "SãoPaulo_SP",
@@ -75022,7 +75022,7 @@
   "Tasmania, Australia": {
     "place": {
       "name": "Tasmania",
-      "state": "TAS",
+      "state": null,
       "country": "Australia",
       "type": "state",
       "encoded": "Tasmania_TAS",
@@ -75364,7 +75364,7 @@
   "Tel Aviv, Tel Aviv District, Israel": {
     "place": {
       "name": "Tel Aviv",
-      "state": "TA",
+      "state": "Tel Aviv District",
       "country": "Israel",
       "type": "city",
       "encoded": "TelAviv_TA",
@@ -76309,7 +76309,7 @@
   "Tirol, Austria": {
     "place": {
       "name": "Tirol",
-      "state": "Tirol",
+      "state": null,
       "country": "Austria",
       "type": "state",
       "encoded": "Tirol_Tirol",
@@ -77101,7 +77101,7 @@
   "Trelleborg, Skåne County, Sweden": {
     "place": {
       "name": "Trelleborg",
-      "state": "Skåne",
+      "state": "Skåne County",
       "country": "Sweden",
       "type": "city",
       "encoded": "Trelleborg_Skåne",
@@ -77317,7 +77317,7 @@
   "Tshwane, Gauteng, South Africa": {
     "place": {
       "name": "Tshwane",
-      "state": "GP",
+      "state": "Gauteng",
       "country": "South Africa",
       "type": "city",
       "encoded": "Tshwane_GP",
@@ -77722,8 +77722,8 @@
   },
   "U.S. Virgin Islands, United States": {
     "place": {
-      "name": "US Virgin Islands",
-      "state": "VI",
+      "name": "U.S. Virgin Islands",
+      "state": null,
       "country": "United States",
       "type": "state",
       "encoded": "USVirginIslands_VI",
@@ -78758,7 +78758,7 @@
   "Victoria Park, Western Australia, Australia": {
     "place": {
       "name": "Victoria Park",
-      "state": "WA",
+      "state": "Western Australia",
       "country": "Australia",
       "type": "city",
       "encoded": "VictoriaPark_WA",
@@ -79179,7 +79179,7 @@
   "Vorarlberg, Austria": {
     "place": {
       "name": "Vorarlberg",
-      "state": "Vorarlberg",
+      "state": null,
       "country": "Austria",
       "type": "state",
       "encoded": "Vorarlberg_Vorarlberg",
@@ -79199,7 +79199,7 @@
   "Västerås, Västmanland County, Sweden": {
     "place": {
       "name": "Västerås",
-      "state": "Västmanland",
+      "state": "Västmanland County",
       "country": "Sweden",
       "type": "city",
       "encoded": "Västerås_Västmanland",
@@ -80224,7 +80224,7 @@
   "Washington, United States": {
     "place": {
       "name": "Washington",
-      "state": "WA",
+      "state": null,
       "country": "United States",
       "type": "state",
       "encoded": "Washington_WA",
@@ -83980,7 +83980,7 @@
   "Winterthur, Zurich, Switzerland": {
     "place": {
       "name": "Winterthur",
-      "state": "ZH",
+      "state": "Zurich",
       "country": "Switzerland",
       "type": "city",
       "encoded": "Winterthur_ZH",
@@ -85484,7 +85484,7 @@
   "Zingst, Mecklenburg-Vorpommern, Germany": {
     "place": {
       "name": "Zingst",
-      "state": "MV",
+      "state": "Mecklenburg-Vorpommern",
       "country": "Germany",
       "type": "city",
       "encoded": "Zingst_MV",
@@ -85552,7 +85552,7 @@
   "Zuid-Holland, Netherlands": {
     "place": {
       "name": "Zuid-Holland",
-      "state": "ZH",
+      "state": null,
       "country": "Netherlands",
       "type": "state",
       "encoded": "Zuid-Holland_ZH",
@@ -85612,7 +85612,7 @@
   "Örebro, Örebro County, Sweden": {
     "place": {
       "name": "Örebro",
-      "state": "Örebro",
+      "state": "Örebro County",
       "country": "Sweden",
       "type": "city",
       "encoded": "Örebro_Örebro",

--- a/data/core.json
+++ b/data/core.json
@@ -2546,7 +2546,7 @@
       }
     ]
   },
-  "Armadale, WA, Australia": {
+  "Armadale, Western Australia, Australia": {
     "place": {
       "name": "Armadale",
       "state": "WA",
@@ -3274,7 +3274,7 @@
       }
     ]
   },
-  "Augsburg, BY, Germany": {
+  "Augsburg, Bavaria, Germany": {
     "place": {
       "name": "Augsburg",
       "state": "BY",
@@ -4353,7 +4353,7 @@
       }
     ]
   },
-  "Basel, BS, Switzerland": {
+  "Basel, Basel-Stadt, Switzerland": {
     "place": {
       "name": "Basel",
       "state": "BS",
@@ -5047,7 +5047,7 @@
       }
     ]
   },
-  "Beijing, BJ, China": {
+  "Beijing, China": {
     "place": {
       "name": "Beijing",
       "state": "BJ",
@@ -6147,7 +6147,7 @@
       }
     ]
   },
-  "Berlin, BE, Germany": {
+  "Berlin, Germany": {
     "place": {
       "name": "Berlin",
       "state": "BE",
@@ -7657,7 +7657,7 @@
       }
     ]
   },
-  "Bonn, NW, Germany": {
+  "Bonn, North Rhine-Westphalia, Germany": {
     "place": {
       "name": "Bonn",
       "state": "NW",
@@ -8507,7 +8507,7 @@
       }
     ]
   },
-  "Bremerhaven, HB, Germany": {
+  "Bremerhaven, Bremen, Germany": {
     "place": {
       "name": "Bremerhaven",
       "state": "HB",
@@ -8843,7 +8843,7 @@
       }
     ]
   },
-  "Brisbane, QLD, Australia": {
+  "Brisbane, Queensland, Australia": {
     "place": {
       "name": "Brisbane",
       "state": "QLD",
@@ -9880,7 +9880,7 @@
       }
     ]
   },
-  "Burnie, TAS, Australia": {
+  "Burnie, Tasmania, Australia": {
     "place": {
       "name": "Burnie",
       "state": "TAS",
@@ -11044,7 +11044,7 @@
       }
     ]
   },
-  "Cape Town, WC, South Africa": {
+  "Cape Town, Western Cape, South Africa": {
     "place": {
       "name": "Cape Town",
       "state": "WC",
@@ -14099,7 +14099,7 @@
       }
     ]
   },
-  "Chur, GR, Switzerland": {
+  "Chur, Grisons, Switzerland": {
     "place": {
       "name": "Chur",
       "state": "GR",
@@ -17147,7 +17147,7 @@
       }
     ]
   },
-  "Cottbus, BB, Germany": {
+  "Cottbus, Brandenburg, Germany": {
     "place": {
       "name": "Cottbus",
       "state": "BB",
@@ -19997,7 +19997,7 @@
       }
     ]
   },
-  "Derwent Valley, TAS, Australia": {
+  "Derwent Valley, Tasmania, Australia": {
     "place": {
       "name": "Derwent Valley",
       "state": "TAS",
@@ -20303,7 +20303,7 @@
       }
     ]
   },
-  "Dietzenbach, HE, Germany": {
+  "Dietzenbach, Hesse, Germany": {
     "place": {
       "name": "Dietzenbach",
       "state": "HE",
@@ -20571,7 +20571,7 @@
       }
     ]
   },
-  "Dorset, TAS, Australia": {
+  "Dorset, Tasmania, Australia": {
     "place": {
       "name": "Dorset",
       "state": "TAS",
@@ -20896,7 +20896,7 @@
       }
     ]
   },
-  "Dresden, SN, Germany": {
+  "Dresden, Saxony, Germany": {
     "place": {
       "name": "Dresden",
       "state": "SN",
@@ -26134,7 +26134,7 @@
       }
     ]
   },
-  "Flensburg, SH, Germany": {
+  "Flensburg, Schleswig-Holstein, Germany": {
     "place": {
       "name": "Flensburg",
       "state": "SH",
@@ -27621,7 +27621,7 @@
       }
     ]
   },
-  "Frankfurt, HE, Germany": {
+  "Frankfurt, Hesse, Germany": {
     "place": {
       "name": "Frankfurt",
       "state": "HE",
@@ -28106,7 +28106,7 @@
       }
     ]
   },
-  "Fremantle, WA, Australia": {
+  "Fremantle, Western Australia, Australia": {
     "place": {
       "name": "Fremantle",
       "state": "WA",
@@ -35162,7 +35162,7 @@
       }
     ]
   },
-  "Hobart, TAS, Australia": {
+  "Hobart, Tasmania, Australia": {
     "place": {
       "name": "Hobart",
       "state": "TAS",
@@ -36721,7 +36721,7 @@
       }
     ]
   },
-  "Ingolstadt, BY, Germany": {
+  "Ingolstadt, Bavaria, Germany": {
     "place": {
       "name": "Ingolstadt",
       "state": "BY",
@@ -38034,7 +38034,7 @@
       }
     ]
   },
-  "Johannesburg, GP, South Africa": {
+  "Johannesburg, Gauteng, South Africa": {
     "place": {
       "name": "Johannesburg",
       "state": "GP",
@@ -38430,7 +38430,7 @@
       }
     ]
   },
-  "Jönköping, Jönköping, Sweden": {
+  "Jönköping, Jönköping County, Sweden": {
     "place": {
       "name": "Jönköping",
       "state": "Jönköping",
@@ -38724,7 +38724,7 @@
       }
     ]
   },
-  "Kassel, HE, Germany": {
+  "Kassel, Hesse, Germany": {
     "place": {
       "name": "Kassel",
       "state": "HE",
@@ -38852,7 +38852,7 @@
       }
     ]
   },
-  "Kempten, BY, Germany": {
+  "Kempten, Bavaria, Germany": {
     "place": {
       "name": "Kempten",
       "state": "BY",
@@ -39860,7 +39860,7 @@
       }
     ]
   },
-  "Koblenz, RP, Germany": {
+  "Koblenz, Rhineland-Palatinate, Germany": {
     "place": {
       "name": "Koblenz",
       "state": "RP",
@@ -39936,7 +39936,7 @@
       }
     ]
   },
-  "Konstanz, BW, Germany": {
+  "Konstanz, Baden-Württemberg, Germany": {
     "place": {
       "name": "Konstanz",
       "state": "BW",
@@ -41517,7 +41517,7 @@
       }
     ]
   },
-  "Landshut, BY, Germany": {
+  "Landshut, Bavaria, Germany": {
     "place": {
       "name": "Landshut",
       "state": "BY",
@@ -43343,7 +43343,7 @@
       }
     ]
   },
-  "Lindau, BY, Germany": {
+  "Lindau, Bavaria, Germany": {
     "place": {
       "name": "Lindau",
       "state": "BY",
@@ -48566,7 +48566,7 @@
       }
     ]
   },
-  "Mexico City, DF, Mexico": {
+  "Mexico City, Mexico": {
     "place": {
       "name": "Mexico City",
       "state": "DF",
@@ -52646,7 +52646,7 @@
       }
     ]
   },
-  "München, BY, Germany": {
+  "München, Bavaria, Germany": {
     "place": {
       "name": "München",
       "state": "BY",
@@ -52666,7 +52666,7 @@
       }
     ]
   },
-  "Münster, NW, Germany": {
+  "Münster, North Rhine-Westphalia, Germany": {
     "place": {
       "name": "Münster",
       "state": "NW",
@@ -56158,7 +56158,7 @@
       }
     ]
   },
-  "Nürnberg, BY, Germany": {
+  "Nürnberg, Bavaria, Germany": {
     "place": {
       "name": "Nürnberg",
       "state": "BY",
@@ -56634,7 +56634,7 @@
       }
     ]
   },
-  "Ochtrup, NW, Germany": {
+  "Ochtrup, North Rhine-Westphalia, Germany": {
     "place": {
       "name": "Ochtrup",
       "state": "NW",
@@ -59219,7 +59219,7 @@
       }
     ]
   },
-  "Passau, BY, Germany": {
+  "Passau, Bavaria, Germany": {
     "place": {
       "name": "Passau",
       "state": "BY",
@@ -60064,7 +60064,7 @@
       }
     ]
   },
-  "Perth, WA, Australia": {
+  "Perth, Western Australia, Australia": {
     "place": {
       "name": "Perth",
       "state": "WA",
@@ -63673,7 +63673,7 @@
       }
     ]
   },
-  "Regensburg, BY, Germany": {
+  "Regensburg, Bavaria, Germany": {
     "place": {
       "name": "Regensburg",
       "state": "BY",
@@ -63807,7 +63807,7 @@
       }
     ]
   },
-  "Reykjavík, Höfuðborgarsvæðið, Iceland": {
+  "Reykjavík, Iceland": {
     "place": {
       "name": "Reykjavík",
       "state": "Höfuðborgarsvæðið",
@@ -64395,7 +64395,7 @@
       }
     ]
   },
-  "Rio de Janeiro, RJ, Brazil": {
+  "Rio de Janeiro, Rio de Janeiro, Brazil": {
     "place": {
       "name": "Rio de Janeiro",
       "state": "RJ",
@@ -65615,7 +65615,7 @@
       }
     ]
   },
-  "Rosenheim, BY, Germany": {
+  "Rosenheim, Bavaria, Germany": {
     "place": {
       "name": "Rosenheim",
       "state": "BY",
@@ -65747,7 +65747,7 @@
       }
     ]
   },
-  "Rostock, MV, Germany": {
+  "Rostock, Mecklenburg-Vorpommern, Germany": {
     "place": {
       "name": "Rostock",
       "state": "MV",
@@ -66994,7 +66994,7 @@
       }
     ]
   },
-  "San Pedro Garza García, NL, Mexico": {
+  "San Pedro Garza García, Nuevo León, Mexico": {
     "place": {
       "name": "San Pedro Garza García",
       "state": "NL",
@@ -67529,7 +67529,7 @@
       }
     ]
   },
-  "Sassnitz, MV, Germany": {
+  "Sassnitz, Mecklenburg-Vorpommern, Germany": {
     "place": {
       "name": "Sassnitz",
       "state": "MV",
@@ -68423,7 +68423,7 @@
       }
     ]
   },
-  "Seoul, Seoul Special Metropolitan City, Korea": {
+  "Seoul, Korea": {
     "place": {
       "name": "Seoul",
       "state": "Seoul Special Metropolitan City",
@@ -70846,7 +70846,7 @@
       }
     ]
   },
-  "South Perth, WA, Australia": {
+  "South Perth, Western Australia, Australia": {
     "place": {
       "name": "South Perth",
       "state": "WA",
@@ -73341,7 +73341,7 @@
       }
     ]
   },
-  "Stirling, WA, Australia": {
+  "Stirling, Western Australia, Australia": {
     "place": {
       "name": "Stirling",
       "state": "WA",
@@ -73823,7 +73823,7 @@
       }
     ]
   },
-  "Stuttgart, BW, Germany": {
+  "Stuttgart, Baden-Württemberg, Germany": {
     "place": {
       "name": "Stuttgart",
       "state": "BW",
@@ -73851,7 +73851,7 @@
       }
     ]
   },
-  "Subiaco, WA, Australia": {
+  "Subiaco, Western Australia, Australia": {
     "place": {
       "name": "Subiaco",
       "state": "WA",
@@ -74693,7 +74693,7 @@
       }
     ]
   },
-  "São Paulo, SP, Brazil": {
+  "São Paulo, São Paulo, Brazil": {
     "place": {
       "name": "São Paulo",
       "state": "SP",
@@ -75361,7 +75361,7 @@
       }
     ]
   },
-  "Tel Aviv, TA, Israel": {
+  "Tel Aviv, Tel Aviv District, Israel": {
     "place": {
       "name": "Tel Aviv",
       "state": "TA",
@@ -77098,7 +77098,7 @@
       }
     ]
   },
-  "Trelleborg, Skåne, Sweden": {
+  "Trelleborg, Skåne County, Sweden": {
     "place": {
       "name": "Trelleborg",
       "state": "Skåne",
@@ -77314,7 +77314,7 @@
       }
     ]
   },
-  "Tshwane, GP, South Africa": {
+  "Tshwane, Gauteng, South Africa": {
     "place": {
       "name": "Tshwane",
       "state": "GP",
@@ -78755,7 +78755,7 @@
       }
     ]
   },
-  "Victoria Park, WA, Australia": {
+  "Victoria Park, Western Australia, Australia": {
     "place": {
       "name": "Victoria Park",
       "state": "WA",
@@ -79196,7 +79196,7 @@
       }
     ]
   },
-  "Västerås, Västmanland, Sweden": {
+  "Västerås, Västmanland County, Sweden": {
     "place": {
       "name": "Västerås",
       "state": "Västmanland",
@@ -83977,7 +83977,7 @@
       }
     ]
   },
-  "Winterthur, ZH, Switzerland": {
+  "Winterthur, Zurich, Switzerland": {
     "place": {
       "name": "Winterthur",
       "state": "ZH",
@@ -85481,7 +85481,7 @@
       }
     ]
   },
-  "Zingst, MV, Germany": {
+  "Zingst, Mecklenburg-Vorpommern, Germany": {
     "place": {
       "name": "Zingst",
       "state": "MV",
@@ -85609,7 +85609,7 @@
       }
     ]
   },
-  "Örebro, Örebro, Sweden": {
+  "Örebro, Örebro County, Sweden": {
     "place": {
       "name": "Örebro",
       "state": "Örebro",

--- a/data/core.json
+++ b/data/core.json
@@ -10232,7 +10232,7 @@
       }
     ]
   },
-  "California, CA, United States": {
+  "California, United States": {
     "place": {
       "name": "California",
       "state": "CA",
@@ -15879,7 +15879,7 @@
       }
     ]
   },
-  "Colorado, CO, United States": {
+  "Colorado, United States": {
     "place": {
       "name": "Colorado",
       "state": "CO",
@@ -16494,7 +16494,7 @@
       }
     ]
   },
-  "Connecticut, CT, United States": {
+  "Connecticut, United States": {
     "place": {
       "name": "Connecticut",
       "state": "CT",
@@ -26314,7 +26314,7 @@
       }
     ]
   },
-  "Florida, FL, United States": {
+  "Florida, United States": {
     "place": {
       "name": "Florida",
       "state": "FL",
@@ -35422,7 +35422,7 @@
       }
     ]
   },
-  "Hong Kong, HK, China": {
+  "Hong Kong, China": {
     "place": {
       "name": "Hong Kong",
       "state": "HK",
@@ -45336,7 +45336,7 @@
       }
     ]
   },
-  "Maharashtra, MH, India": {
+  "Maharashtra, India": {
     "place": {
       "name": "Maharashtra",
       "state": "MH",
@@ -45408,7 +45408,7 @@
       }
     ]
   },
-  "Maine, ME, United States": {
+  "Maine, United States": {
     "place": {
       "name": "Maine",
       "state": "ME",
@@ -50381,7 +50381,7 @@
       }
     ]
   },
-  "Montana, MT, United States": {
+  "Montana, United States": {
     "place": {
       "name": "Montana",
       "state": "MT",
@@ -53720,7 +53720,7 @@
       }
     ]
   },
-  "New Hampshire, NH, United States": {
+  "New Hampshire, United States": {
     "place": {
       "name": "New Hampshire",
       "state": "NH",
@@ -55211,7 +55211,7 @@
       }
     ]
   },
-  "North Carolina, NC, United States": {
+  "North Carolina, United States": {
     "place": {
       "name": "North Carolina",
       "state": "NC",
@@ -55712,7 +55712,7 @@
       }
     ]
   },
-  "Northern Territory, NT, Australia": {
+  "Northern Territory, Australia": {
     "place": {
       "name": "Northern Territory",
       "state": "NT",
@@ -56848,7 +56848,7 @@
       }
     ]
   },
-  "Oklahoma, OK, United States": {
+  "Oklahoma, United States": {
     "place": {
       "name": "Oklahoma",
       "state": "OK",
@@ -57464,7 +57464,7 @@
       }
     ]
   },
-  "Oregon, OR, United States": {
+  "Oregon, United States": {
     "place": {
       "name": "Oregon",
       "state": "OR",
@@ -70487,7 +70487,7 @@
       }
     ]
   },
-  "South Australia, SA, Australia": {
+  "South Australia, Australia": {
     "place": {
       "name": "South Australia",
       "state": "SA",
@@ -75019,7 +75019,7 @@
       }
     ]
   },
-  "Tasmania, TAS, Australia": {
+  "Tasmania, Australia": {
     "place": {
       "name": "Tasmania",
       "state": "TAS",
@@ -76306,7 +76306,7 @@
       }
     ]
   },
-  "Tirol, Tirol, Austria": {
+  "Tirol, Austria": {
     "place": {
       "name": "Tirol",
       "state": "Tirol",
@@ -77720,7 +77720,7 @@
       }
     ]
   },
-  "US Virgin Islands, VI, United States": {
+  "U.S. Virgin Islands, United States": {
     "place": {
       "name": "US Virgin Islands",
       "state": "VI",
@@ -79176,7 +79176,7 @@
       }
     ]
   },
-  "Vorarlberg, Vorarlberg, Austria": {
+  "Vorarlberg, Austria": {
     "place": {
       "name": "Vorarlberg",
       "state": "Vorarlberg",
@@ -80221,7 +80221,7 @@
       }
     ]
   },
-  "Washington, WA, United States": {
+  "Washington, United States": {
     "place": {
       "name": "Washington",
       "state": "WA",
@@ -85549,7 +85549,7 @@
       }
     ]
   },
-  "Zuid-Holland, ZH, Netherlands": {
+  "Zuid-Holland, Netherlands": {
     "place": {
       "name": "Zuid-Holland",
       "state": "ZH",


### PR DESCRIPTION
These changes were all made directly in Directus. However, to preserve the prior URL encoding, I had to manually update the PlaceId in `core.json` before running `sync-directus`.

Chanes:

* States don't have `state` set
* City-states don't have `state` set
* States use the full name