### PR TITLE
Use canvas renderer

### DIFF
--- a/src/js/layout/map.ts
+++ b/src/js/layout/map.ts
@@ -1,6 +1,5 @@
 import { Map, TileLayer } from "leaflet";
 
-export const NO_MANDATES_MARKERS_PANE = "noMandatesMarkers";
 const MIN_ZOOM = 3;
 const MAX_ZOOM = 13;
 
@@ -21,6 +20,8 @@ export default function createMap(): Map {
   const map = new Map("map", {
     layers: [BASE_LAYER],
     worldCopyJump: true,
+    // Canvas mode substantially speeds up the map.
+    preferCanvas: true,
   });
 
   // Set default view show all the US on mobile. While this is fairly zoomed out,
@@ -32,9 +33,5 @@ export default function createMap(): Map {
     '<a href="https://parkingreform.org/support/">Parking Reform Network</a>',
   );
 
-  // Workaround for no mandates markers appearing at the top of the map
-  // https://stackoverflow.com/a/49501320
-  map.createPane(NO_MANDATES_MARKERS_PANE);
-  map.getPane(NO_MANDATES_MARKERS_PANE)!.style.zIndex = "900";
   return map;
 }

--- a/src/js/main.ts
+++ b/src/js/main.ts
@@ -15,6 +15,7 @@ import initPlaceMarkers from "./map-features/markers";
 import initScorecard from "./map-features/scorecard";
 import initSearch from "./search";
 import initTable from "./table";
