### PR TITLE
Make FilterState the single source of truth for filter checkboxes 

### DIFF
--- a/src/js/filter-features/options.ts
+++ b/src/js/filter-features/options.ts
@@ -157,32 +157,6 @@ function getVisibleCheckboxes(
   );
 }
 
-function extractLabel(
-  input: HTMLInputElement,
-  preserveCapitalization?: boolean,
-): string | undefined {
-  const text = input.parentElement?.textContent?.trim();
-  return preserveCapitalization ? text : text?.toLowerCase();
-}
-
-/**
- * Get all options that are checked, regardless of if they are hidden.
- */
-export function determineCheckedLabels(
-  fieldset: HTMLFieldSetElement,
-  preserveCapitalization?: boolean,
-): Set<string> {
-  return new Set(
-    Array.from(
-      fieldset.querySelectorAll<HTMLInputElement>(
-        'input[type="checkbox"]:checked',
-      ),
-    )
-      .map((input) => extractLabel(input, preserveCapitalization))
-      .filter((x) => x !== undefined),
-  );
-}
-
 export function determineSupplementalTitle(
   fieldset: HTMLFieldSetElement,
 ): string {
@@ -250,12 +224,13 @@ function generateAccordionForFilterGroup(
     const inputId = `filter-${params.htmlName}-option-${i}`;
     const checked = filterState[params.filterStateKey].has(val);
     const description = params.preserveCapitalization ? val : capitalize(val);
-    const [label] = generateCheckbox(
+    const [label, input] = generateCheckbox(
       inputId,
       params.htmlName,
       checked,
       description,
     );
+    input.dataset.value = val;
     filterOptionsContainer.appendChild(label);
   });
 
@@ -308,14 +283,14 @@ function updateCheckboxStats(
 function updateCheckboxVisibility(
   optionsInDataset: readonly string[],
   fieldSet: HTMLFieldSetElement,
-  preserveCapitalization?: boolean,
 ): void {
   const validOptions = new Set(optionsInDataset);
   fieldSet
     .querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
     .forEach((checkbox) => {
-      const label = extractLabel(checkbox, preserveCapitalization);
-      checkbox.parentElement!.hidden = !label || !validOptions.has(label);
+      checkbox.parentElement!.hidden = !validOptions.has(
+        checkbox.dataset.value!,
+      );
     });
 }
 
@@ -330,54 +305,58 @@ function initFilterGroup(
   );
   optionsContainer.appendChild(accordionElements.outerContainer);
 
-  accordionElements.fieldSet.addEventListener("change", () => {
-    updateCheckboxStats(accordionState, accordionElements.fieldSet);
-    const checkedLabels = determineCheckedLabels(
-      accordionElements.fieldSet,
-      params.preserveCapitalization,
+  const currentValues = (): Set<string> =>
+    filterManager.getState()[params.filterStateKey];
+  const visibleValues = (): Set<string> =>
+    new Set(
+      getVisibleCheckboxes(accordionElements.fieldSet).map(
+        (input) => input.dataset.value!,
+      ),
     );
-    filterManager.update({ [params.filterStateKey]: checkedLabels });
+
+  accordionElements.fieldSet.addEventListener("change", (event) => {
+    const input = event.target as HTMLInputElement;
+    const value = input.dataset.value;
+    if (value === undefined) return;
+    const next = new Set(currentValues());
+    if (input.checked) {
+      next.add(value);
+    } else {
+      next.delete(value);
+    }
+    filterManager.update({ [params.filterStateKey]: next });
   });
 
   accordionElements.checkAllButton.addEventListener("click", () => {
-    const visibleCheckboxes = getVisibleCheckboxes(accordionElements.fieldSet);
-    visibleCheckboxes.forEach((input) => {
-      input.checked = true;
-    });
-    updateCheckboxStats(accordionState, accordionElements.fieldSet);
-    const checkedLabels = determineCheckedLabels(
-      accordionElements.fieldSet,
-      params.preserveCapitalization,
-    );
-    filterManager.update({
-      [params.filterStateKey]: checkedLabels,
-    });
+    const next = new Set([...currentValues(), ...visibleValues()]);
+    filterManager.update({ [params.filterStateKey]: next });
   });
 
   accordionElements.uncheckAllButton.addEventListener("click", () => {
-    const visibleCheckboxes = getVisibleCheckboxes(accordionElements.fieldSet);
-    visibleCheckboxes.forEach((input) => {
-      input.checked = false;
-    });
-    updateCheckboxStats(accordionState, accordionElements.fieldSet);
-    const checkedLabels = determineCheckedLabels(
-      accordionElements.fieldSet,
-      params.preserveCapitalization,
+    const visible = visibleValues();
+    const next = new Set(
+      [...currentValues()].filter((value) => !visible.has(value)),
     );
-    filterManager.update({
-      [params.filterStateKey]: checkedLabels,
-    });
+    filterManager.update({ [params.filterStateKey]: next });
   });
 
   filterManager.subscribe(
     `possibly update ${params.htmlName} filter UI`,
     (state) => {
+      // Project state onto the checkboxes. Setting `.checked` programmatically
+      // does not fire a `change` event, so there is no feedback loop.
+      const selected = state[params.filterStateKey];
+      accordionElements.fieldSet
+        .querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
+        .forEach((input) => {
+          input.checked = selected.has(input.dataset.value!);
+        });
+
       updateCheckboxVisibility(
         FILTER_OPTIONS.getOptions(state.policyTypeFilter, state.status)[
           params.filterStateKey
         ],
         accordionElements.fieldSet,
-        params.preserveCapitalization,
       );
       updateCheckboxStats(accordionState, accordionElements.fieldSet);
 

--- a/src/js/filter-features/options.ts
+++ b/src/js/filter-features/options.ts
@@ -343,13 +343,12 @@ function initFilterGroup(
   filterManager.subscribe(
     `possibly update ${params.htmlName} filter UI`,
     (state) => {
-      // Project state onto the checkboxes. Setting `.checked` programmatically
-      // does not fire a `change` event, so there is no feedback loop.
-      const selected = state[params.filterStateKey];
       accordionElements.fieldSet
         .querySelectorAll<HTMLInputElement>('input[type="checkbox"]')
         .forEach((input) => {
-          input.checked = selected.has(input.dataset.value!);
+          input.checked = state[params.filterStateKey].has(
+            input.dataset.value!,
+          );
         });
 
       updateCheckboxVisibility(

--- a/tests/app/filter.test.ts
+++ b/tests/app/filter.test.ts
@@ -1,4 +1,4 @@
-import { type Page, test } from "@playwright/test";
+import { expect, type Page, test } from "@playwright/test";
 import type { ReformStatus } from "../../src/js/model/types";
 import type { PolicyTypeFilter } from "../../src/js/state/FilterState";
 import {
@@ -211,3 +211,41 @@ for (const edgeCase of TESTS) {
     }
   });
 }
+
+// `FilterState`'s option Sets are a single unified view across every dataset, so
+// checked-but-hidden values must persist when the user switches datasets.
+// "Uncheck all" therefore may only drop the options *visible* in the current
+// dataset — not options that exist solely in a different dataset. A regression to
+// naive `new Set()` semantics would wipe the entire set and silently reset the
+// other datasets' selections.
+//
+// The specific years below can be updated as the data changes: "1960" must be a
+// year present only in "reduce parking minimums", and "2020" a year present in
+// both it and "remove parking minimums".
+test("uncheck-all only affects the current dataset's options", async ({
+  page,
+}) => {
+  await loadMap(page);
+  await openFilter(page);
+
+  // In the "remove parking minimums" dataset, uncheck all of its year options.
+  await page
+    .locator("#filter-policy-type-dropdown")
+    .selectOption("remove parking minimums");
+  await page.locator("#filter-accordion-toggle-year").click();
+  await page.locator("#filter-year-uncheck-all").click();
+
+  // Switch to the "reduce parking minimums" dataset, whose year options differ.
+  await page
+    .locator("#filter-policy-type-dropdown")
+    .selectOption("reduce parking minimums");
+
+  // "1960" exists only in this dataset, so uncheck-all above never touched it.
+  await expect(
+    page.locator('.filter-year input[data-value="1960"]'),
+  ).toBeChecked();
+  // "2020" exists in both datasets, so uncheck-all above did remove it.
+  await expect(
+    page.locator('.filter-year input[data-value="2020"]'),
+  ).not.toBeChecked();
+});

--- a/tests/app/filterOptions.test.ts
+++ b/tests/app/filterOptions.test.ts
@@ -1,10 +1,7 @@
 import { expect, test } from "@playwright/test";
 import { Window } from "happy-dom";
 
-import {
-  determineCheckedLabels,
-  determineSupplementalTitle,
-} from "../../src/js/filter-features/options";
+import { determineSupplementalTitle } from "../../src/js/filter-features/options";
 
 function createFieldset(childrenHTML: string): HTMLFieldSetElement {
   const window = new Window();
@@ -25,24 +22,4 @@ test("determineSupplementalTitle", () => {
       <label hidden><input type="checkbox"></label>
     `);
   expect(determineSupplementalTitle(fieldset)).toEqual(" (2/3)");
-});
-
-test("determineCheckedLabels should return labels of checked checkboxes", () => {
-  const fieldset = createFieldset(`
-    <div><input type="checkbox" checked>First Option</div>
-    <div><input type="checkbox">Second Option</div>
-    <div><input type="checkbox" checked>Third Option</div>
-    <div hidden><input type="checkbox" checked>Hidden Checked</div>
-    <div hidden><input type="checkbox">Hidden Unchecked</div>
-  `);
-
-  const result = determineCheckedLabels(fieldset);
-  expect(result).toEqual(
-    new Set(["first option", "third option", "hidden checked"]),
-  );
-
-  const preserveCapitalization = determineCheckedLabels(fieldset, true);
-  expect(preserveCapitalization).toEqual(
-    new Set(["First Option", "Third Option", "Hidden Checked"]),
-  );
 });


### PR DESCRIPTION
[below description is AI-written]

Previously the checkbox filter groups stored their truth in the DOM: every interaction mutated the DOM, then read it back via `determineCheckedLabels` (querying `input:checked` and reconstructing the Set from each checkbox's `textContent`). Nothing pushed FilterState -> checkboxes after init, so the two only stayed in sync because every mutation happened to go through the DOM first.

This inverts the flow. Handlers now compute the new Set from user intent and call `filterManager.update(...)`; a subscriber projects state back onto `input.checked`. Each checkbox carries its raw value in `data-value`, replacing the capitalize -> lowercase `textContent` round-trip.

Why this is safe:

- No feedback loop. Setting `.checked` programmatically does not fire a `change` event, so the projection subscriber cannot re-trigger the change handler.

- Cross-dataset selections are preserved. FilterState's option Sets are a single unified view across all datasets, and `updateCheckboxVisibility` only hides out-of-dataset options -- it never unchecks them. The old code preserved checked-but-hidden values because `determineCheckedLabels` read back the entire DOM. The intent-based handlers reproduce this exactly: check-all unions in the visible values, uncheck-all removes only the visible values, and single-toggle copies current state then adds/deletes one value. A naive `new Set(visible)` / `new Set()` would silently drop other datasets' selections -- and pass the existing single-dataset e2e tests -- so a new test asserts a year unique to one dataset stays checked after uncheck-all in another.

- First paint stays correct. The subscriber runs at `filterManager.initialize()` and Observable notifies synchronously, so URL-encoded filters render matching state immediately.