### PR TITLE
Reorder CI installation steps

### DIFF
--- a/.github/workflows/deploy-map-staging.yaml
+++ b/.github/workflows/deploy-map-staging.yaml
@@ -13,12 +13,11 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-      - name: Install dependencies
-        run: |
-          npm ci
-          npx playwright install --with-deps chromium
 
+      - run: npm ci
       - run: npm run build
+
+      - run: npx playwright install --with-deps chromium
       - run: npm run test-dist
 
       - name: Archive dist/ contents

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -11,14 +11,12 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22
-      - name: Install dependencies
-        run: |
-          npm ci
-          npx playwright install --with-deps chromium
-
+      
+      - run: npm ci
       - run: npm run check
       - run: npm run lint
-      - run: npm test
-
       - run: npm run gen-redirects
       - run: npm run gen-data-set
+
+      - run: npx playwright install --with-deps chromium
+      - run: npm test


### PR DESCRIPTION
Playwright installation is slow and only needed by our tests. Now we run our very fast quick checks before installing Playwright so that we get feedback on failures sooner.