### PR TITLE
Improve benchmark clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ element.appendChild(icon);
 
 ### Benchmark performance
 
-`npm run benchmark` measures initial map load, table-view load, and cold-load transfer size using a headless browser. It expects a production build to already be served, so in one terminal run:
+`npm run benchmark` measures the high-level tasks a user performs — initial page load, opening the table view, switching the policy-type filter (to "reduce minimums" and back to "any reform"), and loading the search widget — plus cold-load transfer size, using a headless browser. It expects a production build to already be served, so in one terminal run:
 
 ```bash
 ❯ npm run build
@@ -125,9 +125,9 @@ Then, in another terminal:
 ❯ npm run benchmark
 ```
 
-It runs a few times with the browser cache disabled (so bundle size counts), prints a median/min/max summary, and writes `benchmark-results/latest.json` for before/after comparison. Options: `--runs N`, `--out <path>`, `--headed`, and `PORT` to override the port.
+It runs a few times with the browser cache disabled (so bundle size counts) and writes `benchmark-results/latest.json` for before/after comparison. Each task is reported as one overall median (with min/max) plus the granular stages that make it up, indented underneath. For example, the initial page load breaks down into network, first paint, data fetch, JS build, and marker paint, which sum to the total; the filter and search tasks split their time-to-paint into a synchronous JS portion and the remaining paint. Options: `--runs N`, `--out <path>`, `--headed`, and `PORT` to override the port.
 
-To compare two saved benchmark files, use `scripts/compare-benchmarks.py benchmark-results/<before.json> benchmark-results/<after.json>`. It prints a table of the summary medians (absolute and percent change) and warns if the two runs have different place counts, since that would make the comparison not apples-to-apples.
+To compare two saved benchmark files, use `scripts/compare-benchmarks.py benchmark-results/<before.json> benchmark-results/<after.json>`. It prints each task's total delta (absolute and percent change) with its stage deltas indented underneath, and warns if the two runs have different place counts, since that would make the comparison not apples-to-apples.
 
 ## Staging
 

--- a/scripts/benchmark.ts
+++ b/scripts/benchmark.ts
@@ -376,6 +376,12 @@ async function runOnce(browser: Browser): Promise<RunResult> {
   }
 }
 
