### PR TITLE
Closing scorecard is smarter about resetting search

### DIFF
--- a/src/js/map-features/scorecard.ts
+++ b/src/js/map-features/scorecard.ts
@@ -170,10 +170,11 @@ export default function initScorecard(
 
   // Closing the scorecard resets search.
   scorecardState.subscribe(({ type }) => {
-    // Don't run this code when initializing the scorecardState observable.
-    if (!scorecardState.isInitialized) return;
-
-    if (type === "hidden") {
+    if (
+      scorecardState.isInitialized &&
+      type === "hidden" &&
+      filterManager.getState().searchInput !== null
+    ) {
       filterManager.update({ searchInput: null });
     }
   }, "reset search FilterState when scorecard closed");


### PR DESCRIPTION
The logs for Observable in the console showed that we were running "reset search FilterState when scorecard closed" every time the scorecard closed, even if search was never even used in the app.