### PR TITLE
Fix memory leaks with share link and table

### DIFF
--- a/src/js/layout/share.ts
+++ b/src/js/layout/share.ts
@@ -29,20 +29,22 @@ export function createUrl(searchParams: URLSearchParams): string {
 }
 
 export default function initShareLink(filterManager: PlaceFilterManager): void {
-  filterManager.subscribe("update share link", (filterState) => {
-    const shareIcon = document.querySelector<HTMLButtonElement>(
-      ".header-share-icon-container",
-    );
-    const fullScreenIcon = document.querySelector<HTMLAnchorElement>(
-      ".header-full-screen-icon-container",
-    );
-    if (!shareIcon || !fullScreenIcon) return;
+  const shareIcon = document.querySelector<HTMLButtonElement>(
+    ".header-share-icon-container",
+  );
+  const fullScreenIcon = document.querySelector<HTMLAnchorElement>(
+    ".header-full-screen-icon-container",
+  );
+  if (!shareIcon || !fullScreenIcon) return;
 
-    const shareUrl = createUrl(encodeFilterState(filterState));
-    shareIcon.addEventListener("click", async () => {
-      await copyToClipboard(shareUrl);
-      switchShareIcons(shareIcon);
-    });
+  let shareUrl = createUrl(encodeFilterState(filterManager.getState()));
+  filterManager.subscribe("update share link", (filterState) => {
+    shareUrl = createUrl(encodeFilterState(filterState));
     fullScreenIcon.href = shareUrl;
+  });
+
+  shareIcon.addEventListener("click", async () => {
+    await copyToClipboard(shareUrl);
+    switchShareIcons(shareIcon);
   });
 }

--- a/src/js/table.ts
+++ b/src/js/table.ts
@@ -169,16 +169,20 @@ export function tableDownloadFileName(
   return `parking-reforms--${policy}--${status}.csv`;
 }
 
-function updateCounterDownload(
+/**
+ * Wire up the download button once. The policy type/status it downloads are
+ * read from `getDownloadTarget` at click-time.
+ */
+function initCounterDownload(
   table: Tabulator,
-  policyType: PolicyTypeFilter,
-  status: ReformStatus,
+  getDownloadTarget: () => [PolicyTypeFilter, ReformStatus],
 ): void {
   const button = document.querySelector(".counter-table-download");
   if (!button) return;
-  button.addEventListener("click", () =>
-    table.download("csv", tableDownloadFileName(policyType, status)),
-  );
+  button.addEventListener("click", () => {
+    const [policyType, status] = getDownloadTarget();
+    table.download("csv", tableDownloadFileName(policyType, status));
+  });
 }
 
 export default function initTable(
@@ -386,10 +390,16 @@ export default function initTable(
   // we switch to table view.
   let dataRefreshQueued = false;
 
+  // Track the latest policy type and status for the download button.
+  let downloadPolicyType = currentPolicyTypeFilter;
+  let downloadStatus = currentStatus;
+  initCounterDownload(table, () => [downloadPolicyType, downloadStatus]);
+
   filterManager.subscribe(
     "update table's records",
     ({ policyTypeFilter, status }) => {
-      updateCounterDownload(table, policyTypeFilter, status);
+      downloadPolicyType = policyTypeFilter;
+      downloadStatus = status;
       if (!tableBuilt) return;
       if (viewToggle.getValue() === "map") {
         dataRefreshQueued = true;


### PR DESCRIPTION
We were setting up >1 event listener on the share link icon and table download button. Now, we only use one event listener and dynamically read the values at click-time.