+interface Stat {
+  median: number;
+  min: number;
+  max: number;
+}
+
 function median(values: number[]): number {
   const sorted = [...values].sort((a, b) => a - b);
   const mid = Math.floor(sorted.length / 2);
@@ -384,16 +390,154 @@ function median(values: number[]): number {
     : sorted[mid];
 }
 
-function summarize(values: number[]): {
-  median: number;
-  min: number;
-  max: number;
-} {
+function summarize(values: number[]): Stat {
   return {
     median: median(values),
     min: Math.min(...values),
     max: Math.max(...values),
   };
+}
+
+// A high-level task is reported as one overall time plus granular stages that
+// sum to it. Rather than repeat a `summarize(runs.map(...))` per metric, we
+// describe each task once (how to read its total and each stage from a raw
+// RunResult) and drive the JSON, the console summary, and the per-run output off
+// this single list.
+interface StageDescriptor {
+  key: string;
+  label: string;
+  note?: string;
+  value: (r: RunResult) => number;
+}
+
+interface TaskDescriptor {
+  key: string;
+  label: string;
+  note?: string;
+  total: (r: RunResult) => number;
+  stages: StageDescriptor[];
+}
+
+interface TaskStat {
+  total: Stat;
+  stages: Record<string, Stat>;
+}
+
+// For the initial load the stages are the wall-clock gaps between consecutive
+// milestones (responseEnd -> fcp -> dataFetched -> counterReady -> painted).
+// Those milestones are captured as absolute marks on the browser's clock and
+// differenced here, so the stages add up exactly to `painted` (the total). The
+// interaction tasks split their felt time-to-paint into the synchronous JS
+// portion and the remaining paint.
+const TASKS: TaskDescriptor[] = [
+  {
+    key: "initialLoad",
+    label: "Initial page load",
+    total: (r) => r.initialPaintedMs,
+    stages: [
+      {
+        key: "network",
+        label: "network",
+        note: "HTML downloaded",
+        value: (r) => r.initialResponseEndMs,
+      },
+      {
+        key: "firstPaint",
+        label: "first paint",
+        note: "first pixels",
+        value: (r) => r.initialFcpMs - r.initialResponseEndMs,
+      },
+      {
+        key: "dataFetch",
+        label: "data fetch",
+        note: "largest resource",
+        value: (r) => r.initialDataFetchedMs - r.initialFcpMs,
+      },
+      {
+        key: "jsBuild",
+        label: "JS build",
+        note: "filter/build",
+        value: (r) => r.initialCounterReadyMs - r.initialDataFetchedMs,
+      },
+      {
+        key: "markerPaint",
+        label: "marker paint",
+        note: "map visible",
+        value: (r) => r.initialPaintedMs - r.initialCounterReadyMs,
+      },
+    ],
+  },
+  {
+    key: "tableView",
+    label: "Table view",
+    total: (r) => r.tableLoadMs,
+    stages: [],
+  },
+  {
+    key: "filterReduceMin",
+    label: "Filter → reduce min",
+    total: (r) => r.filterReduceMinMs,
+    stages: [
+      { key: "js", label: "JS", value: (r) => r.filterReduceMinJsMs },
+      {
+        key: "paint",
+        label: "paint",
+        value: (r) => r.filterReduceMinMs - r.filterReduceMinJsMs,
+      },
+    ],
+  },
+  {
+    key: "filterReset",
+    label: "Filter → any reform",
+    total: (r) => r.filterResetMs,
+    stages: [
+      { key: "js", label: "JS", value: (r) => r.filterResetJsMs },
+      {
+        key: "paint",
+        label: "paint",
+        value: (r) => r.filterResetMs - r.filterResetJsMs,
+      },
+    ],
+  },
+  {
+    key: "loadSearch",
+    label: "Load search",
+    note: "first click builds Choices.js",
+    total: (r) => r.searchInitMs,
+    stages: [
+      { key: "js", label: "JS", value: (r) => r.searchInitJsMs },
+      {
+        key: "paint",
+        label: "paint",
+        value: (r) => r.searchInitMs - r.searchInitJsMs,
+      },
+    ],
+  },
+];
+
+function summarizeTask(task: TaskDescriptor, runs: RunResult[]): TaskStat {
+  return {
+    total: summarize(runs.map(task.total)),
+    stages: Object.fromEntries(
+      task.stages.map((stage) => [stage.key, summarize(runs.map(stage.value))]),
+    ),
+  };
+}
+
+// One run reshaped into the same nested { total, stages } shape as the summary.
+function runToNested(r: RunResult): Record<string, unknown> {
+  const tasks = Object.fromEntries(
+    TASKS.map((task) => [
+      task.key,
+      {
+        total: task.total(r),
+        stages: Object.fromEntries(
+          task.stages.map((stage) => [stage.key, stage.value(r)]),
+        ),
+      },
+    ]),
+  );
+  return { ...tasks, totalBytes: r.totalBytes };
 }
 
 const fmtMs = (ms: number): string => `${ms.toFixed(0)} ms`;
@@ -432,18 +576,9 @@ async function main(): Promise<void> {
   }
 
   const { numPlaces } = runs[0];
-  const responseEnd = summarize(runs.map((r) => r.initialResponseEndMs));
-  const fcp = summarize(runs.map((r) => r.initialFcpMs));
-  const dataFetched = summarize(runs.map((r) => r.initialDataFetchedMs));
-  const counterReady = summarize(runs.map((r) => r.initialCounterReadyMs));
-  const painted = summarize(runs.map((r) => r.initialPaintedMs));
-  const table = summarize(runs.map((r) => r.tableLoadMs));
-  const filterReduceMin = summarize(runs.map((r) => r.filterReduceMinMs));
-  const filterReduceMinJs = summarize(runs.map((r) => r.filterReduceMinJsMs));
-  const filterReset = summarize(runs.map((r) => r.filterResetMs));
-  const filterResetJs = summarize(runs.map((r) => r.filterResetJsMs));
-  const searchInit = summarize(runs.map((r) => r.searchInitMs));
-  const searchInitJs = summarize(runs.map((r) => r.searchInitJsMs));
+  const tasks = Object.fromEntries(
+    TASKS.map((task) => [task.key, summarizeTask(task, runs)]),
+  );
   const transfer = summarize(runs.map((r) => r.totalBytes));
 
   // Largest resources, using the run with the median total transfer as
@@ -455,53 +590,30 @@ async function main(): Promise<void> {
     .sort((a, b) => b[1] - a[1])
     .slice(0, 5);
 
-  const markLine = (
-    label: string,
-    s: { median: number; min: number; max: number },
-    note = "",
-  ): void =>
-    console.log(
-      `  ${label.padEnd(16)}median ${fmtMs(s.median)} (min ${fmtMs(
-        s.min,
-      )}, max ${fmtMs(s.max)})${note}`,
-    );
-
   console.log(`\n===== Summary =====`);
-  console.log(`Places shown:  ${numPlaces}`);
-  console.log(`Initial load (cumulative ms from navigation start):`);
-  markLine("response end:", responseEnd, "  HTML downloaded");
-  markLine("first paint:", fcp, "  first pixels");
-  markLine("data fetched:", dataFetched, "  largest resource");
-  markLine("counter ready:", counterReady, "  JS filter/build done");
-  markLine("markers painted:", painted, "  map visible (felt load)");
+  console.log(`Places shown: ${numPlaces}\n`);
+
+  // One line per task with its overall time, then its granular stages indented
+  // underneath (stages sum to the total).
+  for (const task of TASKS) {
+    const stat = tasks[task.key];
+    const note = task.note ? `  ${task.note}` : "";
+    console.log(
+      `${task.label.padEnd(20)} median ${fmtMs(stat.total.median)} (min ${fmtMs(
+        stat.total.min,
+      )}, max ${fmtMs(stat.total.max)})${note}`,
+    );
+    for (const stage of task.stages) {
+      const s = stat.stages[stage.key];
+      const stageNote = stage.note ? `  ${stage.note}` : "";
+      console.log(
+        `  ${stage.label.padEnd(14)}${fmtMs(s.median).padStart(7)}${stageNote}`,
+      );
+    }
+  }
+
   console.log(
-    `Table load:    median ${fmtMs(table.median)} (min ${fmtMs(
-      table.min,
-    )}, max ${fmtMs(table.max)})`,
-  );
-  console.log(
-    `Filter → reduce min: median ${fmtMs(
-      filterReduceMin.median,
-    )} painted (min ${fmtMs(filterReduceMin.min)}, max ${fmtMs(
-      filterReduceMin.max,
-    )}); ${fmtMs(filterReduceMinJs.median)} JS-only`,
-  );
-  console.log(
-    `Filter → any reform: median ${fmtMs(
-      filterReset.median,
-    )} painted (min ${fmtMs(filterReset.min)}, max ${fmtMs(
-      filterReset.max,
-    )}); ${fmtMs(filterResetJs.median)} JS-only`,
-  );
-  console.log(
-    `Search init:   median ${fmtMs(searchInit.median)} painted (min ${fmtMs(
-      searchInit.min,
-    )}, max ${fmtMs(searchInit.max)}); ${fmtMs(
-      searchInitJs.median,
-    )} JS-only  first click builds Choices.js`,
-  );
-  console.log(
-    `Transfer:      median ${fmtMb(transfer.median)} (min ${fmtMb(
+    `\n${"Transfer".padEnd(20)} median ${fmtMb(transfer.median)} (min ${fmtMb(
       transfer.min,
     )}, max ${fmtMb(transfer.max)})`,
   );
@@ -516,36 +628,9 @@ async function main(): Promise<void> {
     gitCommit: gitCommit(),
     url: BASE_URL,
     numPlaces,
-    summary: {
-      initialResponseEndMs: responseEnd,
-      initialFcpMs: fcp,
-      initialDataFetchedMs: dataFetched,
-      initialCounterReadyMs: counterReady,
-      initialPaintedMs: painted,
-      tableLoadMs: table,
-      filterReduceMinMs: filterReduceMin,
-      filterReduceMinJsMs: filterReduceMinJs,
-      filterResetMs: filterReset,
-      filterResetJsMs: filterResetJs,
-      searchInitMs: searchInit,
-      searchInitJsMs: searchInitJs,
-      totalBytes: transfer,
-    },
-    runs: runs.map((r) => ({
-      initialResponseEndMs: r.initialResponseEndMs,
-      initialFcpMs: r.initialFcpMs,
-      initialDataFetchedMs: r.initialDataFetchedMs,
-      initialCounterReadyMs: r.initialCounterReadyMs,
-      initialPaintedMs: r.initialPaintedMs,
-      tableLoadMs: r.tableLoadMs,
-      filterReduceMinMs: r.filterReduceMinMs,
-      filterReduceMinJsMs: r.filterReduceMinJsMs,
-      filterResetMs: r.filterResetMs,
-      filterResetJsMs: r.filterResetJsMs,
-      searchInitMs: r.searchInitMs,
-      searchInitJsMs: r.searchInitJsMs,
-      totalBytes: r.totalBytes,
-    })),
+    tasks,
+    transfer,
+    runs: runs.map(runToNested),
   };
   fs.mkdirSync(path.dirname(args.out), { recursive: true });
   fs.writeFileSync(args.out, `${JSON.stringify(output, null, 2)}\n`);

--- a/scripts/compare-benchmarks.py
+++ b/scripts/compare-benchmarks.py
@@ -1,5 +1,9 @@
 #!/usr/bin/env python3
-"""Compare the summary stats of two benchmark-results/*.json files.
+"""Compare two benchmark-results/*.json files.
+
+Each file has a nested `tasks` map (one high-level task -> {total, stages}) plus a
+top-level `transfer` stat. We print, per task, the overall median delta followed by
+its granular stages indented underneath.
 
 Usage:
     python3 scripts/compare-benchmarks.py <before.json> <after.json>
@@ -17,17 +21,22 @@ def load(path: Path) -> dict[str, Any]:
         return json.load(f)
 
 
-def fmt_value(key: str, value: float) -> str:
-    if key == "totalBytes":
-        return f"{value / 1_000_000:.2f} MB"
+def fmt_ms(value: float) -> str:
     return f"{value:.0f} ms"
 
 
-def fmt_delta(key: str, delta: float) -> str:
+def fmt_mb(value: float) -> str:
+    return f"{value / 1_000_000:.2f} MB"
+
+
+def fmt_delta_ms(delta: float) -> str:
     sign = "+" if delta >= 0 else ""
-    if key == "totalBytes":
-        return f"{sign}{delta / 1_000_000:.2f} MB"
     return f"{sign}{delta:.0f} ms"
+
+
+def fmt_delta_mb(delta: float) -> str:
+    sign = "+" if delta >= 0 else ""
+    return f"{sign}{delta / 1_000_000:.2f} MB"
 
 
 def fmt_percent(pct: float | None) -> str:
@@ -37,9 +46,29 @@ def fmt_percent(pct: float | None) -> str:
     return f"{sign}{pct:.1f}%"
 
 
+def row(
+    label: str,
+    before_median: float | None,
+    after_median: float | None,
+    fmt_value: Any,
+    fmt_delta: Any,
+) -> None:
+    if before_median is None or after_median is None:
+        return
+    delta = after_median - before_median
+    pct = (delta / before_median * 100) if before_median else None
+    print(
+        f"{label:<24}"
+        f"{fmt_value(before_median):>14}"
+        f"{fmt_value(after_median):>14}"
+        f"{fmt_delta(delta):>14}"
+        f"{fmt_percent(pct):>10}"
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="Compare summary stats between two benchmark-results JSON files."
+        description="Compare two benchmark-results JSON files (nested schema)."
     )
     parser.add_argument("before", type=Path, help="Baseline benchmark JSON file")
     parser.add_argument("after", type=Path, help="Candidate benchmark JSON file")
@@ -68,29 +97,45 @@ def main() -> None:
             file=sys.stderr,
         )
 
-    before_summary = before.get("summary", {})
-    after_summary = after.get("summary", {})
-    keys = [k for k in before_summary if k in after_summary]
-    keys += [k for k in after_summary if k not in before_summary]
-
     header = f"{'Metric':<24}{'Before':>14}{'After':>14}{'Delta':>14}{'Delta %':>10}"
     print(header)
     print("-" * len(header))
 
+    before_tasks = before.get("tasks", {})
+    after_tasks = after.get("tasks", {})
+    # Preserve the insertion order the benchmark wrote (initial load first, etc.),
+    # then append any task only present in the newer file.
+    keys = list(before_tasks) + [k for k in after_tasks if k not in before_tasks]
+
     for key in keys:
-        before_median = before_summary.get(key, {}).get("median")
-        after_median = after_summary.get(key, {}).get("median")
-        if before_median is None or after_median is None:
-            continue
-        delta = after_median - before_median
-        pct = (delta / before_median * 100) if before_median else None
-        print(
-            f"{key:<24}"
-            f"{fmt_value(key, before_median):>14}"
-            f"{fmt_value(key, after_median):>14}"
-            f"{fmt_delta(key, delta):>14}"
-            f"{fmt_percent(pct):>10}"
+        b = before_tasks.get(key, {})
+        a = after_tasks.get(key, {})
+        row(
+            key,
+            b.get("total", {}).get("median"),
+            a.get("total", {}).get("median"),
+            fmt_ms,
+            fmt_delta_ms,
         )
+        b_stages = b.get("stages", {})
+        a_stages = a.get("stages", {})
+        stage_keys = list(b_stages) + [k for k in a_stages if k not in b_stages]
+        for stage in stage_keys:
+            row(
+                f"  {stage}",
+                b_stages.get(stage, {}).get("median"),
+                a_stages.get(stage, {}).get("median"),
+                fmt_ms,
+                fmt_delta_ms,
+            )
+
+    row(
+        "transfer",
+        before.get("transfer", {}).get("median"),
+        after.get("transfer", {}).get("median"),
+        fmt_mb,
+        fmt_delta_mb,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Now we have a more nested structure and make more clear what each individual step contributes.

```
Before: benchmark-results/nested-a.json (commit e400ef6f, 2026-07-02T22:19:07.167Z, 6034 places)
After:  benchmark-results/nested-b.json (commit e400ef6f, 2026-07-02T22:19:48.353Z, 6034 places)

Metric                          Before         After         Delta   Delta %
----------------------------------------------------------------------------
initialLoad                     406 ms        308 ms        -98 ms    -24.1%
  network                         2 ms          1 ms         -0 ms    -13.3%
  firstPaint                    114 ms        122 ms         +8 ms     +6.6%
  dataFetch                     115 ms         66 ms        -50 ms    -43.1%
  jsBuild                       120 ms        111 ms         -9 ms     -7.5%
  markerPaint                    15 ms         14 ms         -2 ms    -10.5%
tableView                       158 ms        154 ms         -4 ms     -2.7%
filterReduceMin                  16 ms         16 ms         +0 ms     +1.9%
  js                             11 ms         11 ms         -0 ms     -4.5%
  paint                           5 ms          6 ms         +1 ms    +20.0%
filterReset                      33 ms         31 ms         -2 ms     -5.2%
  js                             28 ms         27 ms         -2 ms     -5.6%
  paint                           4 ms          4 ms         -0 ms     -2.3%
loadSearch                      144 ms        136 ms         -8 ms     -5.6%
  js                             94 ms         90 ms         -5 ms     -5.2%
  paint                          49 ms         46 ms         -3 ms     -5.9%
transfer                       2.97 MB       2.97 MB      +0.00 MB     +0.0%
```