### PR TITLE
Clean up scripts: DRY CSV place projection, fix UA/geocoder bugs

### DIFF
--- a/scripts/brokenLinks.ts
+++ b/scripts/brokenLinks.ts
@@ -8,6 +8,12 @@ import {
 import { DIRECTUS_BASE_URL } from "./lib/paths";
 import { runScript } from "./lib/runScript";
 
+// A real browser User-Agent, unlike lib/geocoder.ts's "prn-update-map-data" fetch
+// UA, because many sites reject non-browser UAs and would otherwise show up as
+// false-positive dead links.
+const BROWSER_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36";
+
 export function extractCitationIdAndLinks(
   data: Record<string, ExtendedEntry>,
 ): Array<[number, string]> {
@@ -30,8 +36,7 @@ async function findDeadLink(link: string): Promise<number | null> {
     const response = await fetch(link, {
       method: "HEAD",
       headers: {
-        "User-Agent":
-          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",
+        "User-Agent": BROWSER_USER_AGENT,
         Accept:
           "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
         "Accept-Language": "en-US,en;q=0.9",
@@ -59,10 +64,10 @@ async function main(): Promise<void> {
 
   // We use a for loop to avoid making too many network calls -> rate limiting.
   for (const [i, [id, link]] of citationIdAndLinks.entries()) {
-    const deadLink = await findDeadLink(link);
-    if (deadLink !== null) {
+    const deadLinkStatus = await findDeadLink(link);
+    if (deadLinkStatus !== null) {
       const directusEntry = `${DIRECTUS_BASE_URL}/admin/content/citations/${id}`;
-      console.log(`${link} (${directusEntry})`);
+      console.log(`[${deadLinkStatus}] ${link} (${directusEntry})`);
     }
 
     if ((i + 1) % 10 === 0) {

--- a/scripts/generateDataSet.ts
+++ b/scripts/generateDataSet.ts
@@ -49,24 +49,29 @@ function determineAnyPolicySet(
   };
 }
 
+type CsvRow = Record<string, string | number | null | undefined>;
+
+function placeToCsvRow(entry: ProcessedCompleteEntry): CsvRow {
+  return {
+    place: entry.place.name,
+    state: entry.place.state,
+    country: entry.place.country,
+    population: entry.place.pop,
+    place_type: entry.place.type,
+    lat: entry.place.coord[1],
+    long: entry.place.coord[0],
+  };
+}
+
 export function createAnyPolicyCsvs(data: ProcessedCompleteEntry[]): {
   adopted: string;
   proposed: string;
   repealed: string;
 } {
-  const adopted: any[] = [];
-  const proposed: any[] = [];
-  const repealed: any[] = [];
+  const adopted: CsvRow[] = [];
+  const proposed: CsvRow[] = [];
+  const repealed: CsvRow[] = [];
   data.forEach((entry) => {
-    const initialValues = {
-      place: entry.place.name,
-      state: entry.place.state,
-      country: entry.place.country,
-      place_type: entry.place.type,
-      population: entry.place.pop,
-      lat: entry.place.coord[1],
-      long: entry.place.coord[0],
-    };
     const prnUrl = { prn_url: entry.place.url };
 
     const adoptedPolicySet = determineAnyPolicySet(entry, "adopted");
@@ -75,7 +80,7 @@ export function createAnyPolicyCsvs(data: ProcessedCompleteEntry[]): {
 
     if (adoptedPolicySet.hasReforms) {
       adopted.push({
-        ...initialValues,
+        ...placeToCsvRow(entry),
         all_minimums_removed: toBoolean(entry.place.repeal),
         ...adoptedPolicySet.csvValues,
         ...prnUrl,
@@ -83,14 +88,14 @@ export function createAnyPolicyCsvs(data: ProcessedCompleteEntry[]): {
     }
     if (proposedPolicySet.hasReforms) {
       proposed.push({
-        ...initialValues,
+        ...placeToCsvRow(entry),
         ...proposedPolicySet.csvValues,
         ...prnUrl,
       });
     }
     if (repealedPolicySet.hasReforms) {
       repealed.push({
-        ...initialValues,
+        ...placeToCsvRow(entry),
         ...repealedPolicySet.csvValues,
         ...prnUrl,
       });
@@ -104,13 +109,13 @@ export function createAnyPolicyCsvs(data: ProcessedCompleteEntry[]): {
   };
 }
 
-function validateNumEntries(
+function validateNumEntries<T>(
   csv: string,
   data: ProcessedCompleteEntry[],
-  getter: (entry: ProcessedCompleteEntry) => Array<any> | undefined,
+  getter: (entry: ProcessedCompleteEntry) => Array<T> | undefined,
 ): void {
   const numJson = sum(data.flatMap((entry) => getter(entry)?.length ?? 0));
-  const numCsv = csv.split("\r\n").length - 1;
+  const numCsv = Papa.parse(csv).data.length - 1;
   if (numJson !== numCsv) {
     throw new Error(`CSV has unequal entries to JSON: ${numCsv} vs ${numJson}`);
   }
@@ -126,13 +131,7 @@ export function createLandUseCsv(
     const policies = getter(entry);
     if (!policies) return [];
     return policies.map((policy) => ({
-      place: entry.place.name,
-      state: entry.place.state,
-      country: entry.place.country,
-      population: entry.place.pop,
-      place_type: entry.place.type,
-      lat: entry.place.coord[1],
-      long: entry.place.coord[0],
+      ...placeToCsvRow(entry),
       all_minimums_removed: toBoolean(entry.place.repeal),
       status: policy.status,
       reform_date: policy.date?.raw,
@@ -157,13 +156,7 @@ export function createBenefitDistrictCsv(
     const records = entry.benefit_district;
     if (!records) return [];
     return records.map((record) => ({
-      place: entry.place.name,
-      state: entry.place.state,
-      country: entry.place.country,
-      population: entry.place.pop,
-      place_type: entry.place.type,
-      lat: entry.place.coord[1],
-      long: entry.place.coord[0],
+      ...placeToCsvRow(entry),
       status: record.status,
       reform_date: record.date?.raw,
       summary: record.summary,

--- a/scripts/lib/geocoder.ts
+++ b/scripts/lib/geocoder.ts
@@ -27,7 +27,7 @@ export async function getLongLat(
 ): Promise<[number, number] | null> {
   const stateQuery = state ? `${state}, ` : "";
   // We try the most precise query first, then fall back to less precise queries.
-  const locationMethods = [() => `${placeName}, ${stateQuery}, ${countryCode}`];
+  const locationMethods = [() => `${placeName}, ${stateQuery}${countryCode}`];
   if (stateQuery) {
     locationMethods.push(() => `${placeName}, ${stateQuery}`);
   }

--- a/tests/scripts/generateDataSet.test.ts-snapshots/overview-adopted.csv
+++ b/tests/scripts/generateDataSet.test.ts-snapshots/overview-adopted.csv
@@ -1,2 +1,2 @@
-place,state,country,place_type,population,lat,long,all_minimums_removed,minimums_removal,minimums_reduction,maximums,benefit_districts,prn_url
-My City,NY,United States,city,24104,14.23,44.23,TRUE,FALSE,FALSE,TRUE,FALSE,https://parkingreform.org/my-city-details.html
+place,state,country,population,place_type,lat,long,all_minimums_removed,minimums_removal,minimums_reduction,maximums,benefit_districts,prn_url
+My City,NY,United States,24104,city,14.23,44.23,TRUE,FALSE,FALSE,TRUE,FALSE,https://parkingreform.org/my-city-details.html

--- a/tests/scripts/generateDataSet.test.ts-snapshots/overview-proposed.csv
+++ b/tests/scripts/generateDataSet.test.ts-snapshots/overview-proposed.csv
@@ -1,3 +1,3 @@
-place,state,country,place_type,population,lat,long,minimums_removal,minimums_reduction,maximums,benefit_districts,prn_url
-Another Place,CA,United States,county,414,24.23,80.3,TRUE,FALSE,FALSE,FALSE,https://parkingreform.org/another-place.html
-Place with PBD,GDL,Mexico,city,5141414,30.23,90.3,FALSE,FALSE,FALSE,TRUE,https://parkingreform.org/place-with-pbd.html
+place,state,country,population,place_type,lat,long,minimums_removal,minimums_reduction,maximums,benefit_districts,prn_url
+Another Place,CA,United States,414,county,24.23,80.3,TRUE,FALSE,FALSE,FALSE,https://parkingreform.org/another-place.html
+Place with PBD,GDL,Mexico,5141414,city,30.23,90.3,FALSE,FALSE,FALSE,TRUE,https://parkingreform.org/place-with-pbd.html

--- a/tests/scripts/generateDataSet.test.ts-snapshots/overview-repealed.csv
+++ b/tests/scripts/generateDataSet.test.ts-snapshots/overview-repealed.csv
@@ -1,2 +1,2 @@
-place,state,country,place_type,population,lat,long,minimums_removal,minimums_reduction,maximums,benefit_districts,prn_url
-My City,NY,United States,city,24104,14.23,44.23,FALSE,FALSE,TRUE,FALSE,https://parkingreform.org/my-city-details.html
+place,state,country,population,place_type,lat,long,minimums_removal,minimums_reduction,maximums,benefit_districts,prn_url
+My City,NY,United States,24104,city,14.23,44.23,FALSE,FALSE,TRUE,FALSE,https://parkingreform.org/my-city-details.html


### PR DESCRIPTION
- generateDataSet.ts: extract placeToCsvRow() helper to dedupe the place projection repeated across the three CSV builders, unify place_type/population column ordering, replace any[] with a loose CsvRow type, and make the row-count validation parse the CSV (respecting quoted embedded newlines) instead of naively splitting on "\r\n".
- brokenLinks.ts: hoist the browser User-Agent to a named constant documenting why it differs from geocoder.ts's fetch UA, and use the dead link's status code in the log line instead of discarding it.
- geocoder.ts: fix a double-comma in the most-precise geocode query.