### PR TITLE
Make search initialization lazy for performance

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "parcel",
-    "build": "rm -rf dist; parcel build --detailed-report",
+    "build": "rm -rf dist .parcel-cache; parcel build --detailed-report",
     "test": "npm run gen-html -- --quiet; playwright test",
     "check": "tsc --noEmit",
     "fmt": "prettier --write .",

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -77,7 +77,7 @@ interface Args {
 function parseArgs(): Args {
   const argv = process.argv.slice(2);
   const args: Args = {
-    runs: 5,
+    runs: 15,
     headed: false,
     out: path.join("benchmark-results", "latest.json"),
   };

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -15,6 +15,7 @@ const TABLE_COUNTER = "#table-counter";
 const TABLE_TOGGLE = ".header-table-icon-container";
 const MAP_TOGGLE = ".header-map-icon-container";
 const FILTER_TOGGLE = ".header-filter-icon-container";
+const SEARCH_TOGGLE = ".header-search-icon-container";
 const POLICY_DROPDOWN = "#filter-policy-type-dropdown";
 
 // The counters start empty and are populated with text beginning "Showing"
@@ -132,6 +133,8 @@ interface RunResult {
   filterReduceMinJsMs: number;
   filterResetMs: number;
   filterResetJsMs: number;
+  searchInitMs: number;
+  searchInitJsMs: number;
   totalBytes: number;
   numPlaces: number;
   // URL -> bytes transferred, for reporting the largest resources.
@@ -189,6 +192,53 @@ async function timePolicyChange(
         },
       ),
     { target: targetValue, selector: POLICY_DROPDOWN },
+  );
+}
+
+// Click the search icon and time how long until the Choices.js widget is built
+// and PAINTED. Search is initialized lazily (see src/js/search.ts): clicking the
+// icon synchronously constructs `new Choices(...)` from ~6,000 places -- the
+// single most expensive piece of app JS -- which is why it's kept off the
+// initial-load critical path. This measures that deferred cost directly.
+//
+// Runs in-page (like timePolicyChange) so timing isn't polluted by CDP
+// round-trips. `icon.click()` runs the real handler, whose `new Choices(...)`
+// builds the widget's DOM synchronously (the `.choices__inner` container), so
+// when click() returns all the JS is done. But the browser hasn't laid out and
+// painted that DOM yet -- that's the next frame. So, as elsewhere, we wait for
+// the next animation frame and then a macrotask posted from within it (which
+// runs just after that frame paints) and stop the clock there.
+async function timeSearchInit(
+  page: Page,
+): Promise<{ jsMs: number; paintedMs: number }> {
+  return page.evaluate(
+    (selector) =>
+      new Promise<{ jsMs: number; paintedMs: number }>((resolve, reject) => {
+        const icon = document.querySelector<HTMLElement>(selector);
+        if (!icon) {
+          reject(new Error(`search icon not found: ${selector}`));
+          return;
+        }
+
+        const start = performance.now();
+        icon.click();
+        // The click handler has synchronously built Choices.js.
+        const jsMs = performance.now() - start;
+
+        if (!document.querySelector(".choices__inner")) {
+          reject(new Error("search widget (.choices__inner) was not built"));
+          return;
+        }
+
+        requestAnimationFrame(() => {
+          const channel = new MessageChannel();
+          channel.port1.onmessage = () => {
+            resolve({ jsMs, paintedMs: performance.now() - start });
+          };
+          channel.port2.postMessage(undefined);
+        });
+      }),
+    SEARCH_TOGGLE,
   );
 }
 
