### PR TITLE
Reorder broken links output to be more ergonomic

### DIFF
--- a/scripts/brokenLinks.ts
+++ b/scripts/brokenLinks.ts
@@ -55,7 +55,7 @@ async function main(): Promise<void> {
     const deadLink = await findDeadLink(link);
     if (deadLink !== null) {
       const directusEntry = `https://mandates-map.directus.app/admin/content/citations/${id}`;
-      console.log(`${directusEntry}: ${link}`);
+      console.log(`${link} (${directusEntry})`);
     }
 
     if ((i + 1) % 10 === 0) {


### PR DESCRIPTION
The main task is manually verifying the link works. So, the bad link should be front-and-center. The secondary task is updating Directus after, so it comes after.