### PR TITLE
Fix rsync for static pages deploy

### DIFF
--- a/.github/workflows/deploy-static-pages.yaml
+++ b/.github/workflows/deploy-static-pages.yaml
@@ -58,7 +58,7 @@ jobs:
               -C /var/www/${{ secrets.PRN_SERVER_HOST }}/mandates-map/details-tmp
 
             rsync --archive --verbose --delete --no-times \
-              /var/www/${{ secrets.PRN_SERVER_HOST }}/mandates-map/details-tmp \
+              /var/www/${{ secrets.PRN_SERVER_HOST }}/mandates-map/details-tmp/ \
               /var/www/${{ secrets.PRN_SERVER_HOST }}/mandates-map/city_detail/
 
             rm -rf /var/www/${{ secrets.PRN_SERVER_HOST }}/mandates-map/details-tmp


### PR DESCRIPTION
Without the trailing slash, rscync copies the files as having `/details-tmp` in the prefix.