### PR TITLE
Tokenize font weight & improve comments for magic values

### DIFF
--- a/src/css/_about.scss
+++ b/src/css/_about.scss
@@ -39,6 +39,7 @@
   h3 {
     margin: 0;
     font-size: typography.$font-size-lg;
+    font-weight: typography.$font-weight-bold;
   }
 }
 
@@ -52,7 +53,7 @@
     margin-right: spacing.$element-gap;
     line-height: typography.$line-height-base;
     font-size: typography.$font-size-xl;
-    font-weight: 500;
+    font-weight: typography.$font-weight-bold;
   }
 }
 

--- a/src/css/_counters.scss
+++ b/src/css/_counters.scss
@@ -19,8 +19,12 @@
   font-size: typography.$font-size-base;
   line-height: typography.$line-height-base;
 
+  // Set a minimum for when the counter is not yet populated.
+  // 68px is the height of the counter with 2 rows, which is the shortest
+  // it will ever be.
+  min-height: 68px;
+
   padding: spacing.$element-gap spacing.$container-edge-spacing;
-  min-height: 40px; // This is for when the counter is not yet populated.
   width: 260px;
 
   color: colors.$black;

--- a/src/css/_population-slider.scss
+++ b/src/css/_population-slider.scss
@@ -7,11 +7,6 @@
 
 @use "filter";
 
-// uncomment to visualize slider mechanism
-// input {
-//   border: solid;
-// }
-
 $thumbsize: icons.$icon-size-md;
 
 .population-slider-container {
@@ -24,6 +19,11 @@ $thumbsize: icons.$icon-size-md;
     filter.$filter-inner-width - (spacing.$container-edge-spacing * 2)
   );
   margin: spacing.$element-gap spacing.$container-edge-spacing;
+
+  // You can uncomment this code to visualize the slider mechanism when debugging.
+  // input {
+  //   border: solid;
+  // }
 }
 
 .population-slider-controls {

--- a/src/css/_scorecard.scss
+++ b/src/css/_scorecard.scss
@@ -50,7 +50,7 @@
   margin: 0;
   line-height: typography.$line-height-tight;
 
-  font-weight: normal;
+  font-weight: typography.$font-weight-regular;
   font-size: typography.$font-size-xl;
 
   .scorecard-supplemental-place-info {

--- a/src/css/_table.scss
+++ b/src/css/_table.scss
@@ -27,5 +27,5 @@ div.tabulator {
 }
 
 .tabulator-paginator button {
-  font-weight: normal;
+  font-weight: typography.$font-weight-regular;
 }

--- a/src/css/_zoom.scss
+++ b/src/css/_zoom.scss
@@ -18,13 +18,14 @@ div.leaflet-left .leaflet-control {
 }
 
 div.leaflet-control-zoom.leaflet-bar {
+  // We add 46px to correctly offset with Leaflet's code.
   top: calc(46px + spacing.$map-controls-margin-top - header.$header-height);
 
   a {
     width: $button-width;
     height: spacing.$min-touch-target;
     font-size: $label-font-size;
-    font-weight: normal;
+    font-weight: typography.$font-weight-regular;
 
     @include mixins.flex-center;
 

--- a/src/css/style.scss
+++ b/src/css/style.scss
@@ -18,4 +18,4 @@
 @import "npm:tabulator-tables/dist/css/tabulator.min.css";
 @import "npm:leaflet/dist/leaflet.css";
 @import "npm:choices.js/public/assets/styles/choices.css";
-@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500;600&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Poppins:wght@400;500&display=swap");

--- a/src/css/theme/_resets.scss
+++ b/src/css/theme/_resets.scss
@@ -28,13 +28,13 @@ button {
 }
 
 p {
-  margin: 0 0 10px;
+  margin: 0 0 spacing.$element-gap;
 }
 
 ul,
 ol {
   margin-top: 0;
-  margin-bottom: 10px;
+  margin-bottom: spacing.$element-gap;
   padding: 0;
   padding-inline-start: spacing.$list-indent;
 }

--- a/src/css/theme/_typography.scss
+++ b/src/css/theme/_typography.scss
@@ -9,6 +9,9 @@ $line-height-tight: 1.1;
 $line-height-snug: 1.2;
 $line-height-base: 1.3;
 
+$font-weight-regular: 400;
+$font-weight-bold: 500;
+
 body,
 div.leaflet-container {
   font-family: Poppins, Helvetica, Arial, sans-serif;


### PR DESCRIPTION
This also removes font weight 600 from Google Fonts, as we never used it. It fixes the h3 in the about popup to use font weight 500 rather than the default of 700.