@@ -299,6 +349,9 @@ async function runOnce(browser: Browser): Promise<RunResult> {
     const forward = await timePolicyChange(page, "reduce parking minimums");
     const back = await timePolicyChange(page, "any parking reform");
 
+    // Time the lazily-built search widget (first click constructs Choices.js).
+    const search = await timeSearchInit(page);
+
     const totalBytes = Object.values(resources).reduce((a, b) => a + b, 0);
 
     return {
@@ -312,6 +365,8 @@ async function runOnce(browser: Browser): Promise<RunResult> {
       filterReduceMinJsMs: forward.jsMs,
       filterResetMs: back.paintedMs,
       filterResetJsMs: back.jsMs,
+      searchInitMs: search.paintedMs,
+      searchInitJsMs: search.jsMs,
       totalBytes,
       numPlaces,
       resources,
@@ -387,6 +442,8 @@ async function main(): Promise<void> {
   const filterReduceMinJs = summarize(runs.map((r) => r.filterReduceMinJsMs));
   const filterReset = summarize(runs.map((r) => r.filterResetMs));
   const filterResetJs = summarize(runs.map((r) => r.filterResetJsMs));
+  const searchInit = summarize(runs.map((r) => r.searchInitMs));
+  const searchInitJs = summarize(runs.map((r) => r.searchInitJsMs));
   const transfer = summarize(runs.map((r) => r.totalBytes));
 
   // Largest resources, using the run with the median total transfer as
@@ -437,6 +494,13 @@ async function main(): Promise<void> {
     )}); ${fmtMs(filterResetJs.median)} JS-only`,
   );
   console.log(
+    `Search init:   median ${fmtMs(searchInit.median)} painted (min ${fmtMs(
+      searchInit.min,
+    )}, max ${fmtMs(searchInit.max)}); ${fmtMs(
+      searchInitJs.median,
+    )} JS-only  first click builds Choices.js`,
+  );
+  console.log(
     `Transfer:      median ${fmtMb(transfer.median)} (min ${fmtMb(
       transfer.min,
     )}, max ${fmtMb(transfer.max)})`,
@@ -463,6 +527,8 @@ async function main(): Promise<void> {
       filterReduceMinJsMs: filterReduceMinJs,
       filterResetMs: filterReset,
       filterResetJsMs: filterResetJs,
+      searchInitMs: searchInit,
+      searchInitJsMs: searchInitJs,
       totalBytes: transfer,
     },
     runs: runs.map((r) => ({
@@ -476,6 +542,8 @@ async function main(): Promise<void> {
       filterReduceMinJsMs: r.filterReduceMinJsMs,
       filterResetMs: r.filterResetMs,
       filterResetJsMs: r.filterResetJsMs,
+      searchInitMs: r.searchInitMs,
+      searchInitJsMs: r.searchInitJsMs,
       totalBytes: r.totalBytes,
     })),
   };

--- a/src/js/search.ts
+++ b/src/js/search.ts
@@ -13,18 +13,24 @@ function updateSearchPopupUI(isVisible: boolean) {
 
 type SearchPopupObservable = Observable<boolean>;
 
-function initSearchPopup(): SearchPopupObservable {
+function initSearchPopup(onFirstOpen: () => void): SearchPopupObservable {
   const isVisible = new Observable<boolean>("search popup", false);
   isVisible.subscribe(updateSearchPopupUI);
 
   const popup = document.querySelector("#search-popup");
-  const selectElement = document.querySelector<HTMLInputElement>("div.choices");
   const icon = document.querySelector(".header-search-icon-container");
   if (!icon) throw new Error("icon not found");
 
   icon.addEventListener("click", () => {
-    isVisible.setValue(!isVisible.getValue());
-    setTimeout(() => selectElement?.click(), 100);
+    const nowVisible = !isVisible.getValue();
+    isVisible.setValue(nowVisible);
+    // Build the (expensive) Choices widget lazily on first open. `div.choices`
+    // does not exist until then, so query it after building.
+    if (nowVisible) onFirstOpen();
+    setTimeout(
+      () => document.querySelector<HTMLElement>("div.choices")?.click(),
+      100,
+    );
   });
 
   // Clicks outside the popup close it.
@@ -44,51 +50,60 @@ function initSearchPopup(): SearchPopupObservable {
 }
 
 export default function initSearch(filterManager: PlaceFilterManager): void {
-  const places = Object.entries(filterManager.entries).map(
-    ([placeId, entry]) => ({
-      value: placeId,
-      label: placeId,
-      customProperties: {
-        place: entry.place.name,
-        state: entry.place.state ?? "",
-        country: entry.place.country,
-      },
-    }),
-  );
   const htmlElement = document.querySelector(".search");
   if (!htmlElement) return;
 
-  const choices = new Choices(htmlElement, {
-    position: "bottom",
-    choices: places,
-    placeholderValue: "Search",
-    removeItemButton: true,
-    allowHTML: false,
-    itemSelectText: "",
-    searchEnabled: true,
-    searchResultLimit: 10,
-    searchFields: [
-      "label",
-      "customProperties.place",
-      "customProperties.state",
-      "customProperties.country",
-    ],
-  });
+  // Building Choices.js with the full set of places is expensive (~93ms), so
+  // defer it until the user first opens the search popup.
+  let choices: Choices | null = null;
 
-  // Set initial state.
-  choices.setChoiceByValue(filterManager.getState().searchInput || "");
+  const buildChoices = (): void => {
+    if (choices) return;
+    const places = Object.entries(filterManager.entries).map(
+      ([placeId, entry]) => ({
+        value: placeId,
+        label: placeId,
+        customProperties: {
+          place: entry.place.name,
+          state: entry.place.state ?? "",
+          country: entry.place.country,
+        },
+      }),
+    );
 
-  // Also set up the popup.
-  const popupIsVisible = initSearchPopup();
+    choices = new Choices(htmlElement, {
+      position: "bottom",
+      choices: places,
+      placeholderValue: "Search",
+      removeItemButton: true,
+      allowHTML: false,
+      itemSelectText: "",
+      searchEnabled: true,
+      searchResultLimit: 10,
+      searchFields: [
+        "label",
+        "customProperties.place",
+        "customProperties.state",
+        "customProperties.country",
+      ],
+    });
+
+    // Set initial state.
+    choices.setChoiceByValue(filterManager.getState().searchInput || "");
+  };
+
+  // Also set up the popup, which builds Choices on first open.
+  const popupIsVisible = initSearchPopup(buildChoices);
 
   // Ensure that programmatic changes that set FilterState.searchInput to null
   // update the UI element too.
   filterManager.subscribe("reset search UI when search is cleared", (state) => {
-    if (state.searchInput === null) choices.setChoiceByValue("");
+    if (state.searchInput === null) choices?.setChoiceByValue("");
   });
 
   // User-driven inputs to search should update the FilterState.
   htmlElement.addEventListener("change", () => {
+    if (!choices) return;
     filterManager.update({
       searchInput: (choices.getValue(true) as string) || null,
     });

--- a/src/js/search.ts
+++ b/src/js/search.ts
@@ -13,7 +13,7 @@ function updateSearchPopupUI(isVisible: boolean) {
 
 type SearchPopupObservable = Observable<boolean>;
 
-function initSearchPopup(onFirstOpen: () => void): SearchPopupObservable {
+function initSearchPopup(onOpen: () => void): SearchPopupObservable {
   const isVisible = new Observable<boolean>("search popup", false);
   isVisible.subscribe(updateSearchPopupUI);
 
@@ -24,9 +24,9 @@ function initSearchPopup(onFirstOpen: () => void): SearchPopupObservable {
   icon.addEventListener("click", () => {
     const nowVisible = !isVisible.getValue();
     isVisible.setValue(nowVisible);
-    // Build the (expensive) Choices widget lazily on first open. `div.choices`
-    // does not exist until then, so query it after building.
-    if (nowVisible) onFirstOpen();
+    // Build the Choices.js widget before the setTimeout below, since `div.choices` does
+    // not exist until then.
+    if (nowVisible) onOpen();
     setTimeout(
       () => document.querySelector<HTMLElement>("div.choices")?.click(),
       100,
@@ -53,7 +53,7 @@ export default function initSearch(filterManager: PlaceFilterManager): void {
   const htmlElement = document.querySelector(".search");
   if (!htmlElement) return;
 
-  // Building Choices.js with the full set of places is expensive (~93ms), so
+  // Building Choices.js with the full set of places is expensive (~90ms), so
   // defer it until the user first opens the search popup.
   let choices: Choices | null = null;
 
@@ -89,10 +89,9 @@ export default function initSearch(filterManager: PlaceFilterManager): void {
     });
 
     // Set initial state.
-    choices.setChoiceByValue(filterManager.getState().searchInput || "");
+    choices.setChoiceByValue(filterManager.getState().searchInput ?? "");
   };
 
-  // Also set up the popup, which builds Choices on first open.
   const popupIsVisible = initSearchPopup(buildChoices);
 
   // Ensure that programmatic changes that set FilterState.searchInput to null


### PR DESCRIPTION
Improves initial load by ~77ms according to benchmarks. It does make the initial opening up of search ~90ms slower, but that's an acceptable tradeoff.