### PR TITLE
Make date parsing lazy for performance

### DIFF
--- a/scripts/lib/optionValues.ts
+++ b/scripts/lib/optionValues.ts
@@ -37,7 +37,7 @@ class OptionValues {
   }
 
   #addDate(date: string | undefined): void {
-    this.year.add(date ? new Date(date).parsed.year.toString() : UNKNOWN_YEAR);
+    this.year.add(date ? new Date(date).year : UNKNOWN_YEAR);
   }
 
   addBenefitDistrict(

--- a/src/js/model/types.ts
+++ b/src/js/model/types.ts
@@ -23,10 +23,6 @@ export class Date {
     if (this.raw.length === 7) return this.parsed.toFormat("LLL yyyy");
     return this.parsed.toFormat("LLL d, yyyy");
   }
-
-  preposition(): "in" | "on" {
-    return this.raw.length === 10 ? "on" : "in";
-  }
 }
 
 export type PlaceId = string;

--- a/src/js/model/types.ts
+++ b/src/js/model/types.ts
@@ -3,19 +3,28 @@ import { DateTime } from "luxon";
 export class Date {
   readonly raw: string;
 
-  readonly parsed: DateTime<true>;
+  #parsed: DateTime<true> | undefined;
 
   constructor(raw: string) {
     this.raw = raw;
-    const parsed = DateTime.fromISO(raw);
-    if (!parsed.isValid) {
-      throw new Error(`Invalid date string: ${raw}`);
-    }
-    this.parsed = parsed;
   }
 
   static fromNullable(dateStr: string | undefined): Date | undefined {
     return dateStr ? new this(dateStr) : undefined;
+  }
+
+  get parsed(): DateTime<true> {
+    if (this.#parsed) return this.#parsed;
+    const parsed = DateTime.fromISO(this.raw);
+    if (!parsed.isValid) {
+      throw new Error(`Invalid date string: ${this.raw}`);
+    }
+    this.#parsed = parsed;
+    return parsed;
+  }
+
+  get year(): string {
+    return this.raw.slice(0, 4);
   }
 
   format(): string {

--- a/src/js/state/FilterState.ts
+++ b/src/js/state/FilterState.ts
@@ -266,7 +266,7 @@ export class PlaceFilterManager {
     if (!isStatus) return false;
 
     const isYear = filterState.year.has(
-      policyRecord.date?.parsed.year.toString() || UNKNOWN_YEAR,
+      policyRecord.date?.year || UNKNOWN_YEAR,
     );
     if (!isYear) return false;
 
@@ -291,9 +291,7 @@ export class PlaceFilterManager {
     const isStatus = record.status === filterState.status;
     if (!isStatus) return false;
 
-    const isYear = filterState.year.has(
-      record.date?.parsed.year.toString() || UNKNOWN_YEAR,
-    );
+    const isYear = filterState.year.has(record.date?.year || UNKNOWN_YEAR);
     if (!isYear) return false;
 
     return true;

--- a/tests/app/types.test.ts
+++ b/tests/app/types.test.ts
@@ -7,9 +7,3 @@ test("Date.format()", () => {
   expect(new Date("2020-02").format()).toEqual("Feb 2020");
   expect(new Date("2020-02-13").format()).toEqual("Feb 13, 2020");
 });
-
-test("Date.preposition()", () => {
-  expect(new Date("2020").preposition()).toEqual("in");
-  expect(new Date("2020-02").preposition()).toEqual("in");
-  expect(new Date("2020-02-13").preposition()).toEqual("on");
-});


### PR DESCRIPTION
Part of https://github.com/ParkingReformNetwork/reform-map/issues/593. Running the benchmarks 100 times shows 10ms speedup (115 ms -> 105 ms). That's not huge, but this win has few downsides.

Note that we no longer eagerly validate the Date. That's fine because Directus already enforces that dates are in the correct format.