+import exposeTestHooks from "./testHooks";
 
 export default async function initApp(): Promise<void> {
   maybeDisableFullScreenIcon();
@@ -32,6 +33,7 @@ export default async function initApp(): Promise<void> {
   const filterManager = new PlaceFilterManager(data, initialState);
 
   const markerGroup = initPlaceMarkers(filterManager, map, viewToggle);
+  exposeTestHooks(map, markerGroup);
   subscribeSnapToPlace(filterManager, map);
   initCounters(filterManager);
   initSearch(filterManager);

--- a/src/js/map-features/markers.ts
+++ b/src/js/map-features/markers.ts
@@ -1,6 +1,5 @@
 import { CircleMarker, FeatureGroup, Map } from "leaflet";
 
-import { NO_MANDATES_MARKERS_PANE } from "../layout/map";
 import { PlaceFilterManager } from "../state/FilterState";
 import { ViewStateObservable } from "../layout/viewToggle";
 import type { PlaceId } from "../model/types";
@@ -12,7 +11,6 @@ const PRIMARY_MARKER_STYLE = {
   color: "white",
   fillColor: "#d7191c",
   fillOpacity: 1,
-  pane: NO_MANDATES_MARKERS_PANE,
 } as const;
 
 const SECONDARY_MARKER_STYLE = {
@@ -34,19 +32,30 @@ function updatePlaceVisibility(
   placesToMarkers: Record<string, MarkerWithPlaceId>,
   markerGroup: FeatureGroup,
 ): void {
-  // Remove markers no longer visible.
+  // Keep track of primary markers so that we can ensure they render on top of secondary ones.
+  const visiblePrimaryMarkers: MarkerWithPlaceId[] = [];
+
+  // Remove markers no longer visible and check if any existing markers are primary.
   for (const placeId of currentlyVisiblePlaceIds) {
+    const marker = placesToMarkers[placeId];
     if (!newVisiblePlaceIds.has(placeId)) {
       // @ts-expect-error the API allows passing a LayerGroup, but the type hint doesn't show this.
-      placesToMarkers[placeId].removeFrom(markerGroup);
+      marker.removeFrom(markerGroup);
     }
+    if (marker.isPrimary) visiblePrimaryMarkers.push(marker);
   }
 
-  // Add new markers not yet visible.
+  // Add newly visible markers.
   for (const placeId of newVisiblePlaceIds) {
+    const marker = placesToMarkers[placeId];
     if (!currentlyVisiblePlaceIds.has(placeId)) {
-      placesToMarkers[placeId].addTo(markerGroup);
+      marker.addTo(markerGroup);
     }
+    if (marker.isPrimary) visiblePrimaryMarkers.push(marker);
+  }
+
+  for (const marker of visiblePrimaryMarkers) {
+    marker.bringToFront();
   }
 }
 

--- a/src/js/map-features/scorecard.ts
+++ b/src/js/map-features/scorecard.ts
@@ -109,8 +109,14 @@ export default function initScorecard(
   const scorecardContainer = document.querySelector("#scorecard-container");
   const header = document.querySelector(".top-header");
 
+  // We use this variable to keep track of when a marker was clicked so that
+  // our event listener on `window` clicks to close out the scorecard
+  // can differentiate when we clicked on a marker vs something else.
+  let markerJustClicked = false;
+
   // Clicking a city marker opens up the scorecard.
   markerGroup.on("click", (e) => {
+    markerJustClicked = true;
     const { placeId } = e.sourceTarget as MarkerWithPlaceId;
     scorecardState.setValue({
       type: "visible",
@@ -131,14 +137,17 @@ export default function initScorecard(
     }
   });
 
-  // Clicks outside the popup close it.
+  // Clicks outside the scorecard popup close it.
   window.addEventListener("click", (event) => {
+    // A click on a map dot opens the scorecard; don't let it immediately close it.
+    if (markerJustClicked) {
+      markerJustClicked = false;
+      return;
+    }
     if (
       scorecardState.getValue().type === "visible" &&
       event.target instanceof Element &&
-      // Clicks on map dots should not trigger this event.
-      !(event.target instanceof SVGPathElement) &&
-      // Clicks on the header also should not trigger the event.
+      // Clicks on the header and scorecard should not close the scorecard.
       !header?.contains(event.target) &&
       !scorecardContainer?.contains(event.target)
     ) {

--- a/src/js/testHooks.ts
+++ b/src/js/testHooks.ts
@@ -2,7 +2,7 @@ import type { FeatureGroup, Map } from "leaflet";
 
 declare global {
   interface Window {
-    mapTestHandles: { map: Map; markerGroup: FeatureGroup };
+    mapTestHandles?: { map: Map; markerGroup: FeatureGroup };
   }
 }
 

--- a/src/js/testHooks.ts
+++ b/src/js/testHooks.ts
@@ -1,0 +1,22 @@
+import type { FeatureGroup, Map } from "leaflet";
+
+declare global {
+  interface Window {
+    mapTestHandles: { map: Map; markerGroup: FeatureGroup };
+  }
+}
+
+/**
+ * Expose the map and marker group for Playwright.
+ *
+ * Canvas rendering paints every marker onto one shared `<canvas>`, so there is no
+ * per-marker DOM for tests to select. These handles let tests count markers
+ * (`markerGroup.getLayers().length`) and project marker coordinates to pixels to
+ * simulate real clicks.
+ */
+export default function exposeTestHooks(
+  map: Map,
+  markerGroup: FeatureGroup,
+): void {
+  window.mapTestHandles = { map, markerGroup };
+}

--- a/tests/app/scorecard.test.ts
+++ b/tests/app/scorecard.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@playwright/test";
 
-import { loadMap } from "./utils";
+import { loadMap, onScreenMarkerPoints } from "./utils";
 import { generateScorecard } from "../../src/js/map-features/scorecard";
 import {
   ProcessedCoreBenefitDistrict,
@@ -19,25 +19,32 @@ test("scorecard pops up and closes", async ({ page }) => {
       (el) => el instanceof HTMLElement && !el.hidden,
     );
 
+  // Markers render on the canvas, so we click them at their projected pixel
+  // coordinates rather than via a DOM selector.
+  const points = await onScreenMarkerPoints(page);
+  const firstMarker = points[0];
+  const secondMarker = points[points.length - 1];
+  expect(firstMarker).not.toEqual(secondMarker);
+
   // click on marker
-  await page.locator(".leaflet-interactive").first().click({ force: true });
+  await page.mouse.click(firstMarker.x, firstMarker.y);
   expect(await scorecardIsVisible()).toBe(true);
   // close popup
   await closeIcon.click();
   expect(await scorecardIsVisible()).toBe(false);
 
   // click on marker
-  await page.locator("path:nth-child(4)").first().click({ force: true });
+  await page.mouse.click(firstMarker.x, firstMarker.y);
   expect(await scorecardIsVisible()).toBe(true);
   // click on another marker
-  await page.locator("path:nth-child(8)").first().click({ force: true });
+  await page.mouse.click(secondMarker.x, secondMarker.y);
   expect(await scorecardIsVisible()).toBe(true);
   // close popup
   await closeIcon.click();
   expect(await scorecardIsVisible()).toBe(false);
 
   // click on marker
-  await page.locator(".leaflet-interactive").first().click({ force: true });
+  await page.mouse.click(firstMarker.x, firstMarker.y);
   expect(await scorecardIsVisible()).toBe(true);
   // click outside of popup (not a marker either)
   await page.click("#map-counter");

--- a/tests/app/utils.ts
+++ b/tests/app/utils.ts
@@ -1,18 +1,25 @@
 import { expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
+import type { CircleMarker } from "leaflet";
 
 import { readRawCoreData } from "../../scripts/lib/data";
-
-const PLACE_MARKER = "path.leaflet-interactive";
 
 export const DEFAULT_ALL_MINIMUMS_RANGE: [number, number] = [120, 200];
 export const DEFAULT_PLACE_RANGE: [number, number] = [6000, 8500];
 
 export const loadMap = async (page: Page): Promise<void> => {
   await page.goto("");
-  // Wait for data to load.
-  await page.waitForSelector(PLACE_MARKER);
+  // Wait until markers have been added to the map.
+  await page.waitForFunction(
+    () => (window.mapTestHandles.markerGroup.getLayers().length ?? 0) > 0,
+  );
 };
+
+async function getNumMapMarkers(page: Page): Promise<number> {
+  return page.evaluate(
+    () => window.mapTestHandles.markerGroup.getLayers().length ?? 0,
+  );
+}
 
 export async function getTotalNumPlaces(): Promise<number> {
   const data = await readRawCoreData();
@@ -23,8 +30,10 @@ export const assertNumPlaces = async (
   page: Page,
   range: [number, number],
 ): Promise<void> => {
-  const mapNumPlaces = await page.locator(PLACE_MARKER).count();
-  expect(mapNumPlaces).toBeGreaterThanOrEqual(range[0]);
+  await expect
+    .poll(() => getNumMapMarkers(page))
+    .toBeGreaterThanOrEqual(range[0]);
+  const mapNumPlaces = await getNumMapMarkers(page);
   expect(mapNumPlaces).toBeLessThanOrEqual(range[1]);
 
   const counter = await page.locator("#map-counter").innerText();
@@ -37,6 +46,42 @@ export const assertNumPlaces = async (
   }
   expect(mapNumPlaces).toEqual(counterNumPlaces);
 };
+
+/**
+ * Get the viewport pixel coordinates for markers currently on screen.
+ */
+export async function onScreenMarkerPoints(
+  page: Page,
+): Promise<Array<{ x: number; y: number }>> {
+  return page.evaluate(() => {
+    const { map, markerGroup } = window.mapTestHandles;
+    const rect = map.getContainer().getBoundingClientRect();
+    const size = map.getSize();
+    const points: Array<{ x: number; y: number }> = [];
+    markerGroup.getLayers().forEach((layer) => {
+      const point = map.latLngToContainerPoint(
+        (layer as CircleMarker).getLatLng(),
+      );
+      // Keep a 20px horizontal inset off the left/right edges, and restrict
+      // vertically to the 25%-70% band. This avoids the overlays that sit on top
+      // of the map canvas and would otherwise intercept the click: the header
+      // and search/filter icons near the top, and the counter and attribution
+      // near the bottom.
+      if (
+        point.x > 20 &&
+        point.x < size.x - 20 &&
+        point.y > size.y * 0.25 &&
+        point.y < size.y * 0.7
+      ) {
+        points.push({
+          x: Math.round(rect.left + point.x),
+          y: Math.round(rect.top + point.y),
+        });
+      }
+    });
+    return points;
+  });
+}
 
 export async function openFilter(page: Page): Promise<void> {
   await page.locator(".header-filter-icon-container").click();

--- a/tests/app/utils.ts
+++ b/tests/app/utils.ts
@@ -11,13 +11,13 @@ export const loadMap = async (page: Page): Promise<void> => {
   await page.goto("");
   // Wait until markers have been added to the map.
   await page.waitForFunction(
-    () => (window.mapTestHandles.markerGroup.getLayers().length ?? 0) > 0,
+    () => (window.mapTestHandles?.markerGroup.getLayers().length ?? 0) > 0,
   );
 };
 
 async function getNumMapMarkers(page: Page): Promise<number> {
   return page.evaluate(
-    () => window.mapTestHandles.markerGroup.getLayers().length ?? 0,
+    () => window.mapTestHandles?.markerGroup.getLayers().length ?? 0,
   );
 }
 
@@ -54,7 +54,9 @@ export async function onScreenMarkerPoints(
   page: Page,
 ): Promise<Array<{ x: number; y: number }>> {
   return page.evaluate(() => {
-    const { map, markerGroup } = window.mapTestHandles;
+    const handles = window.mapTestHandles;
+    if (!handles) return [];
+    const { map, markerGroup } = handles;
     const rect = map.getContainer().getBoundingClientRect();
     const size = map.getSize();
     const points: Array<{ x: number; y: number }> = [];


### PR DESCRIPTION
Canvas substantially speeds up JavaScript, which is important because that is blocking the main thread so makes the UI feel laggy. It does mean that painting the map is now slower, but the overall time should still be faster and we'd rather have slower paint for faster JavaScript.

```
Metric                          Before         After         Delta   Delta %
----------------------------------------------------------------------------
initialLoad                     341 ms        316 ms        -25 ms     -7.3%
  network                         1 ms          1 ms         +0 ms     +0.0%
  firstPaint                    119 ms        115 ms         -4 ms     -3.3%
  dataFetch                      72 ms         76 ms         +4 ms     +6.0%
  jsBuild                       106 ms         72 ms        -34 ms    -32.1%
  markerPaint                    18 ms         28 ms        +10 ms    +58.1%
tableView                       151 ms        143 ms         -8 ms     -5.4%
filterReduceMin                  16 ms         21 ms         +5 ms    +30.2%
  js                             11 ms         10 ms         -1 ms     -8.0%
  paint                           5 ms         11 ms         +6 ms   +118.4%
filterReset                      32 ms         25 ms         -7 ms    -22.5%
  js                             28 ms         10 ms        -18 ms    -63.6%
  paint                           4 ms         15 ms        +11 ms   +266.2%
loadSearch                      138 ms        134 ms         -4 ms     -3.2%
  js                             91 ms         89 ms         -3 ms     -2.9%
  paint                          47 ms         45 ms         -2 ms     -3.6%
transfer                       2.89 MB       2.89 MB      +0.00 MB     +0.0%
```

Anecdotally, the map feels much snappier now. Claude points out that zooming should also be much more responsive now.