### PR TITLE
Run Playwright in parallel in CI

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -11,7 +11,6 @@ const webServerCommand = port === 1234 ? "start" : "serve-dist";
 const baseURL = `http://127.0.0.1:${port}`;
 
 export default defineConfig({
-  workers: process.env.CI ? 1 : undefined,
   use: {
     baseURL,
   },


### PR DESCRIPTION
I don't think it's actually necessary for safety. Our tests are all concurrency-safe. 49s -> 40s.