### PR TITLE
Don't ever show country in map marker tooltip

### DIFF
--- a/src/js/map-features/markers.ts
+++ b/src/js/map-features/markers.ts
@@ -5,7 +5,7 @@ import { PlaceFilterManager } from "../state/FilterState";
 import { ViewStateObservable } from "../layout/viewToggle";
 import type { PlaceId } from "../model/types";
 import { radiusGivenZoom, determineIsPrimary } from "./markerUtils";
-import { stripCountryFromPlaceId } from "../model/placeId";
+import { determinePlaceIdWithoutCountry } from "../model/placeId";
 
 const PRIMARY_MARKER_STYLE = {
   weight: 1,
@@ -66,7 +66,7 @@ export default function initPlaceMarkers(
 
     // The tooltip is the text shown on hover. We strip the country
     // to make it less verbose.
-    marker.bindTooltip(stripCountryFromPlaceId(placeId));
+    marker.bindTooltip(determinePlaceIdWithoutCountry(entry.place));
 
     acc[placeId] = marker;
     return acc;

--- a/src/js/model/placeId.ts
+++ b/src/js/model/placeId.ts
@@ -35,9 +35,12 @@ export function determinesupplementalPlaceInfo(place: {
   return state ? `${state}, ${country}` : country;
 }
 
-export function stripCountryFromPlaceId(placeId: PlaceId): string {
-  const [place, state] = placeId.split(", ");
-  return state ? `${place}, ${state}` : place;
+export function determinePlaceIdWithoutCountry(place: {
+  name: string;
+  state: string | null;
+}): string {
+  const { name, state } = place;
+  return state ? `${name}, ${state}` : name;
 }
 
 /**

--- a/tests/app/placeId.test.ts
+++ b/tests/app/placeId.test.ts
@@ -5,7 +5,7 @@ import {
   encodedPlaceToUrl,
   determinePlaceIdForDirectus,
   determinesupplementalPlaceInfo,
-  stripCountryFromPlaceId,
+  determinePlaceIdWithoutCountry,
 } from "../../src/js/model/placeId";
 
 test.describe("determinePlaceIdForDirectus", () => {
@@ -93,14 +93,18 @@ test("determinesupplementalPlaceInfo", () => {
 });
 
 test("stripCountryFromPlaceId", () => {
-  expect(stripCountryFromPlaceId("Tucson")).toEqual("Tucson");
-  expect(stripCountryFromPlaceId("Tucson, AZ")).toEqual("Tucson, AZ");
-  expect(stripCountryFromPlaceId("Tucson, AZ, United States")).toEqual(
-    "Tucson, AZ",
-  );
   expect(
-    stripCountryFromPlaceId("Tucson, AZ, United States, another string"),
-  ).toEqual("Tucson, AZ");
+    determinePlaceIdWithoutCountry({
+      name: "San Francisco",
+      state: "California",
+    }),
+  ).toEqual("San Francisco, California");
+  expect(
+    determinePlaceIdWithoutCountry({
+      name: "Berlin",
+      state: null,
+    }),
+  ).toEqual("Berlin");
 });
 
 test("encodePlaceId", () => {


### PR DESCRIPTION
We were showing places like `Berlin, Germany` or `U.S. Virgin Islands, United States`. We should never show the country in the marker tooltip text.