### PR TITLE
Fix bug with table download

### DIFF
--- a/src/js/table.ts
+++ b/src/js/table.ts
@@ -178,9 +178,14 @@ function initCounterDownload(
   table: Tabulator,
   getDownloadTarget: () => [PolicyTypeFilter, ReformStatus],
 ): void {
-  const button = document.querySelector(".counter-table-download");
-  if (!button) return;
-  button.addEventListener("click", () => {
+  const container = document.getElementById("table-counter");
+  if (!container) return;
+  container.addEventListener("click", (event) => {
+    if (
+      !(event.target instanceof Element) ||
+      !event.target.matches(".counter-table-download")
+    )
+      return;
     const [policyType, status] = getDownloadTarget();
     table.download("csv", tableDownloadFileName(policyType, status));
   });


### PR DESCRIPTION
We need to use event dispatch because `.counter-table-download` is not stable and it's recreated every time. `table-counter` is stable.